### PR TITLE
add support for --format junit

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Usage:
 Application Options:
   -v, --version                                   Print TFLint version
       --langserver                                Start language server
-  -f, --format=[default|json|checkstyle]          Output format (default: default)
+  -f, --format=[default|json|checkstyle|junit]    Output format (default: default)
   -c, --config=FILE                               Config file name (default: .tflint.hcl)
       --ignore-module=SOURCE                      Ignore module sources
       --enable-rule=RULE_NAME                     Enable rules from the command line

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -13,7 +13,7 @@ import (
 type Options struct {
 	Version       bool     `short:"v" long:"version" description:"Print TFLint version"`
 	Langserver    bool     `long:"langserver" description:"Start language server"`
-	Format        string   `short:"f" long:"format" description:"Output format" choice:"default" choice:"json" choice:"checkstyle" default:"default"`
+	Format        string   `short:"f" long:"format" description:"Output format" choice:"default" choice:"json" choice:"checkstyle" choice:"junit" default:"default"`
 	Config        string   `short:"c" long:"config" description:"Config file name" value-name:"FILE" default:".tflint.hcl"`
 	IgnoreModules []string `long:"ignore-module" description:"Ignore module sources" value-name:"SOURCE"`
 	EnableRules   []string `long:"enable-rule" description:"Enable rules from the command line" value-name:"RULE_NAME"`

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -24,6 +24,8 @@ func (f *Formatter) Print(issues tflint.Issues, err *tflint.Error, sources map[s
 		f.jsonPrint(issues, err)
 	case "checkstyle":
 		f.checkstylePrint(issues, err, sources)
+	case "junit":
+		f.junitPrint(issues, err, sources)
 	default:
 		f.prettyPrint(issues, err, sources)
 	}

--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -1,0 +1,55 @@
+package formatter
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	"github.com/terraform-linters/tflint/tflint"
+
+	"github.com/jstemmer/go-junit-report/formatter"
+)
+
+func (f *Formatter) junitPrint(issues tflint.Issues, tferr *tflint.Error, sources map[string][]byte) {
+	cases := make([]formatter.JUnitTestCase, len(issues))
+
+	for _, issue := range issues.Sort() {
+		cases = append(cases, formatter.JUnitTestCase{
+			Name: issue.Rule.Name(),
+			Classname: issue.Range.Filename,
+			Time: "0",
+			Failure: &formatter.JUnitFailure{
+				Message: issue.Message,
+				Contents: fmt.Sprintf(
+					"line %d, col %d, %s - %s (%s)",
+					issue.Range.Start.Line,
+					issue.Range.Start.Column,
+					issue.Rule.Severity(),
+					issue.Message,
+					issue.Rule.Name(),
+				),
+			},
+		})
+	}
+
+	suites := formatter.JUnitTestSuites{
+		Suites: []formatter.JUnitTestSuite{
+			formatter.JUnitTestSuite{
+				Time: "0",
+				Tests: len(issues),
+				Failures: len(issues),
+				TestCases: cases,
+			},
+		},
+	}
+
+	out, err := xml.MarshalIndent(suites, "", "  ")
+	if err != nil {
+		fmt.Fprint(f.Stderr, err)
+	}
+	fmt.Fprint(f.Stdout, xml.Header)
+	fmt.Fprint(f.Stdout, string(out))
+
+	if tferr != nil {
+		f.printErrors(tferr, sources)
+	}
+}

--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -12,11 +12,11 @@ import (
 func (f *Formatter) junitPrint(issues tflint.Issues, tferr *tflint.Error, sources map[string][]byte) {
 	cases := make([]formatter.JUnitTestCase, len(issues))
 
-	for _, issue := range issues.Sort() {
-		cases = append(cases, formatter.JUnitTestCase{
-			Name: issue.Rule.Name(),
+	for i, issue := range issues.Sort() {
+		cases[i] = formatter.JUnitTestCase{
+			Name:      issue.Rule.Name(),
 			Classname: issue.Range.Filename,
-			Time: "0",
+			Time:      "0",
 			Failure: &formatter.JUnitFailure{
 				Message: issue.Message,
 				Contents: fmt.Sprintf(
@@ -28,15 +28,15 @@ func (f *Formatter) junitPrint(issues tflint.Issues, tferr *tflint.Error, source
 					issue.Rule.Name(),
 				),
 			},
-		})
+		}
 	}
 
 	suites := formatter.JUnitTestSuites{
 		Suites: []formatter.JUnitTestSuite{
-			formatter.JUnitTestSuite{
-				Time: "0",
-				Tests: len(issues),
-				Failures: len(issues),
+			{
+				Time:      "0",
+				Tests:     len(issues),
+				Failures:  len(issues),
 				TestCases: cases,
 			},
 		},

--- a/formatter/junit_test.go
+++ b/formatter/junit_test.go
@@ -1,0 +1,65 @@
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_junitPrint(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Issues tflint.Issues
+		Error  *tflint.Error
+		Stdout string
+	}{
+		{
+			Name:   "no issues",
+			Issues: tflint.Issues{},
+			Stdout: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite tests="0" failures="0" time="0" name="">
+    <properties></properties>
+  </testsuite>
+</testsuites>`,
+		},
+		{
+			Name: "issues",
+			Issues: tflint.Issues{
+				{
+					Rule:    &testRule{},
+					Message: "test",
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+			},
+			Stdout: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite tests="1" failures="1" time="0" name="">
+    <properties></properties>
+    <testcase classname="test.tf" name="test_rule" time="0">
+      <failure message="test" type="">line 1, col 1, Error - test (test_rule)</failure>
+    </testcase>
+  </testsuite>
+</testsuites>`,
+		},
+	}
+
+	for _, tc := range cases {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		formatter := &Formatter{Stdout: stdout, Stderr: stderr}
+
+		formatter.junitPrint(tc.Issues, tc.Error, map[string][]byte{})
+
+		if stdout.String() != tc.Stdout {
+			t.Fatalf("%s: stdout did not match expected:\n%s", tc.Name, cmp.Diff(tc.Stdout, stdout.String()))
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/terraform v0.12.28
 	github.com/hashicorp/terraform-plugin-sdk v1.14.0
 	github.com/jessevdk/go-flags v1.4.0
+	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/mattn/go-colorable v0.1.7
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516


### PR DESCRIPTION
This PR adds support for JUnit output formatting, as supported by CircleCI, Jenkins, and others:

https://circleci.com/docs/2.0/collect-test-data/

I used ESLint's example output as a reference:

https://eslint.org/docs/user-guide/formatters/#junit

The JUnit structs come from github.com/jstemmer/go-junit-report, which handles all the XML details via struct tags.

Closes #786 