### PR TITLE
fix: exclude tfvars files from pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,5 @@
   description: TFLint is a Terraform linter focused on possible errors, best practices, and so on.
   language: golang
   entry: tflint
+  exclude: .*.tfvars$
   types: [terraform]


### PR DESCRIPTION
tflint does not support tfvars files which causes
pre-commit to fail when there are repository changes
to tfvars files