### PR TITLE
Add bucket-owner-full-control to allowed S3 ACLs

### DIFF
--- a/rules/awsrules/aws_s3_bucket_invalid_acl.go
+++ b/rules/awsrules/aws_s3_bucket_invalid_acl.go
@@ -27,6 +27,7 @@ func NewAwsS3BucketInvalidACLRule() *AwsS3BucketInvalidACLRule {
 			"aws-exec-read",
 			"authenticated-read",
 			"log-delivery-write",
+			"bucket-owner-full-control",
 		},
 	}
 }


### PR DESCRIPTION
The `bucket-owner-full-control` ACL is mentioned in AWS documentation: https://docs.aws.amazon.com/AmazonS3/latest/dev/example-walkthroughs-managing-access-example3.html#access-policies-walkthrough-cross-account-acl-acctB-tasks

Add it to the list of allowed ACLs.