### PR TITLE
missing_tags_rule: Suppress false positives when using dynamic blocks

### DIFF
--- a/rules/awsrules/aws_resource_missing_tags_test.go
+++ b/rules/awsrules/aws_resource_missing_tags_test.go
@@ -261,6 +261,39 @@ rule "aws_resource_missing_tags" {
 				},
 			},
 		},
+		{
+			Name: "AutoScaling Group with dynamic tags",
+			Content: `
+locals {
+  tags = [
+    {
+      key   = "Foo",
+      value = "bar",
+    },
+    {
+      key   = "Bar",
+      value = "baz",
+    },
+  ]
+}
+resource "aws_autoscaling_group" "this" {
+  dynamic "tag" {
+    for_each = local.tags
+		  
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+}`,
+			Config: `
+rule "aws_resource_missing_tags" {
+  enabled = true
+  tags = ["Foo", "Bar"]
+}`,
+			Expected: tflint.Issues{},
+		},
 	}
 
 	rule := NewAwsResourceMissingTagsRule()


### PR DESCRIPTION
Closes #949 

Fixes a bug where missing tags rule always fire when using dynamic blocks as tags for the AutoScaling Group.

Note that this is not an essential fix, but suppression of false positives. AutoScaling Groups with dynamic blocks are simply ignored because TFLint cannot expand dynamic blocks.