### PR TITLE
Add support `--recursive` option

### DIFF
--- a/cmd/option.go
+++ b/cmd/option.go
@@ -29,6 +29,7 @@ type Options struct {
 	AwsRegion     string   `long:"aws-region" description:"AWS region used in deep check mode" value-name:"REGION"`
 	Force         bool     `long:"force" description:"Return zero exit status even if issues found"`
 	NoColor       bool     `long:"no-color" description:"Disable colorized output"`
+	Recursive     bool     `long:"recursive" description:"Inspect directories recursively"`
 }
 
 func (opts *Options) toConfig() *tflint.Config {
@@ -53,6 +54,7 @@ func (opts *Options) toConfig() *tflint.Config {
 	log.Printf("[DEBUG]   Module: %t", opts.Module)
 	log.Printf("[DEBUG]   DeepCheck: %t", opts.Deep)
 	log.Printf("[DEBUG]   Force: %t", opts.Force)
+	log.Printf("[DEBUG]   Recursive: %t", opts.Recursive)
 	log.Printf("[DEBUG]   IgnoreModules: %#v", ignoreModules)
 	log.Printf("[DEBUG]   EnableRules: %#v", opts.EnableRules)
 	log.Printf("[DEBUG]   DisableRules: %#v", opts.DisableRules)
@@ -79,6 +81,7 @@ func (opts *Options) toConfig() *tflint.Config {
 		Module:    opts.Module,
 		DeepCheck: opts.Deep,
 		Force:     opts.Force,
+		Recursive: opts.Recursive,
 		AwsCredentials: client.AwsCredentials{
 			AccessKey: opts.AwsAccessKey,
 			SecretKey: opts.AwsSecretKey,

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -29,6 +29,7 @@ type rawConfig struct {
 		Module         *bool              `hcl:"module"`
 		DeepCheck      *bool              `hcl:"deep_check"`
 		Force          *bool              `hcl:"force"`
+		Recursive      *bool              `hcl:"recursive"`
 		AwsCredentials *map[string]string `hcl:"aws_credentials"`
 		IgnoreModule   *map[string]bool   `hcl:"ignore_module"`
 		Varfile        *[]string          `hcl:"varfile"`
@@ -46,6 +47,7 @@ type Config struct {
 	Module         bool
 	DeepCheck      bool
 	Force          bool
+	Recursive      bool
 	AwsCredentials client.AwsCredentials
 	IgnoreModules  map[string]bool
 	Varfiles       []string
@@ -74,6 +76,7 @@ func EmptyConfig() *Config {
 		Module:         false,
 		DeepCheck:      false,
 		Force:          false,
+		Recursive:      false,
 		AwsCredentials: client.AwsCredentials{},
 		IgnoreModules:  map[string]bool{},
 		Varfiles:       []string{},
@@ -135,6 +138,9 @@ func (c *Config) Merge(other *Config) *Config {
 	}
 	if other.Force {
 		ret.Force = true
+	}
+	if other.Recursive {
+		ret.Recursive = true
 	}
 
 	ret.AwsCredentials = ret.AwsCredentials.Merge(other.AwsCredentials)
@@ -230,6 +236,7 @@ func (c *Config) copy() *Config {
 		Module:         c.Module,
 		DeepCheck:      c.DeepCheck,
 		Force:          c.Force,
+		Recursive:      c.Recursive,
 		AwsCredentials: c.AwsCredentials,
 		IgnoreModules:  ignoreModules,
 		Varfiles:       varfiles,
@@ -268,6 +275,7 @@ func loadConfigFromFile(file string) (*Config, error) {
 	log.Printf("[DEBUG]   Module: %t", cfg.Module)
 	log.Printf("[DEBUG]   DeepCheck: %t", cfg.DeepCheck)
 	log.Printf("[DEBUG]   Force: %t", cfg.Force)
+	log.Printf("[DEBUG]   Recursive: %t", cfg.Recursive)
 	log.Printf("[DEBUG]   IgnoreModules: %#v", cfg.IgnoreModules)
 	log.Printf("[DEBUG]   Varfiles: %#v", cfg.Varfiles)
 	log.Printf("[DEBUG]   Variables: %#v", cfg.Variables)
@@ -331,6 +339,9 @@ func (raw *rawConfig) toConfig() *Config {
 		}
 		if rc.Force != nil {
 			ret.Force = *rc.Force
+		}
+		if rc.Recursive != nil {
+			ret.Recursive = *rc.Recursive
 		}
 		if rc.AwsCredentials != nil {
 			credentials := *rc.AwsCredentials

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -140,7 +140,7 @@ func NewModuleRunners(parent *Runner) ([]*Runner, error) {
 		modVars := map[string]*moduleVariable{}
 		for varName, rawVar := range cfg.Module.Variables {
 			if attribute, exists := attributes[varName]; exists {
-				evalauble, err := isEvaluableExpr(attribute.Expr)
+				evalauble, err := parent.isEvaluableExpr(attribute.Expr)
 				if err != nil {
 					return runners, err
 				}
@@ -277,7 +277,7 @@ func (r *Runner) EnsureNoError(err error, proc func() error) error {
 
 // IsNullExpr check the passed expression is null
 func (r *Runner) IsNullExpr(expr hcl.Expression) (bool, error) {
-	evaluable, err := isEvaluableExpr(expr)
+	evaluable, err := r.isEvaluableExpr(expr)
 	if err != nil {
 		return false, err
 	}

--- a/tflint/runner_eval_test.go
+++ b/tflint/runner_eval_test.go
@@ -919,7 +919,7 @@ resource "null_resource" "test" {
 		runner := TestRunner(t, map[string]string{"main.tf": tc.Content})
 
 		err := runner.WalkResourceAttributes("null_resource", "key", func(attribute *hcl.Attribute) error {
-			ret, err := isEvaluableExpr(attribute.Expr)
+			ret, err := runner.isEvaluableExpr(attribute.Expr)
 			if err != nil && tc.Error == "" {
 				t.Fatalf("Failed `%s` test: unexpected error occurred: %s", tc.Name, err)
 			}


### PR DESCRIPTION
Fixes #527 

This is a PoC of recursive directory scanning. I've heard that for large projects there are cases where you want to run tflint in a different context than terraform apply. In such cases, it doesn't make us happy to maintain a shell script that walks directories and runs tflint in each directory.

Run with the `--recursive` option to walk each directory and run the analysis:

```
$ tflint --recursive
```

However, recursive mode has some limitations:

- Module inspection is not allowed
- Named values like `terraform.*` and `path.*` are ignored

These are necessary to run in a different context than Terraform. However, I'm not sure if it can solve the problems of users with complex project structures when there are these limitations. I welcome feedback on this matter.
