### PR TITLE
Add terraform_required_providers rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -78,3 +78,4 @@ These rules suggest to better ways.
 |[terraform_module_pinned_source](terraform_module_pinned_source.md)|✔|
 |[terraform_naming_convention](terraform_naming_convention.md)||
 |[terraform_required_version](terraform_required_version.md)||
+|[terraform_required_providers](terraform_required_providers.md)||

--- a/docs/rules/terraform_required_providers.md
+++ b/docs/rules/terraform_required_providers.md
@@ -13,9 +13,7 @@ rule "terraform_required_providers" {
 ## Example
 
 ```hcl
-provider "template" {
-  version = "2"
-}
+provider "template" {}
 ```
 
 ```

--- a/docs/rules/terraform_required_providers.md
+++ b/docs/rules/terraform_required_providers.md
@@ -38,7 +38,7 @@ Add the `required_providers` attribute to the `terraform` configuration block an
 ```tf
 terraform {
   required_providers {
-    aws = "~> 2.0"
+    template = "~> 2.0"
   }
 }
 ```

--- a/docs/rules/terraform_required_providers.md
+++ b/docs/rules/terraform_required_providers.md
@@ -1,0 +1,46 @@
+# terraform_required_providers
+
+Require that all providers have version constraints through `required_providers` or the provider `version` attribute.
+
+## Configuration
+
+```hcl
+rule "terraform_required_providers" {
+  enabled = true
+}
+```
+
+## Example
+
+```hcl
+provider "template" {
+  version = "2"
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: Provider "template" should have a version constraint in required_providers
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.11.0/docs/rules/terraform_required_providers.md 
+```
+
+## Why
+
+Providers are plugins released on a separate rhythm from Terraform itself, and so they have their own version numbers. For production use, you should constrain the acceptable provider versions via configuration, to ensure that new versions with breaking changes will not be automatically installed by `terraform init` in future.
+
+## How To Fix
+
+Add the `required_providers` attribute to the `terraform` configuration block and include current versions for all providers. For example:
+
+```tf
+terraform {
+  required_providers {
+    aws = "~> 2.0"
+  }
+}
+```
+
+Provider version constraints can also be specified using a version argument within a provider block but this is not recommend, particularly for child modules.

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -48,6 +48,7 @@ var manualDefaultRules = []Rule{
 	terraformrules.NewTerraformNamingConventionRule(),
 	terraformrules.NewTerraformTypedVariablesRule(),
 	terraformrules.NewTerraformRequiredVersionRule(),
+	terraformrules.NewTerraformRequiredProvidersRule(),
 }
 
 var manualDeepCheckRules = []Rule{

--- a/rules/terraformrules/terraform_required_providers.go
+++ b/rules/terraformrules/terraform_required_providers.go
@@ -1,0 +1,54 @@
+package terraformrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+// TerraformRequiredProvidersRule checks whether Terraform sets version constraints for all configured providers
+type TerraformRequiredProvidersRule struct{}
+
+// NewTerraformRequiredProvidersRule returns new rule with default attributes
+func NewTerraformRequiredProvidersRule() *TerraformRequiredProvidersRule {
+	return &TerraformRequiredProvidersRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformRequiredProvidersRule) Name() string {
+	return "terraform_required_providers"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformRequiredProvidersRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *TerraformRequiredProvidersRule) Severity() string {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *TerraformRequiredProvidersRule) Link() string {
+	return tflint.ReferenceLink(r.Name())
+}
+
+// Check checks whether variables have descriptions
+func (r *TerraformRequiredProvidersRule) Check(runner *tflint.Runner) error {
+	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	module := runner.TFConfig.Module
+	for _, provider := range module.ProviderConfigs {
+		if _, ok := module.ProviderRequirements[provider.Name]; !ok && provider.Version.Required == nil {
+			message := fmt.Sprintf(`Provider "%s" should have a version constraint in required_providers`, provider.Name)
+			if provider.Alias != "" {
+				message += fmt.Sprintf(" (%s.%s)", provider.Name, provider.Alias)
+			}
+			runner.EmitIssue(r, message, provider.DeclRange)
+		}
+	}
+
+	return nil
+}

--- a/rules/terraformrules/terraform_required_providers_test.go
+++ b/rules/terraformrules/terraform_required_providers_test.go
@@ -1,0 +1,103 @@
+package terraformrules
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_TerraformRequiredProvidersRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected tflint.Issues
+	}{
+		{
+			Name: "no version",
+			Content: `
+provider "template" {}
+`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: `Provider "template" should have a version constraint in required_providers`,
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 20,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "required_providers set",
+			Content: `
+terraform {
+	required_providers {
+		template = "~> 2"
+	}
+}
+
+provider "template" {} 
+`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "provider alias",
+			Content: `
+provider "template" {
+	version = "~> 2"
+}
+
+provider "template" {
+	alias = "b"
+}
+`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: `Provider "template" should have a version constraint in required_providers (template.b)`,
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   6,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 20,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "version set",
+			Content: `
+provider "template" {
+	version = "~> 2"
+} 
+`,
+			Expected: tflint.Issues{},
+		},
+	}
+
+	rule := NewTerraformRequiredProvidersRule()
+
+	for _, tc := range cases {
+		runner := tflint.TestRunner(t, map[string]string{"module.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}


### PR DESCRIPTION
This PR adds a rule that checks for `terraform.required_providers` and falls back to `provider.version` if set. It borrows copy from the Terraform docs:

https://www.terraform.io/docs/configuration/providers.html#provider-versions