### PR TITLE
Expose `Server.ModuleCalls` for SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/spf13/afero v1.3.1
-	github.com/terraform-linters/tflint-plugin-sdk v0.3.0
+	github.com/terraform-linters/tflint-plugin-sdk v0.3.1-0.20200723121039-5ac6ff48b81e
 	github.com/terraform-providers/terraform-provider-aws v2.70.0+incompatible
 	github.com/zclconf/go-cty v1.5.1
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f

--- a/go.sum
+++ b/go.sum
@@ -297,6 +297,7 @@ github.com/hashicorp/go-tfe v0.8.1/go.mod h1:XAV72S4O1iP8BDaqiaPLmL2B4EE6almocnO
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
@@ -594,8 +595,8 @@ github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BST
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
-github.com/terraform-linters/tflint-plugin-sdk v0.3.0 h1:TUMBlM17mZKMzaZtp1KLj6T6BHLTunVQ/8f2cWOaMjY=
-github.com/terraform-linters/tflint-plugin-sdk v0.3.0/go.mod h1:QoSqSV/8GSOrQy3OStK3EEdsA3yZm13My4BQcnx3Zic=
+github.com/terraform-linters/tflint-plugin-sdk v0.3.1-0.20200723121039-5ac6ff48b81e h1:Gy5cL13r/anqhQN1YtUsvv5yUhShLPRkNV3TYert7Qo=
+github.com/terraform-linters/tflint-plugin-sdk v0.3.1-0.20200723121039-5ac6ff48b81e/go.mod h1:fS73Ot098SYLuHWF+uDHAEXG9iHsHbcVwgQ1Eu9zy6c=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20200710175044-2f23a59662cc h1:RNa/U0gK3SnatBwk9t/bCqK03u7fSvBMZMOnovUoCd0=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20200710175044-2f23a59662cc/go.mod h1:tJCY7WQBTQPyFIf0JOkHSwTMS46J/JTa8dxhwtMcwdY=
 github.com/terraform-providers/terraform-provider-openstack v1.15.0/go.mod h1:2aQ6n/BtChAl1y2S60vebhyJyZXBsuAI5G4+lHrT1Ew=

--- a/plugin/server.go
+++ b/plugin/server.go
@@ -68,6 +68,17 @@ func (s *Server) Resources(req *tfplugin.ResourcesRequest, resp *tfplugin.Resour
 	return nil
 }
 
+// ModuleCalls returns all configs.ModuleCall as tfplugin.ModuleCall
+func (s *Server) ModuleCalls(req *tfplugin.ModuleCallsRequest, resp *tfplugin.ModuleCallsResponse) error {
+	ret := []*tfplugin.ModuleCall{}
+	err := s.runner.WalkModuleCalls(func(call *configs.ModuleCall) error {
+		ret = append(ret, s.encodeModuleCall(call))
+		return nil
+	})
+	*resp = tfplugin.ModuleCallsResponse{ModuleCalls: ret, Err: err}
+	return nil
+}
+
 // Backend returns corresponding configs.Backend as tfplugin.Backend
 func (s *Server) Backend(req *tfplugin.BackendRequest, resp *tfplugin.BackendResponse) error {
 	backend := s.runner.Backend()

--- a/tflint/runner_walk.go
+++ b/tflint/runner_walk.go
@@ -1,8 +1,9 @@
 package tflint
 
 import (
-	"github.com/hashicorp/terraform/configs"
 	"log"
+
+	"github.com/hashicorp/terraform/configs"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -123,6 +124,17 @@ func (r *Runner) WalkResources(resource string, walker func(*configs.Resource) e
 	for _, resource := range r.LookupResourcesByType(resource) {
 		err := walker(resource)
 		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WalkModuleCalls walks all module calls and invokes the passed function
+func (r *Runner) WalkModuleCalls(walker func(*configs.ModuleCall) error) error {
+	for _, call := range r.TFConfig.Module.ModuleCalls {
+		if err := walker(call); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
See the corresponding PR to the SDK this depends on:

https://github.com/terraform-linters/tflint-plugin-sdk/pull/50

Version constraints may be a bit different over the wire: the type exposed
by go-version can't necessarily be exactly reconstructed, as they've
been normalized under the hood. The original value is still accessible
through the usual hcl.Body.PartialContent or similar functions, if
needed.

In Terraform 0.12, I think the Count and ForEach struct members
will never actually be set, but the corresponding Terraform types have
them, so I've included them here. Maybe they'll Just Work once 0.13 is
out of beta and support is added to tflint.