### PR TITLE
add terraform_comment_syntax rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -69,6 +69,7 @@ These rules suggest to better ways.
 | --- | --- |
 |[terraform_deprecated_interpolation](terraform_deprecated_interpolation.md)|✔|
 |[terraform_unused_declarations](terraform_unused_declarations.md)||
+|[terraform_comment_syntax](terraform_comment_syntax.md)||
 |[terraform_documented_outputs](terraform_documented_outputs.md)||
 |[terraform_documented_variables](terraform_documented_variables.md)||
 |[terraform_typed_variables](terraform_typed_variables.md)||

--- a/docs/rules/terraform_comment_syntax.md
+++ b/docs/rules/terraform_comment_syntax.md
@@ -1,0 +1,32 @@
+# terraform_comment_syntax
+
+Disallow `//` comments in favor of `#`.
+
+## Example
+
+```hcl
+# Good
+// Bad
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: Single line comments should begin with # (terraform_comment_syntax)
+
+  on main.tf line 2:
+   2: // Bad
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.16.0/docs/rules/terraform_typed_variables.md
+```
+
+## Why
+
+The Terraform language supports two different syntaxes for single-line comments: `#` and `//`. However, `#` is the default comment style and should be used in most cases.
+
+* [Configuration Syntax: Comments](https://www.terraform.io/docs/configuration/syntax.html#comments)
+
+## How To Fix
+
+Replacing the leading double-slash (`//`) with the number sign (`#`).

--- a/docs/rules/terraform_comment_syntax.md
+++ b/docs/rules/terraform_comment_syntax.md
@@ -29,4 +29,4 @@ The Terraform language supports two different syntaxes for single-line comments:
 
 ## How To Fix
 
-Replacing the leading double-slash (`//`) with the number sign (`#`).
+Replace the leading double-slash (`//`) in your comment with the number sign (`#`).

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -47,6 +47,7 @@ var manualDefaultRules = []Rule{
 	terraformrules.NewTerraformRequiredProvidersRule(),
 	terraformrules.NewTerraformWorkspaceRemoteRule(),
 	terraformrules.NewTerraformUnusedDeclarationsRule(),
+	terraformrules.NewTerraformCommentSyntaxRule(),
 }
 
 var manualDeepCheckRules = []Rule{

--- a/rules/terraformrules/terraform_comment_syntax.go
+++ b/rules/terraformrules/terraform_comment_syntax.go
@@ -1,0 +1,75 @@
+package terraformrules
+
+import (
+	"log"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+// TerraformCommentSyntaxRule checks whether comments use the preferred syntax
+type TerraformCommentSyntaxRule struct{}
+
+// NewTerraformCommentSyntaxRule returns a new rule
+func NewTerraformCommentSyntaxRule() *TerraformCommentSyntaxRule {
+	return &TerraformCommentSyntaxRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformCommentSyntaxRule) Name() string {
+	return "terraform_comment_syntax"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformCommentSyntaxRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *TerraformCommentSyntaxRule) Severity() string {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *TerraformCommentSyntaxRule) Link() string {
+	return tflint.ReferenceLink(r.Name())
+}
+
+// Check checks whether variables have type
+func (r *TerraformCommentSyntaxRule) Check(runner *tflint.Runner) error {
+	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	for name, file := range runner.Files() {
+		if err := r.checkComments(runner, name, file); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *TerraformCommentSyntaxRule) checkComments(runner *tflint.Runner, filename string, file *hcl.File) error {
+	tokens, diags := hclsyntax.LexConfig(file.Bytes, filename, hcl.InitialPos)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	for _, token := range tokens {
+		if token.Type != hclsyntax.TokenComment {
+			continue
+		}
+
+		if strings.HasPrefix(string(token.Bytes), "//") {
+			runner.EmitIssue(
+				r,
+				"Single line comments should begin with #",
+				token.Range,
+			)
+		}
+	}
+
+	return nil
+}

--- a/rules/terraformrules/terraform_comment_syntax.go
+++ b/rules/terraformrules/terraform_comment_syntax.go
@@ -52,6 +52,10 @@ func (r *TerraformCommentSyntaxRule) Check(runner *tflint.Runner) error {
 }
 
 func (r *TerraformCommentSyntaxRule) checkComments(runner *tflint.Runner, filename string, file *hcl.File) error {
+	if strings.HasSuffix(filename, ".json") {
+		return nil
+	}
+
 	tokens, diags := hclsyntax.LexConfig(file.Bytes, filename, hcl.InitialPos)
 	if diags.HasErrors() {
 		return diags

--- a/rules/terraformrules/terraform_comment_syntax_test.go
+++ b/rules/terraformrules/terraform_comment_syntax_test.go
@@ -58,6 +58,12 @@ variable "foo" {
 `,
 			Expected: tflint.Issues{},
 		},
+		{
+			Name:     "JSON",
+			Content:  `{"variable": {"foo": {"type": "string"}}}`,
+			JSON:     true,
+			Expected: tflint.Issues{},
+		},
 	}
 
 	rule := NewTerraformCommentSyntaxRule()

--- a/rules/terraformrules/terraform_comment_syntax_test.go
+++ b/rules/terraformrules/terraform_comment_syntax_test.go
@@ -1,0 +1,79 @@
+package terraformrules
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_TerraformCommentSyntaxRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		JSON     bool
+		Expected tflint.Issues
+	}{
+		{
+			Name:     "hash comment",
+			Content:  `# foo`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "multi-line comment",
+			Content: `
+/*
+	This comment spans multiple lines
+*/			
+`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name:    "double-slash comment",
+			Content: `// foo`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformCommentSyntaxRule(),
+					Message: "Single line comments should begin with #",
+					Range: hcl.Range{
+						Filename: "variables.tf",
+						Start: hcl.Pos{
+							Line:   1,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Line:   1,
+							Column: 7,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "end-of-line hash comment",
+			Content: `
+variable "foo" {
+	type = string # a string
+}
+`,
+			Expected: tflint.Issues{},
+		},
+	}
+
+	rule := NewTerraformCommentSyntaxRule()
+
+	for _, tc := range cases {
+		filename := "variables.tf"
+		if tc.JSON {
+			filename += ".json"
+		}
+
+		runner := tflint.TestRunner(t, map[string]string{filename: tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -235,6 +236,17 @@ func (r *Runner) LookupIssues(files ...string) Issues {
 // or nil if there path does not match any configuration.
 func (r *Runner) File(path string) *hcl.File {
 	return r.files[path]
+}
+
+// Files returns the raw *hcl.File representation of all Terraform configuration in the module directory.
+func (r *Runner) Files() map[string]*hcl.File {
+	result := make(map[string]*hcl.File)
+	for name, file := range r.files {
+		if filepath.Dir(name) == r.TFConfig.Module.SourceDir {
+			result[name] = file
+		}
+	}
+	return result
 }
 
 // EnsureNoError is a helper for processing when no error occurs

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -260,6 +260,27 @@ func Test_NewModuleRunners_withNotAllowedAttributes(t *testing.T) {
 	})
 }
 
+func Test_RunnerFiles(t *testing.T) {
+	runner := TestRunner(t, map[string]string{
+		"main.tf":       "",
+		"child/main.tf": "",
+	})
+
+	expected := map[string]*hcl.File{
+		"main.tf": {
+			Body:  hcl.EmptyBody(),
+			Bytes: []byte{},
+		},
+	}
+
+	files := runner.Files()
+
+	opt := cmpopts.IgnoreFields(hcl.File{}, "Body", "Nav")
+	if !cmp.Equal(expected, files, opt) {
+		t.Fatalf("Failed test: diff: %s", cmp.Diff(expected, files, opt))
+	}
+}
+
 func Test_LookupResourcesByType(t *testing.T) {
 	content := `
 resource "aws_instance" "web" {


### PR DESCRIPTION
This PR adds a `terraform_comment_syntax` rule that enforces the canonical `#` comment style as described in the Terraform syntax guide:

https://www.terraform.io/docs/configuration/syntax.html#comments

This was requested by a colleague who noticed that @takescoop's Terraform configuration contains a mix of `#` and `//` comments but that Terraform clearly recommends `#`.

Since this is an aesthetic preference, the rule is disabled by default.

In order to accomplish this, I've added a `Files` method to the runner which returns all files in the current module. I'm interested in some other syntax-oriented rules that would depend on that method, e.g. enforcing canonical block padding:

```tf
resource "foo" "bar" {
  attribute = "value"

  block {
    
  }
}

resource "foo" "baz" {
  # ...
}
```