### PR TITLE
chore: Allow "latest" as TFLINT_VERSION in the installation script

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -33,7 +33,7 @@ get_latest_release() {
     sed -E 's/.*"([^"]+)".*/\1/'                                                          # Pluck JSON value
 }
 
-if [[ -z "${TFLINT_VERSION}" ]]; then
+if [ -z "${TFLINT_VERSION}" ] || [ "${TFLINT_VERSION}" == "latest" ]; then
   echo "Looking up the latest version ..."
   version=$(get_latest_release)
 else


### PR DESCRIPTION
In GitHub Actions, if you set the matrix for multiple TFLint versions and set the corresponding `TFLINT_VERSION` environment variable, there is no way to set the "latest" version well.

This pull request allows "latest" as a valid `TFLINT_VERSION` value to handle this situation.