### PR TITLE
Add install guide for Windows (choco install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ macOS users can also use [Homebrew](https://brew.sh) to install TFLint:
 $ brew install tflint
 ```
 
+### Chocolatey
+
+Windows users can use [Chocolatey](https://chocolatey.org):
+
+```cmd
+choco install tflint
+```
+
 ### Docker
 
 You can also use [TFLint via Docker](https://hub.docker.com/r/wata727/tflint/).


### PR DESCRIPTION
Windows users can also install `tflint` using Chocolatey: https://chocolatey.org/packages/tflint

```
choco install tflint
```

Equivalent to brew, but for Windows. 👍 