### PR TITLE
Add unused_declarations rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -72,6 +72,7 @@ These rules suggest to better ways.
 |[terraform_dash_in_output_name](terraform_dash_in_output_name.md)||
 |[terraform_dash_in_resource_name](terraform_dash_in_resource_name.md)||
 |[terraform_deprecated_interpolation](terraform_deprecated_interpolation.md)|✔|
+|[terraform_unused_declarations](terraform_unused_declarations.md)||
 |[terraform_documented_outputs](terraform_documented_outputs.md)||
 |[terraform_documented_variables](terraform_documented_variables.md)||
 |[terraform_typed_variables](terraform_typed_variables.md)||

--- a/docs/rules/terraform_unused_declarations.md
+++ b/docs/rules/terraform_unused_declarations.md
@@ -1,0 +1,44 @@
+# terraform_unused_declarations
+
+Disallow variables, data sources, and locals that are declared but never used.
+
+## Example
+
+```hcl
+variable "not_used" {}
+
+variable "used" {}
+output "out" {
+  value = var.used
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: variable "not_used" is declared but not used (terraform_unused_declarations)
+
+  on config.tf line 1:
+   1: variable "not_used" {
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.15.5/docs/rules/terraform_unused_declarations.md
+ 
+```
+
+## Why
+
+Terraform will ignore variables and locals that are not used. It will refresh declared data sources regardless of usage. However, unreferenced variables likely indicate either a bug (and should be referenced) or removed code (and should be removed).
+
+## How To Fix
+
+Remove the declaration. For `variable` and `data`, remove the entire block. For a `local` value, remove the attribute from the `locals` block.
+
+While data sources should generally not have side effects, take greater care when removing them. For example, removing `data "http"` will cause Terraform to no longer perform an HTTP `GET` request during each plan. If a data source is being used for side effects, add an annotation to ignore it:
+
+```tf
+# tflint-ignore: terraform_unused_declarations
+data "http" "example" {
+  url = "https://checkpoint-api.hashicorp.com/v1/check/terraform"
+}
+```

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -49,6 +49,7 @@ var manualDefaultRules = []Rule{
 	terraformrules.NewTerraformTypedVariablesRule(),
 	terraformrules.NewTerraformRequiredVersionRule(),
 	terraformrules.NewTerraformRequiredProvidersRule(),
+	terraformrules.NewTerraformUnusedDeclarationsRule(),
 }
 
 var manualDeepCheckRules = []Rule{

--- a/rules/terraformrules/terraform_unused_declaration.go
+++ b/rules/terraformrules/terraform_unused_declaration.go
@@ -1,0 +1,169 @@
+package terraformrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/terraform/configs"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+// TerraformUnusedDeclarationsRule checks whether variables, data sources, or locals are declared but unused
+type TerraformUnusedDeclarationsRule struct{}
+
+type declarations struct {
+	Variables     map[string]*configs.Variable
+	DataResources map[string]*configs.Resource
+	Locals        map[string]*configs.Local
+}
+
+// NewTerraformUnusedDeclarationsRule returns a new rule
+func NewTerraformUnusedDeclarationsRule() *TerraformUnusedDeclarationsRule {
+	return &TerraformUnusedDeclarationsRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformUnusedDeclarationsRule) Name() string {
+	return "terraform_unused_declarations"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformUnusedDeclarationsRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *TerraformUnusedDeclarationsRule) Severity() string {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *TerraformUnusedDeclarationsRule) Link() string {
+	return tflint.ReferenceLink(r.Name())
+}
+
+// Check emits issues for any variables, locals, and data sources that are declared but not used
+func (r *TerraformUnusedDeclarationsRule) Check(runner *tflint.Runner) error {
+	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	decl := r.declarations(runner.TFConfig.Module)
+	for _, resource := range runner.TFConfig.Module.ManagedResources {
+		r.checkForVariablesInBody(runner, resource.Config, decl)
+	}
+	for _, data := range runner.TFConfig.Module.DataResources {
+		r.checkForVariablesInBody(runner, data.Config, decl)
+	}
+	for _, provider := range runner.TFConfig.Module.ProviderConfigs {
+		r.checkForVariablesInBody(runner, provider.Config, decl)
+	}
+	for _, module := range runner.TFConfig.Module.ModuleCalls {
+		r.checkForVariablesInBody(runner, module.Config, decl)
+	}
+	for _, output := range runner.TFConfig.Module.Outputs {
+		r.checkForVariablesInExpr(runner, output.Expr, decl)
+	}
+	for _, local := range runner.TFConfig.Module.Locals {
+		r.checkForVariablesInExpr(runner, local.Expr, decl)
+	}
+
+	for _, variable := range decl.Variables {
+		runner.EmitIssue(
+			r,
+			fmt.Sprintf(`variable "%s" is declared but not used`, variable.Name),
+			variable.DeclRange,
+		)
+	}
+	for _, data := range decl.DataResources {
+		runner.EmitIssue(
+			r,
+			fmt.Sprintf(`data "%s" "%s" is declared but not used`, data.Type, data.Name),
+			data.DeclRange,
+		)
+	}
+	for _, local := range decl.Locals {
+		runner.EmitIssue(
+			r,
+			fmt.Sprintf(`local.%s is declared but not used`, local.Name),
+			local.DeclRange,
+		)
+	}
+
+	return nil
+}
+
+func (r *TerraformUnusedDeclarationsRule) declarations(module *configs.Module) *declarations {
+	decl := &declarations{
+		Variables:     make(map[string]*configs.Variable, len(module.Variables)),
+		DataResources: make(map[string]*configs.Resource, len(module.DataResources)),
+		Locals:        make(map[string]*configs.Local, len(module.Locals)),
+	}
+
+	for k, v := range module.Variables {
+		decl.Variables[k] = v
+	}
+	for k, v := range module.DataResources {
+		decl.DataResources[k] = v
+	}
+	for k, v := range module.Locals {
+		decl.Locals[k] = v
+	}
+
+	return decl
+}
+
+func (r *TerraformUnusedDeclarationsRule) checkForVariablesInBody(runner *tflint.Runner, body hcl.Body, decl *declarations) {
+	nativeBody, ok := body.(*hclsyntax.Body)
+	if !ok {
+		return
+	}
+
+	for _, attr := range nativeBody.Attributes {
+		r.checkForVariablesInExpr(runner, attr.Expr, decl)
+	}
+
+	for _, block := range nativeBody.Blocks {
+		r.checkForVariablesInBody(runner, block.Body, decl)
+	}
+
+	return
+}
+
+func (r *TerraformUnusedDeclarationsRule) checkForVariablesInExpr(runner *tflint.Runner, expr hcl.Expression, decl *declarations) {
+	for _, variable := range expr.Variables() {
+		split := variable.SimpleSplit()
+		if len(split.Rel) == 0 {
+			continue
+		}
+
+		switch split.RootName() {
+		case "var":
+			if attr, ok := split.Rel[0].(hcl.TraverseAttr); ok {
+				delete(decl.Variables, attr.Name)
+			}
+		case "data":
+			if len(split.Rel) < 2 {
+				continue
+			}
+
+			typeAttr, ok := split.Rel[0].(hcl.TraverseAttr)
+			if !ok {
+				continue
+			}
+
+			nameAttr, ok := split.Rel[1].(hcl.TraverseAttr)
+			if !ok {
+				continue
+			}
+
+			delete(decl.DataResources, fmt.Sprintf("data.%s.%s", typeAttr.Name, nameAttr.Name))
+		case "local":
+			if attr, ok := split.Rel[0].(hcl.TraverseAttr); ok {
+				delete(decl.Locals, attr.Name)
+			}
+		}
+	}
+
+	return
+}

--- a/rules/terraformrules/terraform_unused_declarations_test.go
+++ b/rules/terraformrules/terraform_unused_declarations_test.go
@@ -1,0 +1,171 @@
+package terraformrules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_TerraformUnusedDeclarationsRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected tflint.Issues
+	}{
+		{
+			Name: "unused variable",
+			Content: `
+variable "not_used" {}
+
+variable "used" {}
+output "u" { value = var.used }
+`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformUnusedDeclarationsRule(),
+					Message: `variable "not_used" is declared but not used`,
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 20},
+					},
+				},
+			},
+		},
+		{
+			Name: "unused data source",
+			Content: `
+data "null_data_source" "not_used" {}
+
+data "null_data_source" "used" {}
+output "u" { value = data.null_data_source.used }
+`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformUnusedDeclarationsRule(),
+					Message: `data "null_data_source" "not_used" is declared but not used`,
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 35},
+					},
+				},
+			},
+		},
+		{
+			Name: "unused local source",
+			Content: `
+locals {
+	not_used = ""
+	used = ""
+}
+
+output "u" { value = local.used }
+`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformUnusedDeclarationsRule(),
+					Message: `local.not_used is declared but not used`,
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 3, Column: 2},
+						End:      hcl.Pos{Line: 3, Column: 15},
+					},
+				},
+			},
+		},
+		{
+			Name: "variable used in resource",
+			Content: `
+variable "used" {}
+resource "null_resource" "n" {
+	triggers = {
+		u = var.used
+	}
+}
+`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "variable used in module",
+			Content: `
+variable "used" {}
+module "m" {
+	source = "."
+	u = var.used
+}
+`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "variable used in module",
+			Content: `
+variable "used" {}
+module "m" {
+	source = "."
+	u = var.used
+}
+`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "variable used in provider",
+			Content: `
+variable "aws_region" {}
+provider "aws" {
+	region = var.aws_region
+}
+`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "invalid traversal",
+			Content: `
+output "o" {
+	value = {
+		a = var
+		b = data
+		c = local
+		d = data[0]
+		e = var[0]
+		f = local[0]
+		g = data.foo
+	}
+}
+`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "additional traversal",
+			Content: `
+variable "v" {
+	type = object({ foo = string })
+}
+output "v" {
+	value = var.v.foo
+}
+
+data "terraform_remote_state" "d" {}
+output "d" {
+	value = data.terraform_remote_state.d.outputs.foo
+}
+`,
+			Expected: tflint.Issues{},
+		},
+	}
+
+	rule := NewTerraformUnusedDeclarationsRule()
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			runner := tflint.TestRunner(t, map[string]string{"config.tf": tc.Content})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			tflint.AssertIssues(t, tc.Expected, runner.Issues)
+		})
+	}
+}

