### PR TITLE
update the docker image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ brew install tflint
 You can also use [TFLint via Docker](https://hub.docker.com/r/wata727/tflint/).
 
 ```console
-$ docker run --rm -v $(pwd):/data -t terraform-linters/tflint
+$ docker run --rm -v $(pwd):/data -t wata727/tflint
 ```
 
 ## Features


### PR DESCRIPTION
The docker image `terraform-linters/tflint` is not exist. Correct the name.

fix #529