### PR TITLE
Disable aws_s3_bucket_name rule by default

### DIFF
--- a/rules/awsrules/aws_s3_bucket_name.go
+++ b/rules/awsrules/aws_s3_bucket_name.go
@@ -36,7 +36,7 @@ func (r *AwsS3BucketNameRule) Name() string {
 
 // Enabled returns whether the rule is enabled by default
 func (r *AwsS3BucketNameRule) Enabled() bool {
-	return true
+	return false
 }
 
 // Severity returns the rule severity


### PR DESCRIPTION
This rule warns of style issues, so this PR makes the rule disabled by default.