### PR TITLE
Allow rules to override the declared default severity level

### DIFF
--- a/formatter/pretty.go
+++ b/formatter/pretty.go
@@ -36,7 +36,7 @@ func (f *Formatter) printIssueWithSource(issue *tflint.Issue, sources map[string
 	fmt.Fprintf(
 		f.Stdout,
 		"%s: %s (%s)\n\n",
-		colorSeverity(issue.Rule.Severity()), colorBold(issue.Message), issue.Rule.Name(),
+		colorSeverity(issue.Severity), colorBold(issue.Message), issue.Rule.Name(),
 	)
 	fmt.Fprintf(f.Stdout, "  on %s line %d:\n", issue.Range.Filename, issue.Range.Start.Line)
 

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -56,9 +56,10 @@ type Config struct {
 
 // RuleConfig is a TFLint's rule config
 type RuleConfig struct {
-	Name    string   `hcl:"name,label"`
-	Enabled bool     `hcl:"enabled"`
-	Body    hcl.Body `hcl:",remain"`
+	Name      string   `hcl:"name,label"`
+	Enabled   bool     `hcl:"enabled"`
+	Serverity string   `hcl:"severity,optional"`
+	Body      hcl.Body `hcl:",remain"`
 }
 
 // PluginConfig is a TFLint's plugin config

--- a/tflint/issue.go
+++ b/tflint/issue.go
@@ -8,10 +8,11 @@ import (
 
 // Issue represents a problem in configurations
 type Issue struct {
-	Rule    Rule
-	Message string
-	Range   hcl.Range
-	Callers []hcl.Range
+	Rule     Rule
+	Message  string
+	Severity string
+	Range    hcl.Range
+	Callers  []hcl.Range
 }
 
 // Issues is an alias for the map of Issue

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -325,19 +325,28 @@ func (r *Runner) EachStringSliceExprs(expr hcl.Expression, proc func(val string,
 
 // EmitIssue builds an issue and accumulates it
 func (r *Runner) EmitIssue(rule Rule, message string, location hcl.Range) {
+	ruleConfig, exists := r.config.Rules[rule.Name()]
+
+	severity := rule.Severity()
+	if exists && ruleConfig.Serverity != "" {
+		severity = ruleConfig.Serverity
+	}
+
 	if r.TFConfig.Path.IsRoot() {
 		r.emitIssue(&Issue{
-			Rule:    rule,
-			Message: message,
-			Range:   location,
+			Rule:     rule,
+			Message:  message,
+			Severity: severity,
+			Range:    location,
 		})
 	} else {
 		for _, modVar := range r.listModuleVars(r.currentExpr) {
 			r.emitIssue(&Issue{
-				Rule:    rule,
-				Message: message,
-				Range:   modVar.DeclRange,
-				Callers: append(modVar.callers(), location),
+				Rule:     rule,
+				Message:  message,
+				Severity: severity,
+				Range:    modVar.DeclRange,
+				Callers:  append(modVar.callers(), location),
 			})
 		}
 	}


### PR DESCRIPTION
This adds the ability for rules to override the severity. 

An example usage - this will override the rule's severity to `Error`. By default the severity is declared as "Notice"
```
rule "terraform_naming_convention" {
  enabled  = true
  severity = "Error"
}
```

Fixes https://github.com/terraform-linters/tflint/issues/715