### PR TITLE
required_providers: handle implicit providers

### DIFF
--- a/rules/terraformrules/terraform_required_providers.go
+++ b/rules/terraformrules/terraform_required_providers.go
@@ -57,6 +57,18 @@ func (r *TerraformRequiredProvidersRule) Check(runner *tflint.Runner) error {
 		}
 	}
 
+	for _, resource := range module.ManagedResources {
+		if _, ok := providers[resource.Provider.Type]; !ok {
+			providers[resource.Provider.Type] = resource.DeclRange
+		}
+	}
+
+	for _, data := range module.DataResources {
+		if _, ok := providers[data.Provider.Type]; !ok {
+			providers[data.Provider.Type] = data.DeclRange
+		}
+	}
+
 	for name, decl := range providers {
 		if _, ok := module.ProviderRequirements.RequiredProviders[name]; !ok {
 			runner.EmitIssue(r, fmt.Sprintf(`Missing version constraint for provider "%s" in "required_providers"`, name), decl)

--- a/rules/terraformrules/terraform_required_providers_test.go
+++ b/rules/terraformrules/terraform_required_providers_test.go
@@ -37,6 +37,56 @@ provider "template" {}
 			},
 		},
 		{
+			Name: "implicit provider - resource",
+			Content: `
+resource "random_string" "foo" {
+	length = 16
+}
+`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: `Missing version constraint for provider "random" in "required_providers"`,
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 31,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "implicit provider - data source",
+			Content: `
+data "template_file" "foo" {
+	template = ""
+}
+`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: `Missing version constraint for provider "template" in "required_providers"`,
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   2,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Line:   2,
+							Column: 27,
+						},
+					},
+				},
+			},
+		},
+		{
 			Name: "required_providers set",
 			Content: `
 terraform {


### PR DESCRIPTION
When the `terraform_required_providers` rule is used, it only detects providers with an explicitly declared provider block:

```tf
provider "foo" {}
```

To obtain all provider names, this PR also iterates through resources and data sources. For the reported range in the issue, it will use a:

1. Provider block
2. Resource block
3. Data source block

See #888