### PR TITLE
runner: clean Terraform source path for comparison

### DIFF
--- a/rules/terraformrules/terraform_standard_module_structure.go
+++ b/rules/terraformrules/terraform_standard_module_structure.go
@@ -64,10 +64,13 @@ func (r *TerraformStandardModuleStructureRule) checkFiles(runner *tflint.Runner)
 		return
 	}
 
-	files := runner.Files()
-	for name, file := range files {
+	f := runner.Files()
+	files := make(map[string]*hcl.File, len(f))
+	for name, file := range f {
 		files[filepath.Base(name)] = file
 	}
+
+	log.Printf("[DEBUG] %d files found: %v", len(files), files)
 
 	if files[filenameMain] == nil {
 		runner.EmitIssue(

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -245,7 +245,7 @@ func (r *Runner) File(path string) *hcl.File {
 func (r *Runner) Files() map[string]*hcl.File {
 	result := make(map[string]*hcl.File)
 	for name, file := range r.files {
-		if filepath.Dir(name) == r.TFConfig.Module.SourceDir {
+		if filepath.Dir(name) == filepath.Clean(r.TFConfig.Module.SourceDir) {
 			result[name] = file
 		}
 	}


### PR DESCRIPTION
When TFLint is called with a relative path formatted with a leading `./`, results are empty from `Files()`. The logs I added for the rule that reproduced this printed:

```
$ tflint ./my/module
...
19:14:55 terraform_standard_module_structure.go:73: [DEBUG] 0 files found: map[]
```

`Clean` is called internally by `Dir`, meaning the comparison was `"my/module" == "./my/module"`. Cleaning both paths ensures the values are normalized for comparison.

The tests methods also call `Dir` to process a map of path -> file so adding a basic test didn't actually add coverage. 

But I did verify that it works as expected:

```
19:17:00 terraform_standard_module_structure.go:73: [DEBUG] 6 files found: map[backend.tf:0xc0001a0b40 main.tf:0xc0001a0f00 outputs.tf:0xc0001a0f80 providers.tf:0xc0001a1000 variables.tf:0xc0001a1080 versions.tf:0xc0001a0ac0]
``` 