### PR TITLE
Feature: terraform_dash_in_output_name

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -68,6 +68,7 @@ These rules suggest to better ways.
 |Rule|Enabled by default|
 | --- | --- |
 |[terraform_dash_in_resource_name](terraform_dash_in_resource_name.md)||
+|[terraform_dash_in_output_name](terraform_dash_in_output_name.md)||
 |[terraform_documented_outputs](terraform_documented_outputs.md)||
 |[terraform_documented_variables](terraform_documented_variables.md)||
 |[terraform_module_pinned_source](terraform_module_pinned_source.md)|✔|

--- a/docs/rules/terraform_dash_in_output_name.md
+++ b/docs/rules/terraform_dash_in_output_name.md
@@ -1,0 +1,40 @@
+# terraform_dash_in_output_name
+
+Disallow dashes (-) in `output` names.
+
+## Example
+
+```hcl
+output "dash-name" {
+  value = "foo"
+}
+
+output "no_dash_name" {
+  value = "foo"
+}
+
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Notice: `dash-bois-he` output name has a dash (terraform_dash_in_output_name)
+
+  on outputs.tf line 1:
+   1: output "dash-bois-he" {
+
+Reference: https://github.com/terraform-linters/tflint/blob/master/docs/rules/terraform_dash_in_output_name.md
+```
+
+## Why
+
+Naming conventions are optional, so it is not necessary to follow this. 
+
+Whilst [Terraform Plugin Naming Best Practices](https://www.terraform.io/docs/extend/best-practices/naming.html) 
+does not formally address outputs, I personally believe they are covered by this rule.
+
+
+## How To Fix
+
+Use underscores (_) instead of dashes (-).

--- a/docs/rules/terraform_dash_in_output_name.md
+++ b/docs/rules/terraform_dash_in_output_name.md
@@ -19,10 +19,10 @@ output "no_dash_name" {
 $ tflint
 1 issue(s) found:
 
-Notice: `dash-bois-he` output name has a dash (terraform_dash_in_output_name)
+Notice: `dash-name` output name has a dash (terraform_dash_in_output_name)
 
   on outputs.tf line 1:
-   1: output "dash-bois-he" {
+   1: output "dash-name" {
 
 Reference: https://github.com/terraform-linters/tflint/blob/master/docs/rules/terraform_dash_in_output_name.md
 ```

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -34,6 +34,7 @@ var manualDefaultRules = []Rule{
 	awsrules.NewAwsS3BucketInvalidRegionRule(),
 	awsrules.NewAwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule(),
 	terraformrules.NewTerraformDashInResourceNameRule(),
+	terraformrules.NewTerraformDashInOutputNameRule(),
 	terraformrules.NewTerraformDocumentedOutputsRule(),
 	terraformrules.NewTerraformDocumentedVariablesRule(),
 	terraformrules.NewTerraformModulePinnedSourceRule(),

--- a/rules/terraformrules/terraform_dash_in_output_name.go
+++ b/rules/terraformrules/terraform_dash_in_output_name.go
@@ -1,0 +1,54 @@
+package terraformrules
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+// TerraformDashInOutputNameRule checks whether outputs have any dashes in the name
+type TerraformDashInOutputNameRule struct{}
+
+// NewTerraformDashInOutputNameRule returns a new rule
+func NewTerraformDashInOutputNameRule() *TerraformDashInOutputNameRule {
+	return &TerraformDashInOutputNameRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformDashInOutputNameRule) Name() string {
+	return "terraform_dash_in_output_name"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformDashInOutputNameRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *TerraformDashInOutputNameRule) Severity() string {
+	return tflint.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *TerraformDashInOutputNameRule) Link() string {
+	return tflint.ReferenceLink(r.Name())
+}
+
+// Check checks whether outputs have any dashes in the name
+func (r *TerraformDashInOutputNameRule) Check(runner *tflint.Runner) error {
+	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	for _, output := range runner.TFConfig.Module.Outputs {
+		if strings.Contains(output.Name, "-") {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("`%s` output name has a dash", output.Name),
+				output.DeclRange,
+			)
+		}
+	}
+
+	return nil
+}

--- a/rules/terraformrules/terraform_dash_in_output_name_test.go
+++ b/rules/terraformrules/terraform_dash_in_output_name_test.go
@@ -1,0 +1,55 @@
+package terraformrules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_TerraformDashInOutputNameRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected tflint.Issues
+	}{
+		{
+			Name: "dash in resource name",
+			Content: `
+output "dash-name" {
+	value = aws_alb.main.dns_name
+}`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformDashInOutputNameRule(),
+					Message: "`dash-name` output name has a dash",
+					Range: hcl.Range{
+						Filename: "outputs.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 19},
+					},
+				},
+			},
+		},
+		{
+			Name: "no dash in output name",
+			Content: `
+output "no_dash_name" {
+	value = aws_alb.main.dns_name
+}`,
+			Expected: tflint.Issues{},
+		},
+	}
+
+	rule := NewTerraformDashInOutputNameRule()
+
+	for _, tc := range cases {
+		runner := tflint.TestRunner(t, map[string]string{"outputs.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/terraformrules/terraform_dash_in_output_name_test.go
+++ b/rules/terraformrules/terraform_dash_in_output_name_test.go
@@ -14,7 +14,7 @@ func Test_TerraformDashInOutputNameRule(t *testing.T) {
 		Expected tflint.Issues
 	}{
 		{
-			Name: "dash in resource name",
+			Name: "dash in output name",
 			Content: `
 output "dash-name" {
 	value = aws_alb.main.dns_name


### PR DESCRIPTION
## Why

- I believe whilst the TF documentation does not cover outputs, the 'resource' best practices should also cover outputs (specifically no dashes/hyphens in output name).

## Solves
- #567 