### PR TITLE
Skip to tokenize JSON syntax code

### DIFF
--- a/integration/jsonsyntax/result.json
+++ b/integration/jsonsyntax/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_instance_invalid_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "\"t1.xmicro\" is an invalid value as instance_type",
+      "range": {
+        "filename": "template.tf.json",
+        "start": {
+          "line": 5,
+          "column": 26
+        },
+        "end": {
+          "line": 5,
+          "column": 37
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integration/jsonsyntax/template.tf.json
+++ b/integration/jsonsyntax/template.tf.json
@@ -1,0 +1,10 @@
+{
+  "resource": {
+    "aws_instance": {
+      "example": {
+        "instance_type": "t1.xmicro",
+        "ami": "${join(\"\", [\"ami-123456\"])}"
+      }
+    }
+  }
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -67,6 +67,11 @@ func TestIntegration(t *testing.T) {
 			Command: "./tflint --format json --module",
 			Dir:     "plugin",
 		},
+		{
+			Name:    "jsonsyntax",
+			Command: "./tflint --format json",
+			Dir:     "jsonsyntax",
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/tflint/loader.go
+++ b/tflint/loader.go
@@ -115,6 +115,10 @@ func (l *Loader) LoadAnnotations(dir string) (map[string]Annotations, error) {
 	ret := map[string]Annotations{}
 
 	for _, configFile := range configFiles {
+		if !strings.HasSuffix(configFile, ".tf") {
+			continue
+		}
+
 		src, err := l.fs.ReadFile(configFile)
 		if err != nil {
 			return nil, err

--- a/tflint/test-fixtures/annotation_files/file.tf.json
+++ b/tflint/test-fixtures/annotation_files/file.tf.json
@@ -1,0 +1,10 @@
+{
+  "resource": {
+    "aws_instance": {
+      "example": {
+        "instance_type": "t1.xmicro",
+        "ami": "${join(\"\", [\"ami-123456\"])}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #694 

Tokenize code to get annotations, but this only works for HCL syntax. If the extension is not `*tf`, skip this step.