### PR TITLE
Add support TFLINT_VERSION environment variable to installation script

### DIFF
--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -1,0 +1,28 @@
+name: install_script
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install latest version
+      run: |
+        bash install_linux.sh
+    - name: Install specific version
+      env:
+        TFLINT_VERSION: v0.15.0
+      run: |
+        bash install_linux.sh

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -53,16 +53,29 @@ fi
 echo -e "\n\n===================================================="
 echo "Unpacking /tmp/tflint.zip ..."
 unzip -u /tmp/tflint.zip -d /tmp/
-echo "Installing /tmp/tflint to /usr/local/bin..."
-sudo mkdir -p /usr/local/bin
-sudo install -b -C -v /tmp/tflint /usr/local/bin/
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "Failed to install tflint"
-  exit $retVal
+if [[ $os == "windows"* ]]; then
+  echo "Installing /tmp/tflint to /bin..."
+  mv /tmp/tflint /bin/
+  retVal=$?
+  if [ $retVal -ne 0 ]; then
+    echo "Failed to install tflint"
+    exit $retVal
+  else
+    echo "tflint installed at /bin/ successfully"
+  fi
 else
-  echo "tflint installed at /usr/local/bin/ successfully"
+  echo "Installing /tmp/tflint to /usr/local/bin..."
+  sudo mkdir -p /usr/local/bin
+  sudo install -b -C -v /tmp/tflint /usr/local/bin/
+  retVal=$?
+  if [ $retVal -ne 0 ]; then
+    echo "Failed to install tflint"
+    exit $retVal
+  else
+    echo "tflint installed at /usr/local/bin/ successfully"
+  fi
 fi
+
 echo "Cleaning /tmp/tflint.zip and /tmp/tflint ..."
 rm /tmp/tflint.zip /tmp/tflint
 

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -33,10 +33,15 @@ get_latest_release() {
     sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
 }
 
-echo "Looking up the latest version ..."
-latest_version=$(get_latest_release)
-echo "Downloading latest version of tflint which is $latest_version"
-curl -L -o /tmp/tflint.zip "https://github.com/terraform-linters/tflint/releases/download/${latest_version}/tflint_${os}.zip"
+if [[ -z "${TFLINT_VERSION}" ]]; then
+  echo "Looking up the latest version ..."
+  version=$(get_latest_release)
+else
+  version=${TFLINT_VERSION}
+fi
+
+echo "Downloading TFLint $version"
+curl -L -o /tmp/tflint.zip "https://github.com/terraform-linters/tflint/releases/download/${version}/tflint_${os}.zip"
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "Failed to download tflint_${os}.zip"

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -63,6 +63,8 @@ if [ $retVal -ne 0 ]; then
 else
   echo "tflint installed at /usr/local/bin/ successfully"
 fi
+echo "Cleaning /tmp/tflint.zip and /tmp/tflint ..."
+rm /tmp/tflint.zip /tmp/tflint
 
 echo -e "\n\n===================================================="
 echo "Current tflint version"


### PR DESCRIPTION
Allows any version of TFLint to be installed with install_linux.sh for E2E testing with the Ruleset plugin repository.