### PR TITLE
terraform_required_providers: emit error when only source is specified

### DIFF
--- a/rules/terraformrules/terraform_required_providers.go
+++ b/rules/terraformrules/terraform_required_providers.go
@@ -80,7 +80,7 @@ func (r *TerraformRequiredProvidersRule) Check(runner *tflint.Runner) error {
 			continue
 		}
 
-		if _, ok := module.ProviderRequirements.RequiredProviders[name]; !ok {
+		if provider, ok := module.ProviderRequirements.RequiredProviders[name]; !ok || provider.Requirement.Required == nil {
 			runner.EmitIssue(r, fmt.Sprintf(`Missing version constraint for provider "%s" in "required_providers"`, name), decl)
 		}
 	}

--- a/rules/terraformrules/terraform_required_providers_test.go
+++ b/rules/terraformrules/terraform_required_providers_test.go
@@ -87,17 +87,64 @@ data "template_file" "foo" {
 			},
 		},
 		{
-			Name: "required_providers set",
+			Name: "required_providers object",
 			Content: `
 terraform {
 	required_providers {
-		template = "~> 2"
+		template = {
+			source  = "hashicorp/template"
+			version = "~> 2" 
+		}
 	}
 }
 
 provider "template" {} 
 `,
 			Expected: tflint.Issues{},
+		},
+		{
+			Name: "required_providers string",
+			Content: `
+terraform {
+	required_providers {
+		template = "~> 2" 
+	}
+}
+
+provider "template" {} 
+`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "required_providers object missing version",
+			Content: `
+terraform {
+	required_providers {
+		template = {
+			source = "hashicorp/template"
+		}
+	}
+}
+
+provider "template" {} 
+`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformRequiredProvidersRule(),
+					Message: `Missing version constraint for provider "template" in "required_providers"`,
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   10,
+							Column: 1,
+						},
+						End: hcl.Pos{
+							Line:   10,
+							Column: 20,
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "single provider with alias",
@@ -125,11 +172,14 @@ provider "template" {
 			},
 		},
 		{
-			Name: "version set with alias",
+			Name: "version set",
 			Content: `
 terraform {
   required_providers {
-    template = "~> 2"
+    template = {
+			source = "hashicorp/template"
+			version = "~> 2"
+		}
   }
 }
 
@@ -144,11 +194,11 @@ provider "template" {
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{
-							Line:   8,
+							Line:   11,
 							Column: 1,
 						},
 						End: hcl.Pos{
-							Line:   8,
+							Line:   11,
 							Column: 20,
 						},
 					},
@@ -156,11 +206,14 @@ provider "template" {
 			},
 		},
 		{
-			Name: "version set",
+			Name: "version set with alias",
 			Content: `
 terraform {
   required_providers {
-    template = "~> 2"
+    template = {
+			source = "hashicorp/template"
+			version = "~> 2"
+		}
   }
 }
 
@@ -176,11 +229,11 @@ provider "template" {
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start: hcl.Pos{
-							Line:   8,
+							Line:   11,
 							Column: 1,
 						},
 						End: hcl.Pos{
-							Line:   8,
+							Line:   11,
 							Column: 20,
 						},
 					},


### PR DESCRIPTION
In Terraform 0.13+, all providers not in the `hashicorp` namespace that are loaded from the Terraform Registry require a `source`. This means a user might likely to have the following working config:

```tf
terraform {
  required_providers {
    datadog = {
      source = "datadog/datadog"
    }
  }
}
```

The intent of this rule is to require modules to specify their provider _version_ requirements. Currently, the above is accepted since there's an entry in `required_providers`. Checking for a non-nil version constraint ensures that the version has been included in the provider source.