### PR TITLE
Do not walk resource attributes if the resource is not created

### DIFF
--- a/tflint/runner_walk.go
+++ b/tflint/runner_walk.go
@@ -10,6 +10,15 @@ import (
 // WalkResourceAttributes searches for resources and passes the appropriate attributes to the walker function
 func (r *Runner) WalkResourceAttributes(resource, attributeName string, walker func(*hcl.Attribute) error) error {
 	for _, resource := range r.LookupResourcesByType(resource) {
+		ok, err := r.willEvaluateResource(resource)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			log.Printf("[WARN] Skip walking `%s` because it may not be created", resource.Type+"."+resource.Name)
+			continue
+		}
+
 		body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
 			Attributes: []hcl.AttributeSchema{
 				{
@@ -38,6 +47,15 @@ func (r *Runner) WalkResourceAttributes(resource, attributeName string, walker f
 // WalkResourceBlocks walks all blocks of the passed resource and invokes the passed function
 func (r *Runner) WalkResourceBlocks(resource, blockType string, walker func(*hcl.Block) error) error {
 	for _, resource := range r.LookupResourcesByType(resource) {
+		ok, err := r.willEvaluateResource(resource)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			log.Printf("[WARN] Skip walking `%s` because it may not be created", resource.Type+"."+resource.Name)
+			continue
+		}
+
 		body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
 			Blocks: []hcl.BlockHeaderSchema{
 				{


### PR DESCRIPTION
Fixes #778 

If `count` is zero or `for_each` is empty, Terraform will not evaluate the attributes of that resource. On the other hand, TFLint tries to evaluate the expression of any attribute regardless of the meta-arguments. As a result, TFLint sometimes reports errors that are not reported by Terraform.

To avoid this problem, try to ignore resources that may not be evaluated when walking resource attributes and blocks. You may want to walk all the resources, whether they are evaluated or not, but I think we need to provide each API in that case.