### PR TITLE
plugin: Allow to declare custom attributes in config files

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -62,10 +62,11 @@ func (cli *CLI) inspect(opts Options, dir string, filterFiles []string) int {
 		}
 	}
 
-	for _, ruleset := range plugin.RuleSets {
-		err = ruleset.ApplyConfig(cfg.ToPluginConfig())
+	for name, ruleset := range plugin.RuleSets {
+		err = ruleset.ApplyConfig(cfg.ToPluginConfig(name))
 		if err != nil {
 			cli.formatter.Print(tflint.Issues{}, tflint.NewContextError("Failed to apply config to plugins", err), cli.loader.Sources())
+			return ExitCodeError
 		}
 		for _, runner := range runners {
 			err = ruleset.Check(tfplugin.NewServer(runner, cli.loader.Sources()))

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/spf13/afero v1.4.1
-	github.com/terraform-linters/tflint-plugin-sdk v0.5.1-0.20201024120523-69843955cc45
+	github.com/terraform-linters/tflint-plugin-sdk v0.5.1-0.20201103124703-7e2f951c5aaf
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201015205411-546f68d4a935
 	github.com/zclconf/go-cty v1.7.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b

--- a/go.sum
+++ b/go.sum
@@ -595,8 +595,8 @@ github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible h1:5Td2b0yfaOvw
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c h1:iRD1CqtWUjgEVEmjwTMbP1DMzz1HRytOsgx/rlw/vNs=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
-github.com/terraform-linters/tflint-plugin-sdk v0.5.1-0.20201024120523-69843955cc45 h1:FHFTMNt+RyONj0NoDznEuMwxaE1ZKp+KjwgZiW9+6JA=
-github.com/terraform-linters/tflint-plugin-sdk v0.5.1-0.20201024120523-69843955cc45/go.mod h1:Ho5IxOfE18lhc4KeXSfSxnoZWev34G2617ke+GA+Frc=
+github.com/terraform-linters/tflint-plugin-sdk v0.5.1-0.20201103124703-7e2f951c5aaf h1:e1QN2Ur3z0nQE1HZrrb5IEPjw8dIpScEUG+w6mrbgOQ=
+github.com/terraform-linters/tflint-plugin-sdk v0.5.1-0.20201103124703-7e2f951c5aaf/go.mod h1:Ho5IxOfE18lhc4KeXSfSxnoZWev34G2617ke+GA+Frc=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201015205411-546f68d4a935 h1:PbobnAeVvdzE1/qqTYxaB9h/YIpHCZXbCRBaXNIi0qA=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201015205411-546f68d4a935/go.mod h1:DdjydHaAmjsZl+uZ4QLwfx9iP+trTBMjEqLeAV9/OFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -172,8 +172,8 @@ func (h *handler) inspect() (map[string][]lsp.Diagnostic, error) {
 		}
 	}
 
-	for _, ruleset := range h.plugin.RuleSets {
-		err = ruleset.ApplyConfig(h.config.ToPluginConfig())
+	for name, ruleset := range h.plugin.RuleSets {
+		err = ruleset.ApplyConfig(h.config.ToPluginConfig(name))
 		if err != nil {
 			return ret, fmt.Errorf("Failed to apply config to plugins: %s", err)
 		}

--- a/plugin/discovery.go
+++ b/plugin/discovery.go
@@ -43,8 +43,8 @@ func Discovery(config *tflint.Config) (*Plugin, error) {
 }
 
 func findPlugins(config *tflint.Config, dir string) (*Plugin, error) {
-	clients := []*plugin.Client{}
-	rulesets := []*tfplugin.Client{}
+	clients := map[string]*plugin.Client{}
+	rulesets := map[string]*tfplugin.Client{}
 
 	for _, cfg := range config.Plugins {
 		pluginPath, err := getPluginPath(dir, cfg.Name)
@@ -68,8 +68,8 @@ func findPlugins(config *tflint.Config, dir string) (*Plugin, error) {
 			}
 			ruleset := raw.(*tfplugin.Client)
 
-			clients = append(clients, client)
-			rulesets = append(rulesets, ruleset)
+			clients[cfg.Name] = client
+			rulesets[cfg.Name] = ruleset
 		} else {
 			log.Printf("[INFO] Plugin `%s` found, but the plugin is disabled", cfg.Name)
 		}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -13,9 +13,9 @@ var localPluginRoot = "./.tflint.d/plugins"
 // Plugin is an object handling plugins
 // Basically, it is a wrapper for go-plugin and provides an API to handle them collectively.
 type Plugin struct {
-	RuleSets []*tfplugin.Client
+	RuleSets map[string]*tfplugin.Client
 
-	clients []*plugin.Client
+	clients map[string]*plugin.Client
 }
 
 // Clean is a helper for ending plugin processes

--- a/plugin/stub-generator/sources/bar/main.go
+++ b/plugin/stub-generator/sources/bar/main.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		RuleSet: tflint.RuleSet{
+		RuleSet: &tflint.BuiltinRuleSet{
 			Name:    "bar",
 			Version: "0.1.0",
 			Rules:   []tflint.Rule{},

--- a/plugin/stub-generator/sources/example/main.go
+++ b/plugin/stub-generator/sources/example/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		RuleSet: tflint.RuleSet{
+		RuleSet: &tflint.BuiltinRuleSet{
 			Name:    "example",
 			Version: "0.1.0",
 			Rules: []tflint.Rule{

--- a/plugin/stub-generator/sources/foo/main.go
+++ b/plugin/stub-generator/sources/foo/main.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		RuleSet: tflint.RuleSet{
+		RuleSet: &tflint.BuiltinRuleSet{
 			Name:    "foo",
 			Version: "0.1.0",
 			Rules:   []tflint.Rule{},

--- a/tflint/test-fixtures/config/plugin.hcl
+++ b/tflint/test-fixtures/config/plugin.hcl
@@ -1,0 +1,21 @@
+config {
+  disabled_by_default = true
+}
+
+rule "aws_instance_invalid_type" {
+  enabled = false
+}
+
+rule "aws_instance_invalid_ami" {
+  enabled = true
+}
+
+plugin "foo" {
+  enabled = true
+
+  custom = "foo"
+}
+
+plugin "bar" {
+  enabled = false
+}


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/72

This PR adds `Body` field with the `hcl:",remain"` tag to `tflint.PluginConfig`. This allows you to declare arbitrary custom attributes for each plugin, which previously only allowed `enabled` as attributes for the "plugin" block.

The content declared inside the "plugin" block will be transferred to the plugin as `hcl.Body`. On the plugin side, you can retrieve the configurations by decoding it against your own schema.

For example, the AWS ruleset will be able to declare the following configuration:

```hcl
plugin "aws" {
  enabled = true

  access_key = "AWS_ACCESS_KEY"
  secret_key = "AWS_SECRET_KEY"
  region     = "us-east-1"
  profile    = "AWS_PROFILE"
  shared_credentials_file = "~/.aws/myapp"
}
```