### PR TITLE
Parse absolute paths in TF_DATA_DIR correctly

### DIFF
--- a/tflint/loader.go
+++ b/tflint/loader.go
@@ -238,6 +238,10 @@ func (l *Loader) moduleWalker() configs.ModuleWalker {
 		}
 
 		dir := filepath.Join(l.currentDir, record.Dir)
+		if filepath.IsAbs(record.Dir) {
+			// If record.Dir is an absolute path, leave it
+			dir = record.Dir
+		}
 		if record.Root != "" {
 			dir = filepath.Join(dir, record.Root)
 		}


### PR DESCRIPTION
Resolves #554 

I didn't see how I could add an integration test for this, though.