### PR TITLE
Change the plugins dir with TFLINT_PLUGIN_DIR environment variable

### DIFF
--- a/docs/guides/extend.md
+++ b/docs/guides/extend.md
@@ -12,4 +12,6 @@ plugin "NAME" {
 
 That's all. Now you can freely add custom rules to TFLint!
 
+You can also change the plugin directory with the `TFLINT_PLUGIN_DIR` environment variable.
+
 A plugin is provided as a single binary and can be built using [`tflint-plugin-sdk`](https://github.com/terraform-linters/tflint-plugin-sdk).

--- a/plugin/discovery.go
+++ b/plugin/discovery.go
@@ -22,7 +22,13 @@ import (
 //
 // Files under these directories that satisfy the "tflint-ruleset-*" naming rules
 // enabled in the configuration are treated as plugins.
+//
+// If the `TFLINT_PLUGIN_DIR` environment variable is set, ignore the above and refer to that directory.
 func Discovery(config *tflint.Config) (*Plugin, error) {
+	if dir := os.Getenv("TFLINT_PLUGIN_DIR"); dir != "" {
+		return findPlugins(config, dir)
+	}
+
 	if _, err := os.Stat(localPluginRoot); !os.IsNotExist(err) {
 		return findPlugins(config, localPluginRoot)
 	}

--- a/plugin/discovery_test.go
+++ b/plugin/discovery_test.go
@@ -73,6 +73,34 @@ func Test_Discovery_local(t *testing.T) {
 	}
 }
 
+func Test_Discovery_envVar(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	os.Setenv("TFLINT_PLUGIN_DIR", filepath.Join(cwd, "test-fixtures", "locals", ".tflint.d", "plugins"))
+	defer os.Setenv("TFLINT_PLUGIN_DIR", "")
+
+	plugin, err := Discovery(&tflint.Config{
+		Plugins: map[string]*tflint.PluginConfig{
+			"foo": {
+				Name:    "foo",
+				Enabled: true,
+			},
+		},
+	})
+	defer plugin.Clean()
+
+	if err != nil {
+		t.Fatalf("Unexpected error occurred %s", err)
+	}
+
+	if len(plugin.RuleSets) != 1 {
+		t.Fatalf("Only one plugin must be enabled, but %d plugins are enabled", len(plugin.RuleSets))
+	}
+}
+
 func Test_Discovery_notFound(t *testing.T) {
 	cwd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
Fixes #781 

This PR adds the ability to change the plugin directory with the `TFLINT_PLUGIN_DIR` environment variable. This is useful when running TFLint in CI pipelines, Docker, etc.