### PR TITLE
GCP support status is now experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ TFLint supports multiple providers via plugins. The following is the Major Cloud
 |---|---|---|
 |[AWS](https://github.com/terraform-linters/tflint-ruleset-aws)|Available|Inspections for AWS resources are now built into TFLint. So, it is not necessary to install the plugin separately. In the future, these will be cut out to the plugin, but all are in progress.|
 |[Azure](https://github.com/terraform-linters/tflint-ruleset-azurerm)|Experimental|Experimental support has been started. You can inspect Azure resources by installing the plugin.|
-|[Google Cloud Platform](https://github.com/terraform-linters/tflint-ruleset-google)|Work in Progress|Everything is working and not available.|
+|[Google Cloud Platform](https://github.com/terraform-linters/tflint-ruleset-google)|Experimental|Experimental support has been started. You can inspect GCP resources by installing the plugin.|
 
 Please see the [documentation](docs/guides/extend.md) about the plugin system.
 


### PR DESCRIPTION
tflint-ruleset-google has been released 🎉 

This PR updates provider support status about GCP provider.