### PR TITLE
Add a rule to enforce Terraform types for variables

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -74,4 +74,5 @@ These rules suggest to better ways.
 |[terraform_deprecated_interpolation](terraform_deprecated_interpolation.md)|✔|
 |[terraform_documented_outputs](terraform_documented_outputs.md)||
 |[terraform_documented_variables](terraform_documented_variables.md)||
+|[terraform_typed_variables](terraform_typed_variables.md)||
 |[terraform_module_pinned_source](terraform_module_pinned_source.md)|✔|

--- a/docs/rules/terraform_typed_variables.md
+++ b/docs/rules/terraform_typed_variables.md
@@ -20,7 +20,7 @@ variable "enabled" {
 $ tflint
 1 issue(s) found:
 
-Notice: `no_type` variable has no type (terraform_typed_variables)
+Warning: `no_type` variable has no type (terraform_typed_variables)
 
   on template.tf line 1:
    1: variable "no_type" {

--- a/docs/rules/terraform_typed_variables.md
+++ b/docs/rules/terraform_typed_variables.md
@@ -1,0 +1,37 @@
+# terraform_typed_variables
+
+Disallow `variable` declarations without type.
+
+## Example
+
+```hcl
+variable "no_type" {
+  default = "value"
+}
+
+variable "enabled" {
+  default     = false
+  description = "This is description"
+  type        = bool
+}
+```
+
+```
+$ tflint
+2 issue(s) found:
+
+Notice: `no_type` variable has no type (terraform_typed_variables)
+
+  on template.tf line 1:
+   1: variable "no_type" {
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.11.0/docs/rules/terraform_type_variables.md
+ 
+```
+
+## Why
+
+Since `type` is optional value, it is not always necessary to declare it. But this rule is useful if you want to force declaration of a type.
+
+## How To Fix
+Add a type to the variable. See https://www.terraform.io/docs/configuration/variables.html#type-constraints for more details about types

--- a/docs/rules/terraform_typed_variables.md
+++ b/docs/rules/terraform_typed_variables.md
@@ -18,14 +18,14 @@ variable "enabled" {
 
 ```
 $ tflint
-2 issue(s) found:
+1 issue(s) found:
 
 Notice: `no_type` variable has no type (terraform_typed_variables)
 
   on template.tf line 1:
    1: variable "no_type" {
 
-Reference: https://github.com/terraform-linters/tflint/blob/v0.11.0/docs/rules/terraform_type_variables.md
+Reference: https://github.com/terraform-linters/tflint/blob/v0.11.0/docs/rules/terraform_typed_variables.md
  
 ```
 

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -44,6 +44,7 @@ var manualDefaultRules = []Rule{
 	terraformrules.NewTerraformDocumentedOutputsRule(),
 	terraformrules.NewTerraformDocumentedVariablesRule(),
 	terraformrules.NewTerraformModulePinnedSourceRule(),
+	terraformrules.NewTerraformTypedVariablesRule(),
 }
 
 var manualDeepCheckRules = []Rule{

--- a/rules/terraformrules/terraform_typed_variables.go
+++ b/rules/terraformrules/terraform_typed_variables.go
@@ -1,0 +1,55 @@
+package terraformrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+// TerraformTypedVariablesRule checks whether variables have a type declared
+type TerraformTypedVariablesRule struct{}
+
+// NewTerraformTypedVariablesRule returns a new rule
+func NewTerraformTypedVariablesRule() *TerraformTypedVariablesRule {
+	return &TerraformTypedVariablesRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformTypedVariablesRule) Name() string {
+	return "terraform_typed_variables"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformTypedVariablesRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *TerraformTypedVariablesRule) Severity() string {
+	return tflint.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *TerraformTypedVariablesRule) Link() string {
+	return tflint.ReferenceLink(r.Name())
+}
+
+// Check checks whether variables have type
+func (r *TerraformTypedVariablesRule) Check(runner *tflint.Runner) error {
+	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	for _, variable := range runner.TFConfig.Module.Variables {
+		if variable.Type == cty.DynamicPseudoType {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("`%v` variable has no type", variable.Name),
+				variable.DeclRange,
+			)
+		}
+	}
+
+	return nil
+}

--- a/rules/terraformrules/terraform_typed_variables.go
+++ b/rules/terraformrules/terraform_typed_variables.go
@@ -29,7 +29,7 @@ func (r *TerraformTypedVariablesRule) Enabled() bool {
 
 // Severity returns the rule severity
 func (r *TerraformTypedVariablesRule) Severity() string {
-	return tflint.NOTICE
+	return tflint.WARNING
 }
 
 // Link returns the rule reference link

--- a/rules/terraformrules/terraform_typed_variables_test.go
+++ b/rules/terraformrules/terraform_typed_variables_test.go
@@ -1,0 +1,67 @@
+package terraformrules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_TerraformTypedVariablesRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected tflint.Issues
+	}{
+		{
+			Name: "no type",
+			Content: `
+variable "no_type" {
+  default = "default"
+}`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformTypedVariablesRule(),
+					Message: "`no_type` variable has no type",
+					Range: hcl.Range{
+						Filename: "variables.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 19},
+					},
+				},
+			},
+		},
+		{
+			Name: "complex type",
+			Content: `
+variable "no_type2" {
+  type = list(object({
+    internal = number
+    external = number
+    protocol = string
+  }))
+}`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "with type",
+			Content: `
+variable "with_type" {
+  type = string
+}`,
+			Expected: tflint.Issues{},
+		},
+	}
+
+	rule := NewTerraformTypedVariablesRule()
+
+	for _, tc := range cases {
+		runner := tflint.TestRunner(t, map[string]string{"variables.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}


### PR DESCRIPTION
This rule enforces that a type needs to be declared for variables. Enforcing this rule provides consistency across modules and ensures that engineers think about the type of variable being declared and makes it easier to consume the module knowing the type of the variable.