### PR TITLE
terraform_required_providers: warn on provider.version

### DIFF
--- a/docs/rules/terraform_required_providers.md
+++ b/docs/rules/terraform_required_providers.md
@@ -10,7 +10,7 @@ rule "terraform_required_providers" {
 }
 ```
 
-## Example
+## Examples
 
 ```hcl
 provider "template" {}
@@ -25,13 +25,31 @@ Warning: Provider "template" should have a version constraint in required_provid
 Reference: https://github.com/terraform-linters/tflint/blob/v0.11.0/docs/rules/terraform_required_providers.md 
 ```
 
+<hr>
+
+```hcl
+provider "template" {
+  version = "2"
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: provider.template: version constraint should be specified in "required_providers"
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.11.0/docs/rules/terraform_required_providers.md 
+```
+
+
 ## Why
 
 Providers are plugins released on a separate rhythm from Terraform itself, and so they have their own version numbers. For production use, you should constrain the acceptable provider versions via configuration, to ensure that new versions with breaking changes will not be automatically installed by `terraform init` in future.
 
 ## How To Fix
 
-Add the `required_providers` attribute to the `terraform` configuration block and include current versions for all providers. For example:
+Add the [`required_providers`](https://www.terraform.io/docs/configuration/terraform.html#specifying-required-provider-versions) block to the `terraform` configuration block and include current versions for all providers. For example:
 
 ```tf
 terraform {
@@ -41,4 +59,4 @@ terraform {
 }
 ```
 
-Provider version constraints can also be specified using a version argument within a provider block but this is not recommend, particularly for child modules.
+Provider version constraints can be specified using a [version argument within a provider block](https://www.terraform.io/docs/configuration/providers.html#provider-versions) for backwards compatability. This approach is now discouraged, particularly for child modules.

--- a/docs/rules/terraform_required_providers.md
+++ b/docs/rules/terraform_required_providers.md
@@ -20,9 +20,12 @@ provider "template" {}
 $ tflint
 1 issue(s) found:
 
-Warning: Provider "template" should have a version constraint in required_providers
+Warning: Missing version constraint for provider "template" in "required_providers" (terraform_required_providers)
 
-Reference: https://github.com/terraform-linters/tflint/blob/v0.11.0/docs/rules/terraform_required_providers.md 
+  on main.tf line 1:
+   1: provider "template" {}
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.18.0/docs/rules/terraform_required_providers.md
 ```
 
 <hr>
@@ -35,13 +38,22 @@ provider "template" {
 
 ```
 $ tflint
-1 issue(s) found:
+2 issue(s) found:
 
-Warning: provider.template: version constraint should be specified in "required_providers"
+Warning: provider.template: version constraint should be specified via "required_providers" (terraform_required_providers)
 
-Reference: https://github.com/terraform-linters/tflint/blob/v0.11.0/docs/rules/terraform_required_providers.md 
+  on main.tf line 1:
+   1: provider "template" {
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.18.0/docs/rules/terraform_required_providers.md
+
+Warning: Missing version constraint for provider "template" in "required_providers" (terraform_required_providers)
+
+  on main.tf line 1:
+   1: provider "template" {
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.18.0/docs/rules/terraform_required_providers.md
 ```
-
 
 ## Why
 

--- a/rules/terraformrules/terraform_required_providers_test.go
+++ b/rules/terraformrules/terraform_required_providers_test.go
@@ -21,7 +21,7 @@ provider "template" {}
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformRequiredProvidersRule(),
-					Message: `Provider "template" should have a version constraint in required_providers`,
+					Message: `Missing version constraint for provider "template" in "required_providers"`,
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{
@@ -50,12 +50,8 @@ provider "template" {}
 			Expected: tflint.Issues{},
 		},
 		{
-			Name: "provider alias",
+			Name: "single provider with alias",
 			Content: `
-provider "template" {
-	version = "~> 2"
-}
-
 provider "template" {
 	alias = "b"
 }
@@ -63,15 +59,46 @@ provider "template" {
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformRequiredProvidersRule(),
-					Message: `Provider "template" should have a version constraint in required_providers (template.b)`,
+					Message: `Missing version constraint for provider "template" in "required_providers"`,
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{
-							Line:   6,
+							Line:   2,
 							Column: 1,
 						},
 						End: hcl.Pos{
-							Line:   6,
+							Line:   2,
+							Column: 20,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "version set with alias",
+			Content: `
+terraform {
+  required_providers {
+    template = "~> 2"
+  }
+}
+
+provider "template" {
+	version = "~> 2"
+} 
+`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: `provider.template: version constraint should be specified via "required_providers"`,
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   8,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Line:   8,
 							Column: 20,
 						},
 					},
@@ -81,23 +108,50 @@ provider "template" {
 		{
 			Name: "version set",
 			Content: `
+terraform {
+  required_providers {
+    template = "~> 2"
+  }
+}
+
 provider "template" {
+	alias   = "foo"
 	version = "~> 2"
 } 
 `,
-			Expected: tflint.Issues{},
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: `provider.template.foo: version constraint should be specified via "required_providers"`,
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   8,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Line:   8,
+							Column: 20,
+						},
+					},
+				},
+			},
 		},
 	}
 
 	rule := NewTerraformRequiredProvidersRule()
 
 	for _, tc := range cases {
-		runner := tflint.TestRunner(t, map[string]string{"module.tf": tc.Content})
+		tc := tc
 
-		if err := rule.Check(runner); err != nil {
-			t.Fatalf("Unexpected error occurred: %s", err)
-		}
+		t.Run(tc.Name, func(t *testing.T) {
+			runner := tflint.TestRunner(t, map[string]string{"module.tf": tc.Content})
 
-		tflint.AssertIssues(t, tc.Expected, runner.Issues)
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			tflint.AssertIssues(t, tc.Expected, runner.Issues)
+		})
 	}
 }


### PR DESCRIPTION
This PR updates the required providers rule to warn when a `provider` block specifies a `version` attribute. While this does have the effect of constraining the installed provider version, users should be moving to `required_providers` because declaring a new copy of the provider is likely to have unexpected effects for child modules.

New logic is:

* One issue is emitted for each provider _name_ that is missing from required_providers. If multiple providers for a given name are declared, the first text range will be used.
* One issue is emitted for each provider _instance_ that has a `version`, regardless of whether it also appears in `required_providers`.

This means that users moving from earlier versions with of Terraform with  `provider "foo" { version = "" }` in their configurations will see two issues that share an underlying fix. While it's possible to give more targeted messaging, there's a lot of possible cases here and keeping the rule simple seemed worthwhile.

Closes #839 