### PR TITLE
Expose raw hcl.File objects to rules

### DIFF
--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -127,6 +127,7 @@ func TestCLIRun__noIssuesFound(t *testing.T) {
 
 		loader := tflint.NewMockAbstractLoader(ctrl)
 		loader.EXPECT().LoadConfig(".").Return(configs.NewEmptyConfig(), tc.LoadErr).AnyTimes()
+		loader.EXPECT().Files().Return(map[string]*hcl.File{}, tc.LoadErr).AnyTimes()
 		loader.EXPECT().LoadAnnotations(".").Return(map[string]tflint.Annotations{}, tc.LoadErr).AnyTimes()
 		loader.EXPECT().LoadValuesFiles().Return([]terraform.InputValues{}, tc.LoadErr).AnyTimes()
 		loader.EXPECT().Sources().Return(map[string][]byte{}).AnyTimes()
@@ -264,6 +265,7 @@ func TestCLIRun__issuesFound(t *testing.T) {
 
 		loader := tflint.NewMockAbstractLoader(ctrl)
 		loader.EXPECT().LoadConfig(".").Return(configs.NewEmptyConfig(), nil).AnyTimes()
+		loader.EXPECT().Files().Return(map[string]*hcl.File{}, nil).AnyTimes()
 		loader.EXPECT().LoadAnnotations(".").Return(map[string]tflint.Annotations{}, nil).AnyTimes()
 		loader.EXPECT().LoadValuesFiles().Return([]terraform.InputValues{}, nil).AnyTimes()
 		loader.EXPECT().Sources().Return(map[string][]byte{}).AnyTimes()
@@ -401,6 +403,7 @@ func TestCLIRun__withArguments(t *testing.T) {
 
 		loader := tflint.NewMockAbstractLoader(ctrl)
 		loader.EXPECT().LoadConfig(tc.Dir).Return(configs.NewEmptyConfig(), nil).AnyTimes()
+		loader.EXPECT().Files().Return(map[string]*hcl.File{}, nil).AnyTimes()
 		loader.EXPECT().LoadAnnotations(tc.Dir).Return(map[string]tflint.Annotations{}, nil).AnyTimes()
 		loader.EXPECT().LoadValuesFiles().Return([]terraform.InputValues{}, nil).AnyTimes()
 		loader.EXPECT().Sources().Return(map[string][]byte{}).AnyTimes()

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -96,6 +96,10 @@ func (cli *CLI) setupRunners(opts Options, cfg *tflint.Config, dir string) ([]*t
 	if err != nil {
 		return []*tflint.Runner{}, tflint.NewContextError("Failed to load configurations", err)
 	}
+	files, err := cli.loader.Files()
+	if err != nil {
+		return []*tflint.Runner{}, tflint.NewContextError("Failed to parse files", err)
+	}
 	annotations, err := cli.loader.LoadAnnotations(dir)
 	if err != nil {
 		return []*tflint.Runner{}, tflint.NewContextError("Failed to load configuration tokens", err)
@@ -110,7 +114,7 @@ func (cli *CLI) setupRunners(opts Options, cfg *tflint.Config, dir string) ([]*t
 	}
 	variables = append(variables, cliVars)
 
-	runner, err := tflint.NewRunner(cfg, annotations, configs, variables...)
+	runner, err := tflint.NewRunner(cfg, files, annotations, configs, variables...)
 	if err != nil {
 		return []*tflint.Runner{}, tflint.NewContextError("Failed to initialize a runner", err)
 	}

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -134,6 +134,10 @@ func (h *handler) inspect() (map[string][]lsp.Diagnostic, error) {
 	if err != nil {
 		return ret, fmt.Errorf("Failed to load configurations: %s", err)
 	}
+	files, err := loader.Files()
+	if err != nil {
+		return ret, tflint.NewContextError("Failed to parse files", err)
+	}
 	annotations, err := loader.LoadAnnotations(".")
 	if err != nil {
 		return ret, fmt.Errorf("Failed to load configuration tokens: %s", err)
@@ -148,7 +152,7 @@ func (h *handler) inspect() (map[string][]lsp.Diagnostic, error) {
 	}
 	variables = append(variables, cliVars)
 
-	runner, err := tflint.NewRunner(h.config, annotations, configs, variables...)
+	runner, err := tflint.NewRunner(h.config, files, annotations, configs, variables...)
 	if err != nil {
 		return ret, fmt.Errorf("Failed to initialize a runner: %s", err)
 	}

--- a/rules/awsrules/api/migration_test.go
+++ b/rules/awsrules/api/migration_test.go
@@ -169,7 +169,7 @@ resource "aws_alb" "balancer" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -321,7 +321,7 @@ resource "aws_alb" "balancer" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -441,7 +441,7 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -561,7 +561,7 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -681,7 +681,7 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -852,7 +852,7 @@ resource "aws_db_instance" "mysql" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -972,7 +972,7 @@ resource "aws_elasticache_cluster" "redis" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1143,7 +1143,7 @@ resource "aws_elasticache_cluster" "redis" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1263,7 +1263,7 @@ resource "aws_elasticache_cluster" "redis" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1434,7 +1434,7 @@ resource "aws_elb" "balancer" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1609,7 +1609,7 @@ resource "aws_elb" "balancer" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1780,7 +1780,7 @@ resource "aws_elb" "balancer" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1900,7 +1900,7 @@ resource "aws_instance" "web" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2017,7 +2017,7 @@ resource "aws_instance" "web" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2134,7 +2134,7 @@ resource "aws_instance" "web" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2305,7 +2305,7 @@ resource "aws_instance" "web" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2425,7 +2425,7 @@ resource "aws_launch_configuration" "web" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2542,7 +2542,7 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2659,7 +2659,7 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2776,7 +2776,7 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2897,7 +2897,7 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3014,7 +3014,7 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3131,7 +3131,7 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3248,7 +3248,7 @@ resource "aws_route" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/rules/awsrules/models/models_test.go
+++ b/rules/awsrules/models/models_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/configs/configload"
 	"github.com/hashicorp/terraform/terraform"
@@ -100,7 +101,7 @@ resource "aws_launch_template" "foo" {
 			t.Fatal(tfdiags)
 		}
 
-		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
+		runner, err := tflint.NewRunner(tflint.EmptyConfig(), map[string]*hcl.File{}, map[string]tflint.Annotations{}, cfg, map[string]*terraform.InputValue{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/rules/terraformrules/terraform_typed_variables.go
+++ b/rules/terraformrules/terraform_typed_variables.go
@@ -3,10 +3,8 @@ package terraformrules
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclparse"
 
 	"github.com/terraform-linters/tflint/tflint"
 )
@@ -58,25 +56,7 @@ func (r *TerraformTypedVariablesRule) Check(runner *tflint.Runner) error {
 }
 
 func (r *TerraformTypedVariablesRule) checkFileSchema(runner *tflint.Runner, filename string) error {
-	bytes, err := runner.ReadFile(filename)
-	if err != nil {
-		return err
-	}
-
-	parser := hclparse.NewParser()
-
-	var file *hcl.File
-	var diags hcl.Diagnostics
-
-	if strings.HasSuffix(filename, ".json") {
-		file, diags = parser.ParseJSON(bytes, filename)
-	} else {
-		file, diags = parser.ParseHCL(bytes, filename)
-	}
-
-	if diags.HasErrors() {
-		return diags
-	}
+	file := runner.File(filename)
 
 	content, _, diags := file.Body.PartialContent(&hcl.BodySchema{
 		Blocks: []hcl.BlockHeaderSchema{

--- a/rules/terraformrules/terraform_typed_variables.go
+++ b/rules/terraformrules/terraform_typed_variables.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/zclconf/go-cty/cty"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclparse"
 
 	"github.com/terraform-linters/tflint/tflint"
 )
@@ -41,12 +42,56 @@ func (r *TerraformTypedVariablesRule) Link() string {
 func (r *TerraformTypedVariablesRule) Check(runner *tflint.Runner) error {
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
+	files := make(map[string]*struct{})
 	for _, variable := range runner.TFConfig.Module.Variables {
-		if variable.Type == cty.DynamicPseudoType {
+		files[variable.DeclRange.Filename] = nil
+	}
+
+	for filename := range files {
+		if err := r.checkFileSchema(runner, filename); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *TerraformTypedVariablesRule) checkFileSchema(runner *tflint.Runner, filename string) error {
+	bytes, err := runner.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	parser := hclparse.NewParser()
+	file, diags := parser.ParseHCL(bytes, filename)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	content, _, diags := file.Body.PartialContent(&hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{
+			{
+				Type:       "variable",
+				LabelNames: []string{"name"},
+			},
+		},
+	})
+
+	for _, block := range content.Blocks.OfType("variable") {
+		_, _, diags := block.Body.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{
+					Name:     "type",
+					Required: true,
+				},
+			},
+		})
+
+		if diags.HasErrors() {
 			runner.EmitIssue(
 				r,
-				fmt.Sprintf("`%v` variable has no type", variable.Name),
-				variable.DeclRange,
+				fmt.Sprintf("`%v` variable has no type", block.Labels[0]),
+				block.DefRange,
 			)
 		}
 	}

--- a/rules/terraformrules/terraform_typed_variables_test.go
+++ b/rules/terraformrules/terraform_typed_variables_test.go
@@ -51,6 +51,14 @@ variable "with_type" {
 }`,
 			Expected: tflint.Issues{},
 		},
+		{
+			Name: "type any",
+			Content: `
+variable "any" {
+  type = any
+}`,
+			Expected: tflint.Issues{},
+		},
 	}
 
 	rule := NewTerraformTypedVariablesRule()

--- a/tflint/loader_mock.go
+++ b/tflint/loader_mock.go
@@ -6,6 +6,7 @@ package tflint
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	hcl "github.com/hashicorp/hcl/v2"
 	configs "github.com/hashicorp/terraform/configs"
 	terraform "github.com/hashicorp/terraform/terraform"
 	reflect "reflect"
@@ -81,6 +82,21 @@ func (m *MockAbstractLoader) LoadValuesFiles(arg0 ...string) ([]terraform.InputV
 func (mr *MockAbstractLoaderMockRecorder) LoadValuesFiles(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadValuesFiles", reflect.TypeOf((*MockAbstractLoader)(nil).LoadValuesFiles), arg0...)
+}
+
+// Files mocks base method
+func (m *MockAbstractLoader) Files() (map[string]*hcl.File, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Files")
+	ret0, _ := ret[0].(map[string]*hcl.File)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Files indicates an expected call of Files
+func (mr *MockAbstractLoaderMockRecorder) Files() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Files", reflect.TypeOf((*MockAbstractLoader)(nil).Files))
 }
 
 // Sources mocks base method

--- a/tflint/loader_test.go
+++ b/tflint/loader_test.go
@@ -136,6 +136,36 @@ func Test_LoadConfig_invalidConfiguration(t *testing.T) {
 	})
 }
 
+func Test_Files(t *testing.T) {
+	withinFixtureDir(t, "v0.12.0_module", func() {
+		loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+		_, err = loader.LoadConfig(".")
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		files, err := loader.Files()
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		filename := "module.tf"
+		b, err := afero.ReadFile(loader.fs, filename)
+
+		expected := map[string]*hcl.File{
+			"module.tf": {Bytes: b},
+		}
+
+		opts := cmpopts.IgnoreFields(hcl.File{}, "Body", "Nav")
+		if !cmp.Equal(expected, files, opts) {
+			t.Fatalf("Test failed. Diff: %s", cmp.Diff(expected, files, opts))
+		}
+	})
+}
+
 func Test_LoadAnnotations(t *testing.T) {
 	withinFixtureDir(t, "annotation_files", func() {
 		loader, err := NewLoader(afero.Afero{Fs: afero.NewOsFs()}, EmptyConfig())

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -233,6 +233,7 @@ func (r *Runner) LookupIssues(files ...string) Issues {
 	return issues
 }
 
+// ReadFile reads a file from the current module from disk by filename
 func (r *Runner) ReadFile(filename string) ([]byte, error) {
 	return afero.ReadFile(r.fs, filepath.Join(r.TFConfig.Module.SourceDir, filename))
 }

--- a/tflint/testing.go
+++ b/tflint/testing.go
@@ -37,12 +37,15 @@ func TestRunnerWithConfig(t *testing.T, files map[string]string, config *Config)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	runner, err := NewRunner(config, map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	f, err := loader.Files()
 	if err != nil {
 		t.Fatal(err)
 	}
-	runner.fs = fs
+
+	runner, err := NewRunner(config, f, map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	return runner
 }

--- a/tflint/testing.go
+++ b/tflint/testing.go
@@ -42,6 +42,7 @@ func TestRunnerWithConfig(t *testing.T, files map[string]string, config *Config)
 	if err != nil {
 		t.Fatal(err)
 	}
+	runner.fs = fs
 
 	return runner
 }

--- a/tflint/tflint_test.go
+++ b/tflint/tflint_test.go
@@ -36,8 +36,12 @@ func testRunnerWithInputVariables(t *testing.T, files map[string]string, variabl
 	if err != nil {
 		t.Fatal(err)
 	}
+	f, err := loader.Files()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	runner, err := NewRunner(config, map[string]Annotations{}, cfg, variables...)
+	runner, err := NewRunner(config, f, map[string]Annotations{}, cfg, variables...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,8 +93,12 @@ func testRunnerWithOsFs(t *testing.T, config *Config) *Runner {
 	if err != nil {
 		t.Fatal(err)
 	}
+	f, err := loader.Files()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	runner, err := NewRunner(config, map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
+	runner, err := NewRunner(config, f, map[string]Annotations{}, cfg, map[string]*terraform.InputValue{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +126,12 @@ func testRunnerWithAnnotations(t *testing.T, files map[string]string, annotation
 		t.Fatal(err)
 	}
 
-	runner, err := NewRunner(config, annotations, cfg, map[string]*terraform.InputValue{})
+	f, err := loader.Files()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runner, err := NewRunner(config, f, annotations, cfg, map[string]*terraform.InputValue{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds an initial proof of concept of reading files, parsing as HCL/JSON, and then traversing the content based on a partial schema for exactly the attributes we want. It would close #741 and close #744. 

Happy to factor the parser/parsing into the runner as well. Just wanted to get this up and see if you're interested in this direction for this and similar rules.