### PR TITLE
plugin: Extend runner API for accessing the root provider

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -69,7 +69,7 @@ func (cli *CLI) inspect(opts Options, dir string, filterFiles []string) int {
 			return ExitCodeError
 		}
 		for _, runner := range runners {
-			err = ruleset.Check(tfplugin.NewServer(runner, cli.loader.Sources()))
+			err = ruleset.Check(tfplugin.NewServer(runner, runners[len(runners)-1], cli.loader.Sources()))
 			if err != nil {
 				cli.formatter.Print(tflint.Issues{}, tflint.NewContextError("Failed to check ruleset", err), cli.loader.Sources())
 				return ExitCodeError

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/spf13/afero v1.4.1
-	github.com/terraform-linters/tflint-plugin-sdk v0.6.0
+	github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201205142940-d49361e1c42c
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201118192700-9cc6324740c9
 	github.com/zclconf/go-cty v1.7.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
-github.com/terraform-linters/tflint-plugin-sdk v0.6.0 h1:EphrAk4FheD/p3dSaBaHzhMQCuE6Wz5UN+9mEjdQ73Q=
-github.com/terraform-linters/tflint-plugin-sdk v0.6.0/go.mod h1:EMiQwq0IiBwylbSgx53sdPBRhOHEXrjXhrD0x5C8SjY=
+github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201205142940-d49361e1c42c h1:c19JJeT1VbTXFpqaxi7FBAv4OJAeKVg0mpNs2ySbgi0=
+github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201205142940-d49361e1c42c/go.mod h1:EMiQwq0IiBwylbSgx53sdPBRhOHEXrjXhrD0x5C8SjY=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201118192700-9cc6324740c9 h1:0u9SqTq2nbof0t+7xqfI8Ejhmooe3Qqe09fobOCZY6g=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201118192700-9cc6324740c9/go.mod h1:sToOUnPCXFPwMljH57zM6uOI3q1YVREy4GSlg1Wm8/Y=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -178,7 +178,7 @@ func (h *handler) inspect() (map[string][]lsp.Diagnostic, error) {
 			return ret, fmt.Errorf("Failed to apply config to plugins: %s", err)
 		}
 		for _, runner := range runners {
-			err = ruleset.Check(tfplugin.NewServer(runner, loader.Sources()))
+			err = ruleset.Check(tfplugin.NewServer(runner, runners[len(runners)-1], loader.Sources()))
 			if err != nil {
 				return ret, fmt.Errorf("Failed to check ruleset: %s", err)
 			}

--- a/plugin/encode.go
+++ b/plugin/encode.go
@@ -287,6 +287,12 @@ func (s *Server) encodeBackend(backend *tfconfigs.Backend) *tfplugin.Backend {
 
 func (s *Server) encodeProvider(provider *tfconfigs.Provider) *tfplugin.Provider {
 	configRange := tflint.HCLBodyRange(provider.Config, provider.DeclRange)
+	config := []byte{}
+	if configRange.Empty() {
+		configRange.Filename = provider.DeclRange.Filename
+	} else {
+		config = configRange.SliceBytes(s.runner.File(configRange.Filename).Bytes)
+	}
 
 	return &tfplugin.Provider{
 		Name:       provider.Name,
@@ -297,7 +303,7 @@ func (s *Server) encodeProvider(provider *tfconfigs.Provider) *tfplugin.Provider
 		Version:      provider.Version.Required.String(),
 		VersionRange: provider.Version.DeclRange,
 
-		Config:      configRange.SliceBytes(s.runner.File(configRange.Filename).Bytes),
+		Config:      config,
 		ConfigRange: configRange,
 
 		DeclRange: provider.DeclRange,

--- a/plugin/server_test.go
+++ b/plugin/server_test.go
@@ -20,7 +20,8 @@ resource "aws_instance" "foo" {
   instance_type = "t2.micro"
 }`
 
-	server := NewServer(tflint.TestRunner(t, map[string]string{"main.tf": source}), map[string][]byte{"main.tf": []byte(source)})
+	runner := tflint.TestRunner(t, map[string]string{"main.tf": source})
+	server := NewServer(runner, runner, map[string][]byte{"main.tf": []byte(source)})
 	req := &tfplugin.AttributesRequest{
 		Resource:      "aws_instance",
 		AttributeName: "instance_type",
@@ -70,7 +71,8 @@ resource "aws_instance" "foo" {
   }
 }`
 
-	server := NewServer(tflint.TestRunner(t, map[string]string{"main.tf": source}), map[string][]byte{"main.tf": []byte(source)})
+	runner := tflint.TestRunner(t, map[string]string{"main.tf": source})
+	server := NewServer(runner, runner, map[string][]byte{"main.tf": []byte(source)})
 	req := &tfplugin.BlocksRequest{
 		Resource:  "aws_instance",
 		BlockType: "ebs_block_device",
@@ -134,7 +136,8 @@ resource "aws_s3_bucket" "bar" {
   acl    = "private"
 }`
 
-	server := NewServer(tflint.TestRunner(t, map[string]string{"main.tf": source}), map[string][]byte{"main.tf": []byte(source)})
+	runner := tflint.TestRunner(t, map[string]string{"main.tf": source})
+	server := NewServer(runner, runner, map[string][]byte{"main.tf": []byte(source)})
 	req := &tfplugin.ResourcesRequest{Name: "aws_instance"}
 	var resp tfplugin.ResourcesResponse
 
@@ -245,7 +248,8 @@ variable "instance_type" {
   default = "t2.micro"
 }`
 
-	server := NewServer(tflint.TestRunner(t, map[string]string{"main.tf": source}), map[string][]byte{"main.tf": []byte(source)})
+	runner := tflint.TestRunner(t, map[string]string{"main.tf": source})
+	server := NewServer(runner, runner, map[string][]byte{"main.tf": []byte(source)})
 	req := &tfplugin.EvalExprRequest{
 		Expr: []byte(`var.instance_type`),
 		ExprRange: hcl.Range{
@@ -278,7 +282,8 @@ variable "instance_type" {
 func Test_EvalExpr_errors(t *testing.T) {
 	source := `variable "instance_type" {}`
 
-	server := NewServer(tflint.TestRunner(t, map[string]string{"main.tf": source}), map[string][]byte{"main.tf": []byte(source)})
+	runner := tflint.TestRunner(t, map[string]string{"main.tf": source})
+	server := NewServer(runner, runner, map[string][]byte{"main.tf": []byte(source)})
 	req := &tfplugin.EvalExprRequest{
 		Expr: []byte(`var.instance_type`),
 		ExprRange: hcl.Range{
@@ -315,7 +320,7 @@ func Test_EmitIssue(t *testing.T) {
 		},
 	}
 
-	server := NewServer(runner, map[string][]byte{})
+	server := NewServer(runner, runner, map[string][]byte{})
 	req := &tfplugin.EmitIssueRequest{
 		Rule:    rule,
 		Message: "This is test rule",


### PR DESCRIPTION
To cut out deep checking of AWS rules into a plugin, this PR extends runner API, adds `RootProvider` and `EvalExprOnRootCtx`.

In the ruleset plugin, an RPC server is assigned to each runner (module). If the target of the inspection is the root module, the provider configuration can be accessed, but the child module cannot access the provider configuration defined in the root.

To solve this problem, make use of the extended API to always have access to the root configuration.

See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/79