### PR TITLE
Bump goreleaser version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,5 @@ jobs:
     - name: Run GoReleaser
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        VERSION: v0.116.0
+        VERSION: v0.143.0
       run: curl -sL https://git.io/goreleaser | bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 This release introduces a new CLI flag `--only`. This allows you to run the analysis with only certain rules enabled.
 
+Also, this release is built with Go v1.15. As a result, darwin/386 build will no longer available from the release. Due to a release process issue, this release does not include pre-built binaries, so please check v0.20.1.
+
 ### Breaking Changes
 
 - [#913](https://github.com/terraform-linters/tflint/pull/913): Bump tflint-plugin-sdk to v0.5.0 ([@wata727](https://github.com/wata727))


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint/runs/1107925471

Go v1.15 drops supports of darwin/386. The release build of v0.20 is failing because older versions of goreleaser can't handle this correctly.

This pull request bumps goreleaser to the latest version and revise the v0.20 release notes.