### PR TITLE
plugin: Add support for JSON configuration syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/spf13/afero v1.4.1
-	github.com/terraform-linters/tflint-plugin-sdk v0.5.0
+	github.com/terraform-linters/tflint-plugin-sdk v0.5.1-0.20201024120523-69843955cc45
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201015205411-546f68d4a935
 	github.com/zclconf/go-cty v1.6.1
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b

--- a/go.sum
+++ b/go.sum
@@ -591,8 +591,8 @@ github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible h1:5Td2b0yfaOvw
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c h1:iRD1CqtWUjgEVEmjwTMbP1DMzz1HRytOsgx/rlw/vNs=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
-github.com/terraform-linters/tflint-plugin-sdk v0.5.0 h1:wnVl1oaGoKWhwJCkok82DpiKpO19TuuBljMALTWZXoA=
-github.com/terraform-linters/tflint-plugin-sdk v0.5.0/go.mod h1:xbvHhlyCO/04nM+PBTERWP6VOIYGG5QLZNIgvjxi3xc=
+github.com/terraform-linters/tflint-plugin-sdk v0.5.1-0.20201024120523-69843955cc45 h1:FHFTMNt+RyONj0NoDznEuMwxaE1ZKp+KjwgZiW9+6JA=
+github.com/terraform-linters/tflint-plugin-sdk v0.5.1-0.20201024120523-69843955cc45/go.mod h1:Ho5IxOfE18lhc4KeXSfSxnoZWev34G2617ke+GA+Frc=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201015205411-546f68d4a935 h1:PbobnAeVvdzE1/qqTYxaB9h/YIpHCZXbCRBaXNIi0qA=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201015205411-546f68d4a935/go.mod h1:DdjydHaAmjsZl+uZ4QLwfx9iP+trTBMjEqLeAV9/OFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/integration/plugin/result.json
+++ b/integration/plugin/result.json
@@ -73,6 +73,26 @@
           }
         }
       ]
+    },
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is t1.xmicro",
+      "range": {
+        "filename": "template.tf.json",
+        "start": {
+          "line": 5,
+          "column": 26
+        },
+        "end": {
+          "line": 5,
+          "column": 37
+        }
+      },
+      "callers": []
     }
   ],
   "errors": []

--- a/integration/plugin/result_windows.json
+++ b/integration/plugin/result_windows.json
@@ -73,6 +73,26 @@
           }
         }
       ]
+    },
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is t1.xmicro",
+      "range": {
+        "filename": "template.tf.json",
+        "start": {
+          "line": 5,
+          "column": 26
+        },
+        "end": {
+          "line": 5,
+          "column": 37
+        }
+      },
+      "callers": []
     }
   ],
   "errors": []

--- a/integration/plugin/template.tf.json
+++ b/integration/plugin/template.tf.json
@@ -1,0 +1,17 @@
+{
+  "resource": {
+    "aws_instance": {
+      "example": {
+        "instance_type": "t1.xmicro",
+        "ami": "${join(\"\", [\"ami-123456\"])}",
+        "ebs_block_device": {
+          "device_name": "bar",
+          "volume_size": 10,
+          "foo": {
+            "bar": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/tflint/terraform.go
+++ b/tflint/terraform.go
@@ -11,6 +11,7 @@ import (
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/json"
 	"github.com/hashicorp/terraform/configs"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/zclconf/go-cty/cty"
@@ -58,13 +59,7 @@ func ParseExpression(src []byte, filename string, start hcl.Pos) (hcl.Expression
 	}
 
 	if strings.HasSuffix(filename, ".tf.json") {
-		return nil, hcl.Diagnostics{
-			&hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "JSON configuration syntax is not supported",
-				Subject:  &hcl.Range{Filename: filename, Start: start, End: start},
-			},
-		}
+		return json.ParseExpressionWithStartPos(src, filename, start)
 	}
 
 	panic(fmt.Sprintf("Unexpected file: %s", filename))


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/69

HCL v2.7.0 has started to support parsing JSON config/expression partially. We can take advantage of this to achieve partial server/client transfers of JSON configuration syntax.
