### PR TITLE
testing: compare Rule types and ignore struct fields

### DIFF
--- a/tflint/testing.go
+++ b/tflint/testing.go
@@ -2,6 +2,7 @@ package tflint
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -50,7 +51,7 @@ func AssertIssues(t *testing.T, expected Issues, actual Issues) {
 	opts := []cmp.Option{
 		// Byte field will be ignored because it's not important in tests such as positions
 		cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-		cmpopts.IgnoreFields(Issue{}, "Rule"),
+		ruleComparer(),
 	}
 	if !cmp.Equal(expected, actual, opts...) {
 		t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(expected, actual, opts...))
@@ -61,7 +62,7 @@ func AssertIssues(t *testing.T, expected Issues, actual Issues) {
 func AssertIssuesWithoutRange(t *testing.T, expected Issues, actual Issues) {
 	opts := []cmp.Option{
 		cmpopts.IgnoreFields(Issue{}, "Range"),
-		cmpopts.IgnoreFields(Issue{}, "Rule"),
+		ruleComparer(),
 	}
 	if !cmp.Equal(expected, actual, opts...) {
 		t.Fatalf("Expected issues are not matched:\n %s\n", cmp.Diff(expected, actual, opts...))
@@ -86,4 +87,12 @@ func AssertAppError(t *testing.T, expected Error, got error) {
 	} else {
 		t.Fatalf("unexpected error occurred: %s", got)
 	}
+}
+
+// ruleComparer returns a Comparer func that checks that two rule interfaces
+// have the same underlying type. It does not compare struct fields.
+func ruleComparer() cmp.Option {
+	return cmp.Comparer(func(x, y Rule) bool {
+		return reflect.TypeOf(x) == reflect.TypeOf(y)
+	})
 }


### PR DESCRIPTION
As observed in #738, `AssertIssues` was not comparing the rule in an issue. Purely removing `IgnoreFields` is not an option because it causes panics due to unexported fields:

<details>
<summary>Panic output</summary>

```
--- FAIL: Test_TerraformModulePinnedSource (0.00s)
panic: cannot handle unexported field at {tflint.Issues}[0].Rule.(*terraformrules.TerraformModulePinnedSourceRule).attributeName:
	"github.com/terraform-linters/tflint/rules/terraformrules".TerraformModulePinnedSourceRule
consider using a custom Comparer; if you control the implementation of type, you can also consider using an Exporter, AllowUnexported, or cmpopts.IgnoreUnexported [recovered]
	panic: cannot handle unexported field at {tflint.Issues}[0].Rule.(*terraformrules.TerraformModulePinnedSourceRule).attributeName:
	"github.com/terraform-linters/tflint/rules/terraformrules".TerraformModulePinnedSourceRule
consider using a custom Comparer; if you control the implementation of type, you can also consider using an Exporter, AllowUnexported, or cmpopts.IgnoreUnexported

goroutine 14 [running]:
testing.tRunner.func1.1(0x2029340, 0xc0001bbfd0)
	/usr/local/Cellar/go/1.14/libexec/src/testing/testing.go:941 +0x3d0
testing.tRunner.func1(0xc0002237a0)
	/usr/local/Cellar/go/1.14/libexec/src/testing/testing.go:944 +0x3f9
panic(0x2029340, 0xc0001bbfd0)
	/usr/local/Cellar/go/1.14/libexec/src/runtime/panic.go:967 +0x15d
github.com/google/go-cmp/cmp.validator.apply(0xc000240780, 0x2029340, 0xc0001bbca0, 0x1b8, 0x2029340, 0xc0001bbdc0, 0x1b8)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/options.go:241 +0x5ac
github.com/google/go-cmp/cmp.(*state).tryOptions(0xc000240780, 0x2800380, 0x2029340, 0x2029340, 0xc0001bbca0, 0x1b8, 0x2029340, 0xc0001bbdc0, 0x1b8, 0x4)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:279 +0x132
github.com/google/go-cmp/cmp.(*state).compareAny(0xc000240780, 0x27dea00, 0xc0000a0f00)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:234 +0x2d9
github.com/google/go-cmp/cmp.(*state).compareStruct(0xc000240780, 0x2800380, 0x21f7c00, 0x21f7c00, 0xc0001bbca0, 0x199, 0x21f7c00, 0xc0001bbdc0, 0x199)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:400 +0x61c
github.com/google/go-cmp/cmp.(*state).compareAny(0xc000240780, 0x27de940, 0xc000217640)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:262 +0xdb5
github.com/google/go-cmp/cmp.(*state).comparePtr(0xc000240780, 0x2800380, 0x235f1c0, 0x235f1c0, 0xc0001bbca0, 0x16, 0x235f1c0, 0xc0001bbdc0, 0x16)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:552 +0x31d
github.com/google/go-cmp/cmp.(*state).compareAny(0xc000240780, 0x27dea80, 0xc000217600)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:268 +0xc52
github.com/google/go-cmp/cmp.(*state).compareInterface(0xc000240780, 0x2800380, 0x21f7d00, 0x21f7d00, 0xc00023e800, 0x194, 0x21f7d00, 0xc00023f180, 0x194)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:565 +0x2a1
github.com/google/go-cmp/cmp.(*state).compareAny(0xc000240780, 0x27dea00, 0xc0000a0e00)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:270 +0xb62
github.com/google/go-cmp/cmp.(*state).compareStruct(0xc000240780, 0x2800380, 0x22e56a0, 0x22e56a0, 0xc00023e800, 0x199, 0x22e56a0, 0xc00023f180, 0x199)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:400 +0x61c
github.com/google/go-cmp/cmp.(*state).compareAny(0xc000240780, 0x27de940, 0xc0002172c0)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:262 +0xdb5
github.com/google/go-cmp/cmp.(*state).comparePtr(0xc000240780, 0x2800380, 0x1fdaec0, 0x1fdaec0, 0xc0002102b8, 0x196, 0x1fdaec0, 0xc0002104b0, 0x196)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:552 +0x31d
github.com/google/go-cmp/cmp.(*state).compareAny(0xc000240780, 0x27de9c0, 0xc00008f380)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:268 +0xc52
github.com/google/go-cmp/cmp.(*state).statelessCompare(0xc000240780, 0x27de9c0, 0xc00008f380, 0x2027a00, 0x1)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:205 +0x97
github.com/google/go-cmp/cmp.(*state).compareSlice.func2(0x0, 0x0, 0x0, 0x340cc78)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:466 +0x85
github.com/google/go-cmp/cmp/internal/diff.Difference(0x1, 0x1, 0xc0001e4ec0, 0x1, 0x1, 0xc0004c7898)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/internal/diff/diff.go:221 +0x223
github.com/google/go-cmp/cmp.(*state).compareSlice(0xc000240780, 0x2800380, 0x2162fe0, 0x2162fe0, 0xc000470a60, 0x97, 0x2162fe0, 0xc000470a80, 0x97)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:465 +0x730
github.com/google/go-cmp/cmp.(*state).compareAny(0xc000240780, 0x27dd580, 0xc000217280)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:264 +0x8e9
github.com/google/go-cmp/cmp.Equal(0x2162fe0, 0xc000470a60, 0x2162fe0, 0xc000470a80, 0xc000470a40, 0x2, 0x2, 0x340c980)
	/Users/ben/src/go/pkg/mod/github.com/google/go-cmp@v0.4.0/cmp/compare.go:112 +0x315
github.com/terraform-linters/tflint/tflint.AssertIssues(0xc0002237a0, 0xc0002102b8, 0x1, 0x1, 0xc0002104b0, 0x1, 0x1)
	/Users/ben/src/terraform-linters/tflint/tflint/testing.go:55 +0x26d
github.com/terraform-linters/tflint/rules/terraformrules.Test_TerraformModulePinnedSource(0xc0002237a0)
	/Users/ben/src/terraform-linters/tflint/rules/terraformrules/terraform_module_pinned_source_test.go:514 +0x1675
testing.tRunner(0xc0002237a0, 0x24983a8)
	/usr/local/Cellar/go/1.14/libexec/src/testing/testing.go:992 +0xdc
created by testing.(*T).Run
	/usr/local/Cellar/go/1.14/libexec/src/testing/testing.go:1043 +0x357
FAIL	github.com/terraform-linters/tflint/rules/terraformrules	0.381s
```
</details>

`IgnoreUnexported` doesn't work because every rule is its own struct and we have to pass struct values. Not to mention it doesn't fit the intent here.

In usage, `AssertIssues` is just being used with matching rule _types_ and not with equal values. This implements a custom comparer that performs that check, considering two `Rule` interfaces equal if they both have the same concrete type.