### PR TITLE
Make rule config which is enabled with CLI non-nilable

### DIFF
--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -112,6 +112,12 @@ func TestCLIRun__noIssuesFound(t *testing.T) {
 			Status:  ExitCodeError,
 			Stderr:  "Rule not found: nosuchrule",
 		},
+		{
+			Name:    "enable rule which has required configuration",
+			Command: "./tflint --enable-rule aws_resource_missing_tags",
+			Status:  ExitCodeError,
+			Stderr:  "This rule cannot be enabled with the `--enable-rule` option because it lacks the required configuration",
+		},
 	}
 
 	ctrl := gomock.NewController(t)

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"strings"
 
+	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint/client"
 	"github.com/terraform-linters/tflint/tflint"
 )
@@ -63,12 +64,14 @@ func (opts *Options) toConfig() *tflint.Config {
 		rules[rule] = &tflint.RuleConfig{
 			Name:    rule,
 			Enabled: true,
+			Body:    hcl.EmptyBody(),
 		}
 	}
 	for _, rule := range opts.DisableRules {
 		rules[rule] = &tflint.RuleConfig{
 			Name:    rule,
 			Enabled: false,
+			Body:    hcl.EmptyBody(),
 		}
 	}
 

--- a/cmd/option_test.go
+++ b/cmd/option_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	hcl "github.com/hashicorp/hcl/v2"
 	flags "github.com/jessevdk/go-flags"
 	"github.com/terraform-linters/tflint/client"
 	"github.com/terraform-linters/tflint/tflint"
@@ -212,10 +213,12 @@ func Test_toConfig(t *testing.T) {
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
 						Enabled: true,
+						Body:    hcl.EmptyBody(),
 					},
 					"aws_instance_previous_type": {
 						Name:    "aws_instance_previous_type",
 						Enabled: true,
+						Body:    hcl.EmptyBody(),
 					},
 				},
 				Plugins: map[string]*tflint.PluginConfig{},
@@ -236,10 +239,12 @@ func Test_toConfig(t *testing.T) {
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
 						Enabled: false,
+						Body:    hcl.EmptyBody(),
 					},
 					"aws_instance_previous_type": {
 						Name:    "aws_instance_previous_type",
 						Enabled: false,
+						Body:    hcl.EmptyBody(),
 					},
 				},
 				Plugins: map[string]*tflint.PluginConfig{},

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -294,7 +294,15 @@ func mergeRuleMap(a, b map[string]*RuleConfig) map[string]*RuleConfig {
 		ret[k] = v
 	}
 	for k, v := range b {
-		ret[k] = v
+		// HACK: If you enable the rule through the CLI instead of the file, its hcl.Body will not contain valid range.
+		// @see https://github.com/hashicorp/hcl/blob/v2.5.0/merged.go#L132-L135
+		if prevConfig, exists := ret[k]; exists && v.Body.MissingItemRange().Filename == "<empty>" {
+			ret[k] = v
+			// Do not override body
+			ret[k].Body = prevConfig.Body
+		} else {
+			ret[k] = v
+		}
 	}
 	return ret
 }

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -344,6 +344,11 @@ func (r *Runner) DecodeRuleConfig(ruleName string, val interface{}) error {
 	if rule, exists := r.config.Rules[ruleName]; exists {
 		diags := gohcl.DecodeBody(rule.Body, nil, val)
 		if diags.HasErrors() {
+			// HACK: If you enable the rule through the CLI instead of the file, its hcl.Body will not contain valid range.
+			// @see https://github.com/hashicorp/hcl/blob/v2.5.0/merged.go#L132-L135
+			if rule.Body.MissingItemRange().Filename == "<empty>" {
+				return errors.New("This rule cannot be enabled with the `--enable-rule` option because it lacks the required configuration")
+			}
 			return diags
 		}
 	}


### PR DESCRIPTION
Fixes #760 

In the rule configuration which is enabled with CLI, The `Body` attribute is always nil. So, it panics when decoded the rule configuration.

To prevent this, always set the empty body to the configuration.