### PR TITLE
Remove legacy TF 0.11 fields from module records

### DIFF
--- a/tflint/loader.go
+++ b/tflint/loader.go
@@ -44,7 +44,6 @@ type moduleManifest struct {
 	Version    *version.Version `json:"-"`
 	VersionStr string           `json:"Version,omitempty"`
 	Dir        string           `json:"Dir"`
-	Root       string           `json:"Root"`
 }
 
 type moduleManifestFile struct {
@@ -238,9 +237,6 @@ func (l *Loader) moduleWalker() configs.ModuleWalker {
 		}
 
 		dir := filepath.Join(l.currentDir, record.Dir)
-		if record.Root != "" {
-			dir = filepath.Join(dir, record.Root)
-		}
 		log.Printf("[DEBUG] Trying to load the module: key=%s, version=%s, dir=%s", key, record.VersionStr, dir)
 
 		mod, diags := l.parser.LoadConfigDir(dir)


### PR DESCRIPTION
While working on #555 I discovered that the `Root` field is no longer present in TF 0.12, so I think you could remove it:

https://github.com/hashicorp/terraform/blob/master/internal/modsdir/manifest.go#L19-L41