### PR TITLE
Add python3.8 lambda runtime

### DIFF
--- a/rules/awsrules/models/aws_lambda_function_invalid_runtime.go
+++ b/rules/awsrules/models/aws_lambda_function_invalid_runtime.go
@@ -31,6 +31,7 @@ func NewAwsLambdaFunctionInvalidRuntimeRule() *AwsLambdaFunctionInvalidRuntimeRu
 			"python2.7",
 			"python3.6",
 			"python3.7",
+			"python3.8",
 			"dotnetcore1.0",
 			"dotnetcore2.0",
 			"dotnetcore2.1",


### PR DESCRIPTION
AWS Lambda supports the `python3.8` runtime. See https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html.