### PR TITLE
Remove replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,9 +23,7 @@ require (
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/spf13/afero v1.3.5
 	github.com/terraform-linters/tflint-plugin-sdk v0.4.1-0.20200830151305-aa1706d5964d
-	github.com/terraform-providers/terraform-provider-aws v3.3.0+incompatible
+	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20200820211857-51f8bae0d4ee
 	github.com/zclconf/go-cty v1.6.1
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 )
-
-replace github.com/terraform-providers/terraform-provider-aws v3.3.0+incompatible => github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20200820211857-51f8bae0d4ee


### PR DESCRIPTION
A recent PR added a `replace` directive to the `go.mod` file which makes `tflint` no longer gettable via `go get`.

Closes #833 