### PR TITLE
terraform_rules: Add workaround for skipping child modules inspection

### DIFF
--- a/rules/terraformrules/terraform_comment_syntax.go
+++ b/rules/terraformrules/terraform_comment_syntax.go
@@ -40,6 +40,11 @@ func (r *TerraformCommentSyntaxRule) Link() string {
 
 // Check checks whether variables have type
 func (r *TerraformCommentSyntaxRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	for name, file := range runner.Files() {

--- a/rules/terraformrules/terraform_deprecated_index.go
+++ b/rules/terraformrules/terraform_deprecated_index.go
@@ -38,6 +38,11 @@ func (r *TerraformDeprecatedIndexRule) Link() string {
 
 // Check walks all expressions and emit issues if deprecated index syntax is found
 func (r *TerraformDeprecatedIndexRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	return runner.WalkExpressions(func(expr hcl.Expression) error {

--- a/rules/terraformrules/terraform_deprecated_interpolation.go
+++ b/rules/terraformrules/terraform_deprecated_interpolation.go
@@ -40,6 +40,11 @@ func (r *TerraformDeprecatedInterpolationRule) Link() string {
 // This logic is equivalent to the warning logic implemented in Terraform.
 // See https://github.com/hashicorp/terraform/pull/23348
 func (r *TerraformDeprecatedInterpolationRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	return runner.WalkExpressions(func(expr hcl.Expression) error {

--- a/rules/terraformrules/terraform_documented_outputs.go
+++ b/rules/terraformrules/terraform_documented_outputs.go
@@ -37,6 +37,11 @@ func (r *TerraformDocumentedOutputsRule) Link() string {
 
 // Check checks whether outputs have descriptions
 func (r *TerraformDocumentedOutputsRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	for _, output := range runner.TFConfig.Module.Outputs {

--- a/rules/terraformrules/terraform_documented_variables.go
+++ b/rules/terraformrules/terraform_documented_variables.go
@@ -37,6 +37,11 @@ func (r *TerraformDocumentedVariablesRule) Link() string {
 
 // Check checks whether variables have descriptions
 func (r *TerraformDocumentedVariablesRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	for _, variable := range runner.TFConfig.Module.Variables {

--- a/rules/terraformrules/terraform_module_pinned_source.go
+++ b/rules/terraformrules/terraform_module_pinned_source.go
@@ -64,6 +64,11 @@ var reSemverRevision = regexp.MustCompile("\\?rev=v?\\d+\\.\\d+\\.\\d+$")
 // Check checks if module source version is pinned
 // Note that this rule is valid only for Git or Mercurial source
 func (r *TerraformModulePinnedSourceRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	config := terraformModulePinnedSourceRuleConfig{Style: "flexible"}

--- a/rules/terraformrules/terraform_naming_convention.go
+++ b/rules/terraformrules/terraform_naming_convention.go
@@ -73,6 +73,11 @@ func (r *TerraformNamingConventionRule) Link() string {
 
 // Check checks whether blocks follow naming convention
 func (r *TerraformNamingConventionRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	config := terraformNamingConventionRuleConfig{}

--- a/rules/terraformrules/terraform_required_providers.go
+++ b/rules/terraformrules/terraform_required_providers.go
@@ -38,6 +38,11 @@ func (r *TerraformRequiredProvidersRule) Link() string {
 
 // Check checks whether variables have descriptions
 func (r *TerraformRequiredProvidersRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	providers := make(map[string]hcl.Range)

--- a/rules/terraformrules/terraform_required_version.go
+++ b/rules/terraformrules/terraform_required_version.go
@@ -2,9 +2,10 @@ package terraformrules
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint/tflint"
-	"log"
 )
 
 // TerraformRequiredVersionRule checks whether a terraform version has required_version attribute
@@ -37,6 +38,11 @@ func (r *TerraformRequiredVersionRule) Link() string {
 
 // Check checks whether variables have descriptions
 func (r *TerraformRequiredVersionRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	module := runner.TFConfig.Module

--- a/rules/terraformrules/terraform_standard_module_structure.go
+++ b/rules/terraformrules/terraform_standard_module_structure.go
@@ -45,6 +45,11 @@ func (r *TerraformStandardModuleStructureRule) Link() string {
 
 // Check emits errors for any missing files and any block types that are included in the wrong file
 func (r *TerraformStandardModuleStructureRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	r.checkFiles(runner)

--- a/rules/terraformrules/terraform_typed_variables.go
+++ b/rules/terraformrules/terraform_typed_variables.go
@@ -39,6 +39,11 @@ func (r *TerraformTypedVariablesRule) Link() string {
 
 // Check checks whether variables have type
 func (r *TerraformTypedVariablesRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	files := make(map[string]*struct{})

--- a/rules/terraformrules/terraform_unused_declaration.go
+++ b/rules/terraformrules/terraform_unused_declaration.go
@@ -47,6 +47,11 @@ func (r *TerraformUnusedDeclarationsRule) Link() string {
 
 // Check emits issues for any variables, locals, and data sources that are declared but not used
 func (r *TerraformUnusedDeclarationsRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	decl := r.declarations(runner.TFConfig.Module)

--- a/rules/terraformrules/terraform_workspace_remote.go
+++ b/rules/terraformrules/terraform_workspace_remote.go
@@ -40,6 +40,11 @@ func (r *TerraformWorkspaceRemoteRule) Link() string {
 // Check checks for a "remote" backend and if found emits issues for
 // each use of terraform.workspace in an expression.
 func (r *TerraformWorkspaceRemoteRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
 	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
 
 	backend := runner.TFConfig.Root.Module.Backend


### PR DESCRIPTION
Fixes #878 

This PR adds a workaround to fix false positives in terraform rules.

Module inspection emits an issue in a module argument if an expression contains the module argument. However, this works as expected for rules such as `aws_instance_invalid_type`, but not for rules such as `terraform_deprecated_interpolation`, which has no cause in module arguments.

In order to avoid such false positives, first, in the rules of terraform, analysis other than the root module is explicitly skipped. This is not a good idea, but the goal is first to avoid false positives.