### PR TITLE
rename +build ignore constraint to "generators"

### DIFF
--- a/rules/awsrules/tags/generator/main.go
+++ b/rules/awsrules/tags/generator/main.go
@@ -1,4 +1,4 @@
-// +build ignore
+// +build generators
 
 package main
 


### PR DESCRIPTION
Should resolve an issue where `go mod tidy` removes the provider dependency:

https://github.com/terraform-linters/tflint/pull/803#discussion_r443204793