### PR TITLE
ignore lang.ReferencesInExpr errors when walking all expressions

### DIFF
--- a/rules/terraformrules/terraform_unused_declaration.go
+++ b/rules/terraformrules/terraform_unused_declaration.go
@@ -105,6 +105,7 @@ func (r *TerraformUnusedDeclarationsRule) declarations(module *configs.Module) *
 func (r *TerraformUnusedDeclarationsRule) checkForRefsInExpr(expr hcl.Expression, decl *declarations) error {
 	refs, diags := lang.ReferencesInExpr(expr)
 	if diags.HasErrors() {
+		log.Printf("[DEBUG] Cannot find references in expression, ignoring: %v", diags.Err())
 		return nil
 	}
 

--- a/rules/terraformrules/terraform_unused_declaration.go
+++ b/rules/terraformrules/terraform_unused_declaration.go
@@ -105,7 +105,7 @@ func (r *TerraformUnusedDeclarationsRule) declarations(module *configs.Module) *
 func (r *TerraformUnusedDeclarationsRule) checkForRefsInExpr(expr hcl.Expression, decl *declarations) error {
 	refs, diags := lang.ReferencesInExpr(expr)
 	if diags.HasErrors() {
-		return diags.Err()
+		return nil
 	}
 
 	for _, ref := range refs {

--- a/rules/terraformrules/terraform_unused_declarations_test.go
+++ b/rules/terraformrules/terraform_unused_declarations_test.go
@@ -121,6 +121,28 @@ provider "aws" {
 			Expected: tflint.Issues{},
 		},
 		{
+			Name: "meta-arguments",
+			Content: `
+variable "used" {}
+resource "null_resource" "n" {
+  triggers = {
+    u = var.used
+	}
+  
+  lifecycle {
+    ignore_changes = [triggers]
+  }
+
+  providers = {
+    null = null
+  }
+
+  depends_on = [aws_instance.foo]
+}
+`,
+			Expected: tflint.Issues{},
+		},
+		{
 			Name: "additional traversal",
 			Content: `
 variable "v" {

--- a/rules/terraformrules/terraform_workspace_remote.go
+++ b/rules/terraformrules/terraform_workspace_remote.go
@@ -55,7 +55,7 @@ func (r *TerraformWorkspaceRemoteRule) Check(runner *tflint.Runner) error {
 func (r *TerraformWorkspaceRemoteRule) checkForTerraformWorkspaceInExpr(runner *tflint.Runner, expr hcl.Expression) error {
 	refs, diags := lang.ReferencesInExpr(expr)
 	if diags.HasErrors() {
-		return diags.Err()
+		return nil
 	}
 
 	for _, ref := range refs {

--- a/rules/terraformrules/terraform_workspace_remote.go
+++ b/rules/terraformrules/terraform_workspace_remote.go
@@ -55,6 +55,7 @@ func (r *TerraformWorkspaceRemoteRule) Check(runner *tflint.Runner) error {
 func (r *TerraformWorkspaceRemoteRule) checkForTerraformWorkspaceInExpr(runner *tflint.Runner, expr hcl.Expression) error {
 	refs, diags := lang.ReferencesInExpr(expr)
 	if diags.HasErrors() {
+		log.Printf("[DEBUG] Cannot find references in expression, ignoring: %v", diags.Err())
 		return nil
 	}
 

--- a/rules/terraformrules/terraform_workspace_remote_test.go
+++ b/rules/terraformrules/terraform_workspace_remote_test.go
@@ -182,6 +182,27 @@ locals {
 }`,
 			Expected: tflint.Issues{},
 		},
+		{
+			Name: "meta-arguments",
+			Content: `
+terraform {
+	backend "remote" {}
+}
+resource "aws_instance" "foo" {
+  instance_type = "t3.nano"
+
+  lifecycle {
+    ignore_changes = [instance_type]
+  }
+
+  providers = {
+    aws = aws
+  }
+
+  depends_on = [aws_instance.bar]
+}`,
+			Expected: tflint.Issues{},
+		},
 	}
 
 	rule := NewTerraformWorkspaceRemoteRule()


### PR DESCRIPTION
When visiting all expressions, we might encounter special attributes/blocks, where normal reference rules no longer apply:

https://www.terraform.io/docs/configuration/resources.html#meta-arguments

This currently returns an error for the `unused_declarations` and `workspace_remote` rules:

```
Error: Invalid reference: A reference to a resource type must be followed by at least one attribute access, specifying the resource name.
```

Detecting these attributes seems too brittle/awkward, so simply exiting if an expression cannot be evaluated for references seems like the best fix