### PR TITLE
Bump tflint-plugin-sdk to v0.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/spf13/afero v1.3.1
-	github.com/terraform-linters/tflint-plugin-sdk v0.2.1-0.20200709181856-c6c860906f72
+	github.com/terraform-linters/tflint-plugin-sdk v0.3.0
 	github.com/terraform-providers/terraform-provider-aws v2.68.0+incompatible
 	github.com/zclconf/go-cty v1.5.1
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f

--- a/go.sum
+++ b/go.sum
@@ -593,8 +593,8 @@ github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BST
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
-github.com/terraform-linters/tflint-plugin-sdk v0.2.1-0.20200709181856-c6c860906f72 h1:lWAhRqRY7ObHh/ai3Wsu81nr5oYnBUnswBjTvVK8rOY=
-github.com/terraform-linters/tflint-plugin-sdk v0.2.1-0.20200709181856-c6c860906f72/go.mod h1:QoSqSV/8GSOrQy3OStK3EEdsA3yZm13My4BQcnx3Zic=
+github.com/terraform-linters/tflint-plugin-sdk v0.3.0 h1:TUMBlM17mZKMzaZtp1KLj6T6BHLTunVQ/8f2cWOaMjY=
+github.com/terraform-linters/tflint-plugin-sdk v0.3.0/go.mod h1:QoSqSV/8GSOrQy3OStK3EEdsA3yZm13My4BQcnx3Zic=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20200625234409-8688f3adfb43 h1:tt30KJTNH0vBqyvbVhW+QHa2I1ciwh1XmyIl/m5fjJ4=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20200625234409-8688f3adfb43/go.mod h1:0U3OgA2uDYSc7gNkdWA92+/BxWXwuYhWqqZ4UhM1RCw=
 github.com/terraform-providers/terraform-provider-openstack v1.15.0/go.mod h1:2aQ6n/BtChAl1y2S60vebhyJyZXBsuAI5G4+lHrT1Ew=

--- a/plugin/encode.go
+++ b/plugin/encode.go
@@ -110,10 +110,16 @@ func (s *Server) encodeProvisioner(provisioner *configs.Provisioner) *tfplugin.P
 
 func (s *Server) encodeBackend(backend *configs.Backend) *tfplugin.Backend {
 	configRange := tflint.HCLBodyRange(backend.Config, backend.DeclRange)
+	config := []byte{}
+	if configRange.Empty() {
+		configRange.Filename = backend.DeclRange.Filename
+	} else {
+		config = configRange.SliceBytes(s.runner.File(configRange.Filename).Bytes)
+	}
 
 	return &tfplugin.Backend{
 		Type:        backend.Type,
-		Config:      configRange.SliceBytes(s.runner.File(configRange.Filename).Bytes),
+		Config:      config,
 		ConfigRange: configRange,
 		DeclRange:   backend.DeclRange,
 		TypeRange:   backend.TypeRange,


### PR DESCRIPTION
This brings the following changes:

- Added `Backend` to access the backend configuration
- Updated protocol version. This means all plugins will need to be rebuilt with the new SDK

For details, see the CHANGELOG of tflint-plugin-sdk.