### PR TITLE
Remove go111module on env variable in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM golang:1.13.6-alpine3.10 as builder
 
 RUN apk --no-cache add git make gcc musl-dev zip
 
-ENV GO111MODULE=on
-
 WORKDIR /tflint
 ADD . /tflint
 RUN make build


### PR DESCRIPTION
go 1.13 change go111module auto setting behavior.

```
the auto setting now activates the module-aware mode of the go command whenever the current working directory contains, or is below a directory containing, a go.mod file
```
https://golang.org/doc/go1.13#modules

So I think maybe this environment variable could be removed from Dockerfile.