### PR TITLE
Replacing loadConfigFromFile return func by cfg variable.

### DIFF
--- a/tflint/config.go
+++ b/tflint/config.go
@@ -274,7 +274,7 @@ func loadConfigFromFile(file string) (*Config, error) {
 	log.Printf("[DEBUG]   Rules: %#v", cfg.Rules)
 	log.Printf("[DEBUG]   Plugins: %#v", cfg.Plugins)
 
-	return raw.toConfig(), nil
+	return cfg, nil
 }
 
 func mergeBoolMap(a, b map[string]bool) map[string]bool {


### PR DESCRIPTION
I saw `raw.toConfig()` is been call on [L266](https://github.com/cedarkuo/tflint/blob/master/tflint/config.go#L266) & [L277](https://github.com/cedarkuo/tflint/blob/master/tflint/config.go#L277), but there are no value change behavior in between.

So I think maybe the return value can change to `cfg`?

If there any concern plz let me know, I will really appreciate of that. Thanks.