### PR TITLE
standard_module_structure: fix false positives when passing a directory

### DIFF
--- a/rules/terraformrules/terraform_standard_module_structure.go
+++ b/rules/terraformrules/terraform_standard_module_structure.go
@@ -144,5 +144,5 @@ func (r *TerraformStandardModuleStructureRule) shouldMove(path string, expected 
 		return false
 	}
 
-	return path != expected
+	return filepath.Base(path) != expected
 }

--- a/rules/terraformrules/terraform_standard_module_structure_test.go
+++ b/rules/terraformrules/terraform_standard_module_structure_test.go
@@ -47,8 +47,10 @@ func Test_TerraformStandardModuleStructureRule(t *testing.T) {
 		{
 			Name: "directory in path",
 			Content: map[string]string{
-				"foo/main.tf":      "",
-				"foo/variables.tf": "",
+				"foo/main.tf": "",
+				"foo/variables.tf": `
+variable "v" {}				
+				`,
 			},
 			Expected: tflint.Issues{
 				{


### PR DESCRIPTION
As reported in #834, the `terraform_standard_module_structure` was reporting false warnings when TFLint was invoked with a non-cwd directory:

```
$ /usr/local/bin/tflint -c /tmp/.tflint.hcl /tmp/ok
2 issue(s) found:

Warning: output "test" should be moved from /tmp/ok/outputs.tf to outputs.tf (terraform_standard_module_structure)

  on /tmp/ok/outputs.tf line 1:
   2: output "test" {

Reference: https://github.com/terraform-linters/tflint/blob/v0.17.0/docs/rules/terraform_standard_module_structure.md

Warning: variable "test" should be moved from /tmp/ok/variables.tf to variables.tf (terraform_standard_module_structure)

  on /tmp/ok/variables.tf line 1:
   1: variable "test" {

Reference: https://github.com/terraform-linters/tflint/blob/v0.17.0/docs/rules/terraform_standard_module_structure.md
```

Directories were properly handled when checking that the required files were present:

https://github.com/terraform-linters/tflint/blob/e87fc479efb6e552d2a9f217a3b5685cd9b3e194/rules/terraformrules/terraform_standard_module_structure.go#L62-L65

The logic that checked parsed variables/outputs for their filenames was missing that same logic.

Before including the fix, the modified test validates the bug, failing because of an unexpected issue:

```
--- FAIL: Test_TerraformStandardModuleStructureRule (0.00s)
    --- FAIL: Test_TerraformStandardModuleStructureRule/directory_in_path (0.00s)
        testing.go:83: Expected issues are not matched:
               tflint.Issues{
              	&{Rule: &terraformrules.TerraformStandardModuleStructureRule{}, Message: "Module should include an empty outputs.tf file", Range: {Filename: "foo/outputs.tf", Start: {Line: 1, Column: 1}}},
            + 	&{
            + 		Rule:    &terraformrules.TerraformStandardModuleStructureRule{},
            + 		Message: `variable "v" should be moved from foo/variables.tf to variables.tf`,
            + 		Range:   s"foo/variables.tf:2,1-13",
            + 	},
              }
            
FAIL
FAIL	github.com/terraform-linters/tflint/rules/terraformrules	0.391s
FAIL
```

Closes #834 