### PR TITLE
add terraform_deprecated_index (disallows foo.0)

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -68,6 +68,7 @@ These rules suggest to better ways.
 |Rule|Enabled by default|
 | --- | --- |
 |[terraform_deprecated_interpolation](terraform_deprecated_interpolation.md)|✔|
+|[terraform_deprecated_index](terraform_deprecated_index.md)||
 |[terraform_unused_declarations](terraform_unused_declarations.md)||
 |[terraform_comment_syntax](terraform_comment_syntax.md)||
 |[terraform_documented_outputs](terraform_documented_outputs.md)||

--- a/docs/rules/terraform_deprecated_index.md
+++ b/docs/rules/terraform_deprecated_index.md
@@ -1,0 +1,32 @@
+# terraform_deprecated_index
+
+Disallow legacy dot index syntax.
+
+## Example
+
+```hcl
+locals {
+  list  = ["a", "b", "c"]
+  value = list.0 
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: List items should be accessed using square brackets (terraform_deprecated_index)
+
+  on example.tf line 3:
+   3:   value = list.0
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.16.1/docs/rules/terraform_deprecated_index.md
+```
+
+## Why
+
+Terraform v0.12 supports traditional square brackets for accessing list items by index. However, for backward compatability with v0.11, Terraform continues to support accessing list items with the dot syntax normally used for attributes. While Terraform does not print warnings for this syntax, it is no longer documented and its use is discouraged.
+
+## How To Fix
+
+Switch to the square bracket syntax when accessing items in list, including resources that use `count`.

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -37,6 +37,7 @@ var manualDefaultRules = []Rule{
 	awsrules.NewAwsSpotFleetRequestInvalidExcessCapacityTerminationPolicyRule(),
 	awsrules.NewAwsResourceMissingTagsRule(),
 	awsrules.NewAwsDynamoDBTableInvalidStreamViewTypeRule(),
+	terraformrules.NewTerraformDeprecatedIndexRule(),
 	terraformrules.NewTerraformDeprecatedInterpolationRule(),
 	terraformrules.NewTerraformDocumentedOutputsRule(),
 	terraformrules.NewTerraformDocumentedVariablesRule(),

--- a/rules/terraformrules/terraform_deprecated_index.go
+++ b/rules/terraformrules/terraform_deprecated_index.go
@@ -1,0 +1,68 @@
+package terraformrules
+
+import (
+	"log"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+// TerraformDeprecatedIndexRule warns about usage of the legacy dot syntax for indexes (foo.0)
+type TerraformDeprecatedIndexRule struct{}
+
+// NewTerraformDeprecatedIndexRule return a new rule
+func NewTerraformDeprecatedIndexRule() *TerraformDeprecatedIndexRule {
+	return &TerraformDeprecatedIndexRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformDeprecatedIndexRule) Name() string {
+	return "terraform_deprecated_index"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformDeprecatedIndexRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *TerraformDeprecatedIndexRule) Severity() string {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *TerraformDeprecatedIndexRule) Link() string {
+	return tflint.ReferenceLink(r.Name())
+}
+
+// Check walks all expressions and emit issues if deprecated index syntax is found
+func (r *TerraformDeprecatedIndexRule) Check(runner *tflint.Runner) error {
+	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+	return runner.WalkExpressions(func(expr hcl.Expression) error {
+		for _, variable := range expr.Variables() {
+			for _, traversal := range variable.SimpleSplit().Rel {
+				if traversal, ok := traversal.(hcl.TraverseIndex); ok {
+					filename := traversal.SrcRange.Filename
+					bytes := traversal.SrcRange.SliceBytes(runner.File(filename).Bytes)
+
+					tokens, diags := hclsyntax.LexExpression(bytes, filename, traversal.SrcRange.Start)
+					if diags.HasErrors() {
+						return diags
+					}
+
+					if tokens[0].Type == hclsyntax.TokenDot {
+						runner.EmitIssue(
+							r,
+							"List items should be accessed using square brackets",
+							expr.Range(),
+						)
+					}
+				}
+			}
+		}
+
+		return nil
+	})
+}

--- a/rules/terraformrules/terraform_deprecated_index.go
+++ b/rules/terraformrules/terraform_deprecated_index.go
@@ -23,7 +23,7 @@ func (r *TerraformDeprecatedIndexRule) Name() string {
 
 // Enabled returns whether the rule is enabled by default
 func (r *TerraformDeprecatedIndexRule) Enabled() bool {
-	return true
+	return false
 }
 
 // Severity returns the rule severity

--- a/rules/terraformrules/terraform_deprecated_index_test.go
+++ b/rules/terraformrules/terraform_deprecated_index_test.go
@@ -1,0 +1,74 @@
+package terraformrules
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_TerraformDeprecatedIndexRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected tflint.Issues
+	}{
+		{
+			Name: "deprecated dot index style",
+			Content: `
+locals {
+  list = ["a"]
+  value = list.0
+}
+`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformDeprecatedIndexRule(),
+					Message: "List items should be accessed using square brackets",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 11,
+						},
+						End: hcl.Pos{
+							Line:   4,
+							Column: 17,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "attribute access",
+			Content: `
+locals {
+  map = {a = "b"}
+  value = map.a
+}
+`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "fractional number",
+			Content: `
+locals {
+  value = 1.5
+}
+`,
+			Expected: tflint.Issues{},
+		},
+	}
+
+	rule := NewTerraformDeprecatedIndexRule()
+
+	for _, tc := range cases {
+		runner := tflint.TestRunner(t, map[string]string{"config.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		tflint.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}


### PR DESCRIPTION
This adds a rule that disallows the legacy dot/attribute syntax for accessing indexes in a list. This syntax was officially recommended in v0.11:

https://www.terraform.io/docs/configuration-0-11/interpolation.html

And because most official providers still use 0.11 syntax in their docs, I still see this used quite a bit:

https://www.terraform.io/docs/providers/kubernetes/r/service_account.html
https://www.terraform.io/docs/providers/aws/r/acm_certificate_validation.html

It is no longer present in the 0.12 documentation and didn't even make the HCL spec:

https://github.com/hashicorp/hcl/issues/305