### PR TITLE
Updated comments to reflect true intent of three methods

### DIFF
--- a/rules/terraformrules/terraform_comment_syntax.go
+++ b/rules/terraformrules/terraform_comment_syntax.go
@@ -38,7 +38,7 @@ func (r *TerraformCommentSyntaxRule) Link() string {
 	return tflint.ReferenceLink(r.Name())
 }
 
-// Check checks whether variables have type
+//  checks whether single line comments is used
 func (r *TerraformCommentSyntaxRule) Check(runner *tflint.Runner) error {
 	if !runner.TFConfig.Path.IsRoot() {
 		// This rule does not evaluate child modules.

--- a/rules/terraformrules/terraform_comment_syntax.go
+++ b/rules/terraformrules/terraform_comment_syntax.go
@@ -38,7 +38,7 @@ func (r *TerraformCommentSyntaxRule) Link() string {
 	return tflint.ReferenceLink(r.Name())
 }
 
-//  checks whether single line comments is used
+// Check checks whether single line comments is used
 func (r *TerraformCommentSyntaxRule) Check(runner *tflint.Runner) error {
 	if !runner.TFConfig.Path.IsRoot() {
 		// This rule does not evaluate child modules.

--- a/rules/terraformrules/terraform_required_providers.go
+++ b/rules/terraformrules/terraform_required_providers.go
@@ -36,7 +36,7 @@ func (r *TerraformRequiredProvidersRule) Link() string {
 	return tflint.ReferenceLink(r.Name())
 }
 
-// Checks whether provider required version is set
+//Check Checks whether provider required version is set
 func (r *TerraformRequiredProvidersRule) Check(runner *tflint.Runner) error {
 	if !runner.TFConfig.Path.IsRoot() {
 		// This rule does not evaluate child modules.

--- a/rules/terraformrules/terraform_required_providers.go
+++ b/rules/terraformrules/terraform_required_providers.go
@@ -36,7 +36,7 @@ func (r *TerraformRequiredProvidersRule) Link() string {
 	return tflint.ReferenceLink(r.Name())
 }
 
-// Check checks whether variables have descriptions
+// Checks whether provider required version is set
 func (r *TerraformRequiredProvidersRule) Check(runner *tflint.Runner) error {
 	if !runner.TFConfig.Path.IsRoot() {
 		// This rule does not evaluate child modules.

--- a/rules/terraformrules/terraform_required_version.go
+++ b/rules/terraformrules/terraform_required_version.go
@@ -36,7 +36,7 @@ func (r *TerraformRequiredVersionRule) Link() string {
 	return tflint.ReferenceLink(r.Name())
 }
 
-// Check checks whether variables have descriptions
+// Checks whether required_version is set
 func (r *TerraformRequiredVersionRule) Check(runner *tflint.Runner) error {
 	if !runner.TFConfig.Path.IsRoot() {
 		// This rule does not evaluate child modules.

--- a/rules/terraformrules/terraform_required_version.go
+++ b/rules/terraformrules/terraform_required_version.go
@@ -36,7 +36,7 @@ func (r *TerraformRequiredVersionRule) Link() string {
 	return tflint.ReferenceLink(r.Name())
 }
 
-// Checks whether required_version is set
+// Check Checks whether required_version is set
 func (r *TerraformRequiredVersionRule) Check(runner *tflint.Runner) error {
 	if !runner.TFConfig.Path.IsRoot() {
 		// This rule does not evaluate child modules.


### PR DESCRIPTION
The comments for Check function for Terraform rules - terraform_comment_syntax, terraform_required_Providers and terraform_required_version has been updated to reflect the true intent.

Please approve the pull request such that the changes for these comments are reflected and go docs provides the right messages.

Thanks,
Ritesh