### PR TITLE
terraform_required_providers: ignore terraform provider

### DIFF
--- a/rules/terraformrules/terraform_required_providers.go
+++ b/rules/terraformrules/terraform_required_providers.go
@@ -75,6 +75,11 @@ func (r *TerraformRequiredProvidersRule) Check(runner *tflint.Runner) error {
 	}
 
 	for name, decl := range providers {
+		// builtin
+		if name == "terraform" {
+			continue
+		}
+
 		if _, ok := module.ProviderRequirements.RequiredProviders[name]; !ok {
 			runner.EmitIssue(r, fmt.Sprintf(`Missing version constraint for provider "%s" in "required_providers"`, name), decl)
 		}

--- a/rules/terraformrules/terraform_required_providers_test.go
+++ b/rules/terraformrules/terraform_required_providers_test.go
@@ -187,6 +187,13 @@ provider "template" {
 				},
 			},
 		},
+		{
+			Name: "terraform provider",
+			Content: `
+data "terraform_remote_state" "foo" {}
+`,
+			Expected: tflint.Issues{},
+		},
 	}
 
 	rule := NewTerraformRequiredProvidersRule()


### PR DESCRIPTION
This provider is built in to Terraform rather than downloaded from the registry, therefore a required version would have no effect/meaning.

Closes #919