### PR TITLE
Fix the pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,4 +2,5 @@
   name: Terraform Lint
   description: TFLint is a Terraform linter focused on possible errors, best practices, and so on.
   language: golang
-  entry: main.go
+  entry: tflint
+  types: [terraform]


### PR DESCRIPTION
The existing `pre-commit` configuration doesn't seem to work, as
`pre-commit` needs to be pointed to the compiled binary and not to
`main.go`. This commit fixes that and ensures `pre-commit` only tries to
lint terraform files.