### PR TITLE
escape language server paths

### DIFF
--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -216,11 +217,17 @@ func (h *handler) inspect() (map[string][]lsp.Diagnostic, error) {
 	return ret, nil
 }
 
-func uriToPath(uri lsp.DocumentURI) string {
-	if runtime.GOOS == "windows" {
-		return strings.Replace(string(uri), "file:///", "", 1)
+func uriToPath(uri lsp.DocumentURI) (string, error) {
+	uriToReplace, err := url.QueryUnescape(string(uri))
+
+	if err != nil {
+		return "", err
 	}
-	return strings.Replace(string(uri), "file://", "", 1)
+
+	if runtime.GOOS == "windows" {
+		return strings.Replace(uriToReplace, "file:///", "", 1), nil
+	}
+	return strings.Replace(uriToReplace, "file://", "", 1), nil
 }
 
 func pathToURI(path string) lsp.DocumentURI {

--- a/langserver/handler_test.go
+++ b/langserver/handler_test.go
@@ -1,0 +1,37 @@
+package langserver
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	lsp "github.com/sourcegraph/go-lsp"
+)
+
+func Test_uriToPath_windows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		return
+	}
+
+	uri := lsp.DocumentURI("file:///c%3A/example%20directory")
+	value, _ := uriToPath(uri)
+	expected := "c:/example directory"
+
+	if !cmp.Equal(expected, value) {
+		t.Fatalf("Diff: %s", cmp.Diff(expected, value))
+	}
+}
+
+func Test_uriToPath_others(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		return
+	}
+
+	uri := lsp.DocumentURI("file:///example%20directory")
+	value, _ := uriToPath(uri)
+	expected := "/example directory"
+
+	if !cmp.Equal(expected, value) {
+		t.Fatalf("Diff: %s", cmp.Diff(expected, value))
+	}
+}

--- a/langserver/text_document_did_change.go
+++ b/langserver/text_document_did_change.go
@@ -30,7 +30,11 @@ func (h *handler) textDocumentDidChange(ctx context.Context, conn *jsonrpc2.Conn
 		}
 	}
 
-	changedPath := uriToPath(params.TextDocument.URI)
+	changedPath, err := uriToPath(params.TextDocument.URI)
+
+	if err != nil {
+		return nil, err
+	}
 
 	if err := h.chdir(filepath.Dir(changedPath)); err != nil {
 		return nil, err

--- a/langserver/text_document_did_open.go
+++ b/langserver/text_document_did_open.go
@@ -30,7 +30,11 @@ func (h *handler) textDocumentDidOpen(ctx context.Context, conn *jsonrpc2.Conn, 
 		}
 	}
 
-	openedPath := uriToPath(params.TextDocument.URI)
+	openedPath, err := uriToPath(params.TextDocument.URI)
+
+	if err != nil {
+		return nil, err
+	}
 
 	if err := h.chdir(filepath.Dir(openedPath)); err != nil {
 		return nil, err


### PR DESCRIPTION
When testing the Language Server feature in Windows I have discovered, that VSCode is sending file path as encoded URLs.

This results in paths like `C%3A/` instead of expected `C:/`, hence Language Server is yielding errors during `chdir`.