### PR TITLE
[WIP] - Adding new terraform_blacklisted_resources rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -67,6 +67,7 @@ These rules suggest to better ways.
 
 |Rule|Enabled by default|
 | --- | --- |
+|[terraform_blacklisted_resources](terraform_blacklisted_resources.md)||
 |[terraform_deprecated_interpolation](terraform_deprecated_interpolation.md)|✔|
 |[terraform_unused_declarations](terraform_unused_declarations.md)||
 |[terraform_comment_syntax](terraform_comment_syntax.md)||

--- a/docs/rules/terraform_blacklisted_resources.md
+++ b/docs/rules/terraform_blacklisted_resources.md
@@ -1,0 +1,50 @@
+# terraform_blacklisted_resources
+
+Disallow `resource` declarations of certain types. Each type has a custom message will be displayed.
+
+## Example
+
+```hcl
+rule "terraform_blacklisted_resources" {
+  enabled = true
+  types   = {
+    aws_iam_policy_attachment = "Consider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead."
+  }
+}
+```
+
+```hcl
+resource "random_id" "server" {
+  byte_length = 8
+}
+
+resource "aws_iam_policy_attachment" "test-attach" {
+  name       = "test-attachment"
+  users      = [aws_iam_user.user.name]
+  roles      = [aws_iam_role.role.name]
+  groups     = [aws_iam_group.group.name]
+  policy_arn = aws_iam_policy.policy.arn
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: `aws_iam_policy_attachment` resource type is blacklisted
+
+Consider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead. (terraform_blacklisted_resources)
+
+  on modules.tf line 1:
+   1: resource "aws_iam_policy_attachment" {
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.16.0/docs/rules/terraform_blacklisted_resources.md
+```
+
+## Why
+Organizations may want to disallow some resource types from being used in their organization and provide feedback to 
+alternative resources. An example is the `aws_iam_policy_attachment` and preferring to use
+`aws_iam_role_policy_attachment`, `aws_iam_user_policy_attachment`, or `aws_iam_group_policy_attachment` instead.
+
+## How To Fix
+Follow the guidance provided by the message associated with the blacklisted resource type.

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -48,6 +48,7 @@ var manualDefaultRules = []Rule{
 	terraformrules.NewTerraformWorkspaceRemoteRule(),
 	terraformrules.NewTerraformUnusedDeclarationsRule(),
 	terraformrules.NewTerraformCommentSyntaxRule(),
+	terraformrules.NewTerraformBlacklistedResourcesRule(),
 }
 
 var manualDeepCheckRules = []Rule{

--- a/rules/terraformrules/terraform_blacklisted_resources.go
+++ b/rules/terraformrules/terraform_blacklisted_resources.go
@@ -1,0 +1,77 @@
+package terraformrules
+
+import (
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+// TerraformBlacklistedResourcesRule checks whether variables have a type declared
+type TerraformBlacklistedResourcesRule struct{}
+
+type terraformBlacklistedResourcesRuleConfig struct {
+	Types map[string]string `hcl:"types"`
+}
+
+// TerraformBlacklistedResourcesRule returns a new rule
+func NewTerraformBlacklistedResourcesRule() *TerraformBlacklistedResourcesRule {
+	return &TerraformBlacklistedResourcesRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformBlacklistedResourcesRule) Name() string {
+	return "terraform_blacklisted_resources"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformBlacklistedResourcesRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *TerraformBlacklistedResourcesRule) Severity() string {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *TerraformBlacklistedResourcesRule) Link() string {
+	return tflint.ReferenceLink(r.Name())
+}
+
+// TODO: comment
+func (r *TerraformBlacklistedResourcesRule) Check(runner *tflint.Runner) error {
+	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	config := terraformBlacklistedResourcesRuleConfig{}
+	config.Types = make(map[string]string)
+
+	if err := runner.DecodeRuleConfig(r.Name(), &config); err != nil {
+		return err
+	}
+
+	// Since the resources are stored as a map, there is no guarantee of the order in which
+	// they will be iterated over. The resources need to be iterated in a consistent manner
+	// to ensure that the tests are consistent
+	managedResources := runner.TFConfig.Module.ManagedResources
+	resourceNames := make([]string, 0, len(managedResources))
+	for k := range managedResources {
+		resourceNames = append(resourceNames, k)
+	}
+	sort.Strings(resourceNames)
+
+	for _, resourceName := range resourceNames {
+		resource := managedResources[resourceName]
+		msg, exists := config.Types[resource.Type]
+		if exists {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("`%v` resource type is blacklisted\n\n%v", resource.Type, msg),
+				resource.TypeRange,
+			)
+		}
+	}
+
+	return nil
+}

--- a/rules/terraformrules/terraform_blacklisted_resources.go
+++ b/rules/terraformrules/terraform_blacklisted_resources.go
@@ -40,7 +40,7 @@ func (r *TerraformBlacklistedResourcesRule) Link() string {
 	return tflint.ReferenceLink(r.Name())
 }
 
-// TODO: comment
+// Check whether resources exist of a ceratin type and provides a custom message
 func (r *TerraformBlacklistedResourcesRule) Check(runner *tflint.Runner) error {
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 

--- a/rules/terraformrules/terraform_blacklisted_resources.go
+++ b/rules/terraformrules/terraform_blacklisted_resources.go
@@ -15,7 +15,7 @@ type terraformBlacklistedResourcesRuleConfig struct {
 	Types map[string]string `hcl:"types"`
 }
 
-// TerraformBlacklistedResourcesRule returns a new rule
+// NewTerraformBlacklistedResourcesRule returns a new rule
 func NewTerraformBlacklistedResourcesRule() *TerraformBlacklistedResourcesRule {
 	return &TerraformBlacklistedResourcesRule{}
 }

--- a/rules/terraformrules/terraform_blacklisted_resources_test.go
+++ b/rules/terraformrules/terraform_blacklisted_resources_test.go
@@ -1,0 +1,171 @@
+package terraformrules
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_TerraformBlacklistedResourcesRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Config   string
+		Expected tflint.Issues
+	}{
+		{
+			Name: "empty configuration",
+			Content: `
+resource "random_id" "server" {
+ byte_length = 8
+}
+
+resource "aws_iam_policy_attachment" "test-attach" {
+ name       = "test-attachment"
+ users      = [aws_iam_user.user.name]
+ roles      = [aws_iam_role.role.name]
+ groups     = [aws_iam_group.group.name]
+ policy_arn = aws_iam_policy.policy.arn
+}`,
+			Config: `
+rule "terraform_blacklisted_resources" {
+ enabled = true
+ types   = {
+   google_organization_iam_binding = "This resource is banned from usage"
+ }
+}`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "with types",
+			Content: `
+resource "random_id" "server" {
+  byte_length = 8
+}
+
+resource "aws_iam_policy_attachment" "test-attach" {
+  name       = "test-attachment"
+  users      = [aws_iam_user.user.name]
+  roles      = [aws_iam_role.role.name]
+  groups     = [aws_iam_group.group.name]
+  policy_arn = aws_iam_policy.policy.arn
+}
+
+resource "aws_iam_policy_attachment" "test-attach-2" {
+  name       = "test-attachment-2"
+  users      = [aws_iam_user.user.name]
+  roles      = [aws_iam_role.role.name]
+  groups     = [aws_iam_group.group.name]
+  policy_arn = aws_iam_policy.policy.arn
+}
+`,
+			Config: `
+rule "terraform_blacklisted_resources" {
+  enabled = true
+  types   = {
+    aws_iam_policy_attachment = "Consider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead."
+  }
+}`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformBlacklistedResourcesRule(),
+					Message: "`aws_iam_policy_attachment` resource type is blacklisted\n\nConsider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead.",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 6, Column: 10},
+						End:      hcl.Pos{Line: 6, Column: 37},
+					},
+				},
+				{
+					Rule:    NewTerraformBlacklistedResourcesRule(),
+					Message: "`aws_iam_policy_attachment` resource type is blacklisted\n\nConsider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead.",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 14, Column: 10},
+						End:      hcl.Pos{Line: 14, Column: 37},
+					},
+				},
+			},
+		},
+		{
+			Name: "with multiple types",
+			Content: `
+resource "random_id" "server" {
+ byte_length = 8
+}
+
+resource "aws_iam_policy_attachment" "test-attach" {
+ name       = "test-attachment"
+ users      = [aws_iam_user.user.name]
+ roles      = [aws_iam_role.role.name]
+ groups     = [aws_iam_group.group.name]
+ policy_arn = aws_iam_policy.policy.arn
+}`,
+			Config: `
+rule "terraform_blacklisted_resources" {
+ enabled = true
+ types   = {
+   aws_iam_policy_attachment = "Consider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead."
+   random_id 				  = "Consider random_uuid as an alternative"
+ }
+}`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformBlacklistedResourcesRule(),
+					Message: "`aws_iam_policy_attachment` resource type is blacklisted\n\nConsider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead.",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 6, Column: 10},
+						End:      hcl.Pos{Line: 6, Column: 37},
+					},
+				},
+				{
+					Rule:    NewTerraformBlacklistedResourcesRule(),
+					Message: "`random_id` resource type is blacklisted\n\nConsider random_uuid as an alternative",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 2, Column: 10},
+						End:      hcl.Pos{Line: 2, Column: 21},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewTerraformBlacklistedResourcesRule()
+
+	for _, tc := range cases {
+		runner := tflint.TestRunnerWithConfig(t, map[string]string{"module.tf": tc.Content}, loadConfigFromBlacklistedResourceTempFile(t, tc.Config))
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}
+
+// TODO: Replace with TestRunner
+func loadConfigFromBlacklistedResourceTempFile(t *testing.T, content string) *tflint.Config {
+	if content == "" {
+		return tflint.EmptyConfig()
+	}
+
+	tmpfile, err := ioutil.TempFile("", "terraform_blacklisted_resources")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	config, err := tflint.LoadConfig(tmpfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return config
+}


### PR DESCRIPTION
This rule adds the ability to prevent a resource of a certain type from being used. Each type specified has a custom message that will be displayed to the user that can be used to provide guidance on an alternative.

Fixes https://github.com/terraform-linters/tflint/issues/700