--- a/rules/terraformrules/terraform_unused_declarations_test.go
+++ b/rules/terraformrules/terraform_unused_declarations_test.go
@@ -120,23 +120,6 @@ provider "aws" {
 			Expected: tflint.Issues{},
 		},
 		{
-			Name: "invalid traversal",
-			Content: `
-output "o" {
-	value = {
-		a = var
-		b = data
-		c = local
-		d = data[0]
-		e = var[0]
-		f = local[0]
-		g = data.foo
-	}
-}
-`,
-			Expected: tflint.Issues{},
-		},
-		{
 			Name: "additional traversal",
 			Content: `
 variable "v" {

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -9,6 +9,7 @@ import (
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/terraform/addrs"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/configs/configschema"
@@ -499,6 +500,69 @@ func (r *Runner) LookupIssues(files ...string) Issues {
 		}
 	}
 	return issues
+}
+
+// WalkExpressions visits all blocks that can contain expressions:
+// resource, data, module, provider, locals, and output. It calls the walker
+// function with every expression it encounters and halts if the walker
+// returns an error.
+func (r *Runner) WalkExpressions(walker func(hcl.Expression) error) error {
+	visit := func(expr hcl.Expression) error {
+		return r.WithExpressionContext(expr, func() error {
+			return walker(expr)
+		})
+	}
+
+	for _, resource := range r.TFConfig.Module.ManagedResources {
+		if err := r.walkBody(resource.Config.(*hclsyntax.Body), visit); err != nil {
+			return err
+		}
+	}
+	for _, resource := range r.TFConfig.Module.DataResources {
+		if err := r.walkBody(resource.Config.(*hclsyntax.Body), visit); err != nil {
+			return err
+		}
+	}
+	for _, module := range r.TFConfig.Module.ModuleCalls {
+		if err := r.walkBody(module.Config.(*hclsyntax.Body), visit); err != nil {
+			return err
+		}
+	}
+	for _, provider := range r.TFConfig.Module.ProviderConfigs {
+		if err := r.walkBody(provider.Config.(*hclsyntax.Body), visit); err != nil {
+			return err
+		}
+	}
+	for _, local := range r.TFConfig.Module.Locals {
+		if err := visit(local.Expr); err != nil {
+			return err
+		}
+	}
+	for _, output := range r.TFConfig.Module.Outputs {
+		if err := visit(output.Expr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// walkBody visits all attributes and passes their expressions to the walker function.
+// It recurses on nested blocks.
+func (r *Runner) walkBody(body *hclsyntax.Body, walker func(hcl.Expression) error) error {
+	for _, attr := range body.Attributes {
+		if err := walker(attr.Expr); err != nil {
+			return err
+		}
+	}
+
+	for _, block := range body.Blocks {
+		if err := r.walkBody(block.Body, walker); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // WalkResourceAttributes searches for resources and passes the appropriate attributes to the walker function


### PR DESCRIPTION
Declaring something and then not using it is typically either:

* A bug, and you need to reference it
* A leftover from removed code, and you can remove it

Variables, locals, and data sources are all declared inputs and if they are not direct referenced, they are effectively dead code. This rule works by:

* Copying the maps representing these values
* Visiting all expressions that could reference something, i.e. `resource`, `data`, `locals`, `provider`, `output`, and `module` blocks
* Examining each expression's variables and if they begin with a matched prefix (var, data, local),  deleting the corresponding pointer from the appropriate map
* Emitting any remaining pointers in each map as declared but unused

