### PR TITLE
Add dash checks for data sources and modules

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -67,8 +67,10 @@ These rules suggest to better ways.
 
 |Rule|Enabled by default|
 | --- | --- |
-|[terraform_dash_in_resource_name](terraform_dash_in_resource_name.md)||
+|[terraform_dash_in_data_source_name](terraform_dash_in_data_source_name.md)||
+|[terraform_dash_in_module_name](terraform_dash_in_module_name.md)||
 |[terraform_dash_in_output_name](terraform_dash_in_output_name.md)||
+|[terraform_dash_in_resource_name](terraform_dash_in_resource_name.md)||
 |[terraform_deprecated_interpolation](terraform_deprecated_interpolation.md)|✔|
 |[terraform_documented_outputs](terraform_documented_outputs.md)||
 |[terraform_documented_variables](terraform_documented_variables.md)||

--- a/docs/rules/terraform_dash_in_data_source_name.md
+++ b/docs/rules/terraform_dash_in_data_source_name.md
@@ -1,0 +1,34 @@
+# terraform_dash_in_data_source_name
+
+Disallow dashes (-) in `data` source names.
+
+## Example
+
+```hcl
+data "aws_eip" "dash-name" {
+}
+
+data "aws_eip" "no_dash_name" {
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Notice: `dash-name` data source name has a dash (terraform_dash_in_data_source_name)
+
+  on template.tf line 1:
+   1: data "aws_eip" "dash-name" {
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.11.0/docs/rules/terraform_dash_in_data_source_name.md
+
+```
+
+## Why
+
+Naming conventions are optional, so it is not necessary to follow this. But this rule is useful if you want to force the following naming conventions in line with the [Terraform Plugin Naming Best Practices](https://www.terraform.io/docs/extend/best-practices/naming.html).
+
+## How To Fix
+
+Use underscores (_) instead of dashes (-).

--- a/docs/rules/terraform_dash_in_module_name.md
+++ b/docs/rules/terraform_dash_in_module_name.md
@@ -5,7 +5,7 @@ Disallow dashes (-) in `module` names.
 ## Example
 
 ```hcl
-module dash-name" {
+module "dash-name" {
 }
 
 module "no_dash_name" {

--- a/docs/rules/terraform_dash_in_module_name.md
+++ b/docs/rules/terraform_dash_in_module_name.md
@@ -1,0 +1,34 @@
+# terraform_dash_in_module_name
+
+Disallow dashes (-) in `module` names.
+
+## Example
+
+```hcl
+module dash-name" {
+}
+
+module "no_dash_name" {
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Notice: `dash-name` module name has a dash (terraform_dash_in_module_name)
+
+  on template.tf line 1:
+   1: module "dash-name" {
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.11.0/docs/rules/terraform_dash_in_module_name.md
+
+```
+
+## Why
+
+Naming conventions are optional, so it is not necessary to follow this. But this rule is useful if you want to force the following naming conventions in line with the [Terraform Plugin Naming Best Practices](https://www.terraform.io/docs/extend/best-practices/naming.html).
+
+## How To Fix
+
+Use underscores (_) instead of dashes (-).

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -38,6 +38,8 @@ var manualDefaultRules = []Rule{
 	awsrules.NewAwsResourceMissingTagsRule(),
 	terraformrules.NewTerraformDashInResourceNameRule(),
 	terraformrules.NewTerraformDashInOutputNameRule(),
+	terraformrules.NewTerraformDashInModuleNameRule(),
+	terraformrules.NewTerraformDashInDataSourceNameRule(),
 	terraformrules.NewTerraformDeprecatedInterpolationRule(),
 	terraformrules.NewTerraformDocumentedOutputsRule(),
 	terraformrules.NewTerraformDocumentedVariablesRule(),

--- a/rules/provider_test.go
+++ b/rules/provider_test.go
@@ -53,6 +53,8 @@ func Test_NewRules(t *testing.T) {
 	DefaultRules = []Rule{
 		awsrules.NewAwsRouteNotSpecifiedTargetRule(),
 		terraformrules.NewTerraformDashInResourceNameRule(),
+		terraformrules.NewTerraformDashInDataSourceNameRule(),
+		terraformrules.NewTerraformDashInModuleNameRule(),
 	}
 	deepCheckRules = []Rule{
 		awsrules.NewAwsInstanceInvalidAMIRule(),
@@ -103,6 +105,34 @@ func Test_NewRules(t *testing.T) {
 			Expected: []Rule{
 				awsrules.NewAwsRouteNotSpecifiedTargetRule(),
 				terraformrules.NewTerraformDashInResourceNameRule(),
+			},
+		},
+		{
+			Name: "enabled = true",
+			Config: &tflint.Config{
+				Rules: map[string]*tflint.RuleConfig{
+					"terraform_dash_in_data_source_name": {
+						Enabled: true,
+					},
+				},
+			},
+			Expected: []Rule{
+				awsrules.NewAwsRouteNotSpecifiedTargetRule(),
+				terraformrules.NewTerraformDashInDataSourceNameRule(),
+			},
+		},
+		{
+			Name: "enabled = true",
+			Config: &tflint.Config{
+				Rules: map[string]*tflint.RuleConfig{
+					"terraform_dash_in_module_name": {
+						Enabled: true,
+					},
+				},
+			},
+			Expected: []Rule{
+				awsrules.NewAwsRouteNotSpecifiedTargetRule(),
+				terraformrules.NewTerraformDashInModuleNameRule(),
 			},
 		},
 	}

--- a/rules/terraformrules/terraform_dash_in_data_source_name.go
+++ b/rules/terraformrules/terraform_dash_in_data_source_name.go
@@ -1,0 +1,54 @@
+package terraformrules
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+// TerraformDashInDataSourceNameRule checks whether resources have any dashes in the name
+type TerraformDashInDataSourceNameRule struct{}
+
+// NewTerraformDashInDataSourceNameRule returns a new rule
+func NewTerraformDashInDataSourceNameRule() *TerraformDashInDataSourceNameRule {
+	return &TerraformDashInDataSourceNameRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformDashInDataSourceNameRule) Name() string {
+	return "terraform_dash_in_data_source_name"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformDashInDataSourceNameRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *TerraformDashInDataSourceNameRule) Severity() string {
+	return tflint.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *TerraformDashInDataSourceNameRule) Link() string {
+	return tflint.ReferenceLink(r.Name())
+}
+
+// Check checks whether resources have any dashes in the name
+func (r *TerraformDashInDataSourceNameRule) Check(runner *tflint.Runner) error {
+	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	for _, dataSource := range runner.TFConfig.Module.DataResources {
+		if strings.Contains(dataSource.Name, "-") {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("`%s` data source name has a dash", dataSource.Name),
+				dataSource.DeclRange,
+			)
+		}
+	}
+
+	return nil
+}

--- a/rules/terraformrules/terraform_dash_in_data_source_name_test.go
+++ b/rules/terraformrules/terraform_dash_in_data_source_name_test.go
@@ -1,0 +1,53 @@
+package terraformrules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_TerraformDashInDataSourceNameRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected tflint.Issues
+	}{
+		{
+			Name: "dash in resource name",
+			Content: `
+data "aws_eip" "dash-name" {
+}`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformDashInDataSourceNameRule(),
+					Message: "`dash-name` data source name has a dash",
+					Range: hcl.Range{
+						Filename: "resources.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 27},
+					},
+				},
+			},
+		},
+		{
+			Name: "no dash in resource name",
+			Content: `
+data "aws_eip" "no_dash_name" {
+}`,
+			Expected: tflint.Issues{},
+		},
+	}
+
+	rule := NewTerraformDashInDataSourceNameRule()
+
+	for _, tc := range cases {
+		runner := tflint.TestRunner(t, map[string]string{"resources.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/rules/terraformrules/terraform_dash_in_module_name.go
+++ b/rules/terraformrules/terraform_dash_in_module_name.go
@@ -1,0 +1,54 @@
+package terraformrules
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+// TerraformDashInModuleNameRule checks whether resources have any dashes in the name
+type TerraformDashInModuleNameRule struct{}
+
+// NewTerraformDashInModuleNameRule returns a new rule
+func NewTerraformDashInModuleNameRule() *TerraformDashInModuleNameRule {
+	return &TerraformDashInModuleNameRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformDashInModuleNameRule) Name() string {
+	return "terraform_dash_in_module_name"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformDashInModuleNameRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *TerraformDashInModuleNameRule) Severity() string {
+	return tflint.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *TerraformDashInModuleNameRule) Link() string {
+	return tflint.ReferenceLink(r.Name())
+}
+
+// Check checks whether resources have any dashes in the name
+func (r *TerraformDashInModuleNameRule) Check(runner *tflint.Runner) error {
+	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	for _, moduleCall := range runner.TFConfig.Module.ModuleCalls {
+		if strings.Contains(moduleCall.Name, "-") {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("`%s` module name has a dash", moduleCall.Name),
+				moduleCall.DeclRange,
+			)
+		}
+	}
+
+	return nil
+}

--- a/rules/terraformrules/terraform_dash_in_module_name_test.go
+++ b/rules/terraformrules/terraform_dash_in_module_name_test.go
@@ -1,0 +1,55 @@
+package terraformrules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_TerraformDashInModuleNameRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected tflint.Issues
+	}{
+		{
+			Name: "dash in resource name",
+			Content: `
+module "some-module" {
+	source = ""
+}`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformDashInModuleNameRule(),
+					Message: "`some-module` module name has a dash",
+					Range: hcl.Range{
+						Filename: "resources.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 21},
+					},
+				},
+			},
+		},
+		{
+			Name: "no dash in resource name",
+			Content: `
+module "some_module" {
+	source = ""
+}`,
+			Expected: tflint.Issues{},
+		},
+	}
+
+	rule := NewTerraformDashInModuleNameRule()
+
+	for _, tc := range cases {
+		runner := tflint.TestRunner(t, map[string]string{"resources.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}


### PR DESCRIPTION
Thank you for this awesome project!

* Add `terraform_dash_in_data_source_name` rule, which checks for dashes
in data source names
* Add `terraform_dash_in_module_name` rule, which checks for dashes in
module declarations