### PR TITLE
deprecated_interpolations: evaluate all block types/expressions

### DIFF
--- a/integration/without_module_init/module.tf
+++ b/integration/without_module_init/module.tf
@@ -8,6 +8,6 @@ variable "instance_type" {
 module "instances" {
   source = "./module"
 
-  unknown = "${var.unknown}"
-  instance_type = "${var.instance_type}"
+  unknown = var.unknown
+  instance_type = var.instance_type
 }

--- a/rules/terraformrules/terraform_deprecated_interpolation_test.go
+++ b/rules/terraformrules/terraform_deprecated_interpolation_test.go
@@ -50,6 +50,24 @@ provider "null" {
 			},
 		},
 		{
+			Name: "deprecated single interpolation in locals block",
+			Content: `
+locals {
+	foo = "${var.triggers["foo"]}"
+}`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformDeprecatedInterpolationRule(),
+					Message: "Interpolation-only expressions are deprecated in Terraform v0.12.14",
+					Range: hcl.Range{
+						Filename: "config.tf",
+						Start:    hcl.Pos{Line: 3, Column: 8},
+						End:      hcl.Pos{Line: 3, Column: 32},
+					},
+				},
+			},
+		},
+		{
 			Name: "deprecated single interpolation in nested block",
 			Content: `
 resource "null_resource" "a" {


### PR DESCRIPTION
This updates the `terraform_deprecated_interpolation` rule to use the `runner.WalkExpressions` method so that all expressions are evaluated rather than just resources and providers. This ensures that deprecated interpolations are also caught in locals, module calls, data sources, and outputs.