### PR TITLE
Build EvalContext as the root module

### DIFF
--- a/integration/path/.terraform/modules/modules.json
+++ b/integration/path/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"ec2","Source":"./module","Dir":"module"}]}

--- a/integration/path/main.tf
+++ b/integration/path/main.tf
@@ -1,0 +1,6 @@
+module "ec2" {
+  source = "./module"
+
+  root_suffix = "t2.micro"
+  module_suffix = "t3.micro"
+}

--- a/integration/path/module/ec2.tf
+++ b/integration/path/module/ec2.tf
@@ -1,0 +1,12 @@
+variable "root_suffix" {}
+variable "module_suffix" {}
+
+resource "aws_instance" "path_root" {
+  ami = "ami-12345678"
+  instance_type = "${path.root}/${var.root_suffix}"
+}
+
+resource "aws_instance" "path_module" {
+  ami = "ami-12345678"
+  instance_type = "${path.module}/${var.module_suffix}"
+}

--- a/integration/path/result.json
+++ b/integration/path/result.json
@@ -1,0 +1,91 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_instance_invalid_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "\"./t2.micro\" is an invalid value as instance_type",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 4,
+          "column": 17
+        },
+        "end": {
+          "line": 4,
+          "column": 27
+        }
+      },
+      "callers": [
+        {
+          "filename": "main.tf",
+          "start": {
+            "line": 4,
+            "column": 17
+          },
+          "end": {
+            "line": 4,
+            "column": 27
+          }
+        },
+        {
+          "filename": "module/ec2.tf",
+          "start": {
+            "line": 6,
+            "column": 19
+          },
+          "end": {
+            "line": 6,
+            "column": 52
+          }
+        }
+      ]
+    },
+    {
+      "rule": {
+        "name": "aws_instance_invalid_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "\"module/t3.micro\" is an invalid value as instance_type",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 5,
+          "column": 19
+        },
+        "end": {
+          "line": 5,
+          "column": 29
+        }
+      },
+      "callers": [
+        {
+          "filename": "main.tf",
+          "start": {
+            "line": 5,
+            "column": 19
+          },
+          "end": {
+            "line": 5,
+            "column": 29
+          }
+        },
+        {
+          "filename": "module/ec2.tf",
+          "start": {
+            "line": 11,
+            "column": 19
+          },
+          "end": {
+            "line": 11,
+            "column": 56
+          }
+        }
+      ]
+    }
+  ],
+  "errors": []
+}

--- a/integration/path/result_windows.json
+++ b/integration/path/result_windows.json
@@ -1,0 +1,91 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_instance_invalid_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "\"./t2.micro\" is an invalid value as instance_type",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 4,
+          "column": 17
+        },
+        "end": {
+          "line": 4,
+          "column": 27
+        }
+      },
+      "callers": [
+        {
+          "filename": "main.tf",
+          "start": {
+            "line": 4,
+            "column": 17
+          },
+          "end": {
+            "line": 4,
+            "column": 27
+          }
+        },
+        {
+          "filename": "module\\ec2.tf",
+          "start": {
+            "line": 6,
+            "column": 19
+          },
+          "end": {
+            "line": 6,
+            "column": 52
+          }
+        }
+      ]
+    },
+    {
+      "rule": {
+        "name": "aws_instance_invalid_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "\"module/t3.micro\" is an invalid value as instance_type",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 5,
+          "column": 19
+        },
+        "end": {
+          "line": 5,
+          "column": 29
+        }
+      },
+      "callers": [
+        {
+          "filename": "main.tf",
+          "start": {
+            "line": 5,
+            "column": 19
+          },
+          "end": {
+            "line": 5,
+            "column": 29
+          }
+        },
+        {
+          "filename": "module\\ec2.tf",
+          "start": {
+            "line": 11,
+            "column": 19
+          },
+          "end": {
+            "line": 11,
+            "column": 56
+          }
+        }
+      ]
+    }
+  ],
+  "errors": []
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -72,6 +72,11 @@ func TestIntegration(t *testing.T) {
 			Command: "./tflint --format json",
 			Dir:     "jsonsyntax",
 		},
+		{
+			Name:    "path",
+			Command: "./tflint --format json --module",
+			Dir:     "path",
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -1594,6 +1594,7 @@ resource "null_resource" "test" {
 			opts := cmp.Options{
 				cmpopts.IgnoreFields(hcl.Range{}, "Filename"),
 				cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
+				cmpopts.SortSlices(func(x, y hcl.Range) bool { return x.String() > y.String() }),
 			}
 			if !cmp.Equal(expressions, tc.Expressions, opts) {
 				t.Fatalf("Failed `%s` test: diff=%s", tc.Name, cmp.Diff(expressions, tc.Expressions, opts))


### PR DESCRIPTION
Fixes #733 
Closes #736 

I found that I was making a big mistake in building the eval context. According to the documentation, the `terraform.Evaluator`'s `Config` field should always be the root module, not the individual modules.
https://github.com/hashicorp/terraform/blob/v0.12.24/terraform/evaluate.go#L34-L35

The current implementation builds an Evaluator for each module and each module's evaluation context is treated as the root module. So, the values of `path.root` and` path.module` will always be the same.

This PR makes `path.root` to be evaluated correctly by building Evaluator and EvalContext for the root module.