### PR TITLE
Set up cache and artifact action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,5 +24,17 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: 1.13
+    - name: Restore Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ matrix.os }}-go-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     - name: Run build
       run: make build
+    - name: Upload Artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: tflint-${{ matrix.os }}
+        path: dist/tflint

--- a/.github/workflows/generated_code_checks.yml
+++ b/.github/workflows/generated_code_checks.yml
@@ -14,6 +14,13 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: 1.13
+    - name: Restore Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     - name: make code
       run: |
         export PATH=$PATH:$(go env GOPATH)/bin


### PR DESCRIPTION
Set up [`actions/cache`](https://github.com/actions/cache) to speed up CI. Also, set up [`actions/upload-artifact`](https://github.com/actions/upload-artifact) to make easy to confirm the built binary in the pull request.