### PR TITLE
terraform_workspace_remote: document disabling with local execution

### DIFF
--- a/docs/rules/terraform_workspace_remote.md
+++ b/docs/rules/terraform_workspace_remote.md
@@ -1,6 +1,14 @@
 # terraform_workspace_remote
 
-`terraform.workspace` should not be used with a "remote" backend
+`terraform.workspace` should not be used with a "remote" backend with remote execution. 
+
+If remote operations are [disabled](https://www.terraform.io/docs/cloud/run/index.html#disabling-remote-operations) for your workspace, you can safely disable this rule:
+
+```hcl
+rule "terraform_workspace_remote" {
+  enabled = false
+}
+```
 
 ## Example
 


### PR DESCRIPTION
Updates the documentation for the `terraform_workspace_remote` rule to indicate that it's safe to disable this rule if you don't use remote execution with your workspaces.

Closes #761