### PR TITLE
Cognito user pool domain valiation

### DIFF
--- a/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain.go
@@ -27,7 +27,7 @@ func NewAwsCognitoUserPoolDomainInvalidDomainRule() *AwsCognitoUserPoolDomainInv
 		attributeName: "domain",
 		max:           63,
 		min:           1,
-		pattern:       regexp.MustCompile(`^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$`),
+		pattern:       regexp.MustCompile(`^[a-z0-9](?:[a-z0-9\-\.]{0,61}[a-z0-9])?$`),
 	}
 }
 
@@ -77,7 +77,7 @@ func (r *AwsCognitoUserPoolDomainInvalidDomainRule) Check(runner *tflint.Runner)
 			if !r.pattern.MatchString(val) {
 				runner.EmitIssue(
 					r,
-					fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$`),
+					fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-z0-9](?:[a-z0-9\-\.]{0,61}[a-z0-9])?$`),
 					attribute.Expr.Range(),
 				)
 			}

--- a/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain_test.go
@@ -23,7 +23,7 @@ resource "aws_cognito_user_pool_domain" "foo" {
 			Expected: tflint.Issues{
 				{
 					Rule:    NewAwsCognitoUserPoolDomainInvalidDomainRule(),
-					Message: `"auth example" does not match valid pattern ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$`,
+					Message: `"auth example" does not match valid pattern ^[a-z0-9](?:[a-z0-9\-\.]{0,61}[a-z0-9])?$`,
 				},
 			},
 		},


### PR DESCRIPTION
When trying to use the following domain we fail tflint validation (yet it's a valid domain in terraform and AWS cognito).

resource "aws_cognito_user_pool_domain" "domain" {
  domain          = "ab-cdef.sso.example.com"
  certificate_arn = var.domain_certificate_arn
  user_pool_id    = aws_cognito_user_pool.pool.id
}

Error: "ab-cdef.sso.example.com" does not match valid pattern ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$ (aws_cognito_user_pool_domain_invalid_domain)
  on /builds/sofiinc/devops/sofi-terraform/cognito/at-work/user_pool.at-work.tf line 77
Please, fix the errors printed above

diff --git a/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain.go b/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain.go
index 9cd2688b..243e3381 100644
--- a/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain.go
@@ -27,7 +27,7 @@ func NewAwsCognitoUserPoolDomainInvalidDomainRule() *AwsCognitoUserPoolDomainInv
                attributeName: "domain",
                max:           63,
                min:           1,
-               pattern:       regexp.MustCompile(`^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$`),
+               pattern:       regexp.MustCompile(`^[a-z0-9](?:[a-z0-9\-\.]{0,61}[a-z0-9])?$`),
        }
 }

@@ -77,7 +77,7 @@ func (r *AwsCognitoUserPoolDomainInvalidDomainRule) Check(runner *tflint.Runner)
                        if !r.pattern.MatchString(val) {
                                runner.EmitIssue(
                                        r,
-                                       fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$`),
+                                       fmt.Sprintf(`"%s" does not match valid pattern %s`, truncateLongMessage(val), `^[a-z0-9](?:[a-z0-9\-\.]{0,61}[a-z0-9])?$`),
                                        attribute.Expr.Range(),
                                )
                        }
diff --git a/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain_test.go b/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain_test.go
index aa0f5f34..9ff7b4ac 100644
--- a/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain_test.go
+++ b/rules/awsrules/models/aws_cognito_user_pool_domain_invalid_domain_test.go
@@ -23,7 +23,7 @@ resource "aws_cognito_user_pool_domain" "foo" {
                        Expected: tflint.Issues{
                                {
                                        Rule:    NewAwsCognitoUserPoolDomainInvalidDomainRule(),
-                                       Message: `"auth example" does not match valid pattern ^[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?$`,
+                                       Message: `"auth example" does not match valid pattern ^[a-z0-9](?:[a-z0-9\-\.]{0,61}[a-z0-9])?$`,
                                },
                        },
                },

Version

Error happens on archlinux with this:
TFLint v0.20.2
Terraform v0.13.3

Error does not happen on mac with this:
TFLint v0.20.2
Terraform v0.13.3