### PR TITLE
plugin: Add support for fetching rule config

### DIFF
--- a/cmd/option_test.go
+++ b/cmd/option_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	hcl "github.com/hashicorp/hcl/v2"
 	flags "github.com/jessevdk/go-flags"
 	"github.com/terraform-linters/tflint/client"
@@ -297,8 +298,11 @@ func Test_toConfig(t *testing.T) {
 		}
 
 		ret := opts.toConfig()
-		if !cmp.Equal(tc.Expected, ret) {
-			t.Fatalf("Failed `%s` test: diff=%s", tc.Name, cmp.Diff(tc.Expected, ret))
+		eqlopts := []cmp.Option{
+			cmpopts.IgnoreUnexported(tflint.RuleConfig{}),
+		}
+		if !cmp.Equal(tc.Expected, ret, eqlopts...) {
+			t.Fatalf("Failed `%s` test: diff=%s", tc.Name, cmp.Diff(tc.Expected, ret, eqlopts...))
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/spf13/afero v1.4.1
-	github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201205142940-d49361e1c42c
+	github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201214165213-827cf110e0a9
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201118192700-9cc6324740c9
 	github.com/zclconf/go-cty v1.7.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
-github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201205142940-d49361e1c42c h1:c19JJeT1VbTXFpqaxi7FBAv4OJAeKVg0mpNs2ySbgi0=
-github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201205142940-d49361e1c42c/go.mod h1:EMiQwq0IiBwylbSgx53sdPBRhOHEXrjXhrD0x5C8SjY=
+github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201214165213-827cf110e0a9 h1:ADqZANXUwQzsBtG4nuaz8qGjXsetvHgk67Fr2OmRJs4=
+github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201214165213-827cf110e0a9/go.mod h1:EMiQwq0IiBwylbSgx53sdPBRhOHEXrjXhrD0x5C8SjY=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201118192700-9cc6324740c9 h1:0u9SqTq2nbof0t+7xqfI8Ejhmooe3Qqe09fobOCZY6g=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201118192700-9cc6324740c9/go.mod h1:sToOUnPCXFPwMljH57zM6uOI3q1YVREy4GSlg1Wm8/Y=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/plugin/stub-generator/sources/example/main.go
+++ b/plugin/stub-generator/sources/example/main.go
@@ -52,7 +52,7 @@ func (r *AwsInstanceExampleTypeRule) Link() string {
 func (r *AwsInstanceExampleTypeRule) Check(runner tflint.Runner) error {
 	return runner.WalkResourceAttributes("aws_instance", "instance_type", func(attribute *hcl.Attribute) error {
 		var instanceType string
-		err := runner.EvaluateExpr(attribute.Expr, &instanceType)
+		err := runner.EvaluateExpr(attribute.Expr, &instanceType, nil)
 
 		return runner.EnsureNoError(err, func() error {
 			return runner.EmitIssueOnExpr(

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -62,6 +62,9 @@ type RuleConfig struct {
 	Name    string   `hcl:"name,label"`
 	Enabled bool     `hcl:"enabled"`
 	Body    hcl.Body `hcl:",remain"`
+
+	// file is the result of parsing the HCL file that declares the rule configuration.
+	file *hcl.File
 }
 
 // PluginConfig is a TFLint's plugin config
@@ -284,6 +287,9 @@ func loadConfigFromFile(file string) (*Config, error) {
 	}
 
 	cfg := raw.toConfig()
+	for _, rule := range cfg.Rules {
+		rule.file = f
+	}
 	for _, plugin := range cfg.Plugins {
 		plugin.file = f
 	}
@@ -409,6 +415,11 @@ func (raw *rawConfig) toConfig() *Config {
 	}
 
 	return ret
+}
+
+// Bytes returns the bytes of the configuration file declared in the rule.
+func (r *RuleConfig) Bytes() []byte {
+	return r.file.Bytes
 }
 
 func configBodyRange(body hcl.Body) hcl.Range {

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -115,6 +115,7 @@ func Test_LoadConfig(t *testing.T) {
 		}
 
 		opts := []cmp.Option{
+			cmpopts.IgnoreUnexported(RuleConfig{}),
 			cmpopts.IgnoreUnexported(PluginConfig{}),
 			cmpopts.IgnoreFields(PluginConfig{}, "Body"),
 			cmpopts.IgnoreFields(RuleConfig{}, "Body"),
@@ -578,6 +579,7 @@ func Test_Merge(t *testing.T) {
 		ret := tc.Base.Merge(tc.Other)
 
 		opts := []cmp.Option{
+			cmpopts.IgnoreUnexported(RuleConfig{}),
 			cmpopts.IgnoreUnexported(PluginConfig{}),
 			cmpopts.IgnoreUnexported(hclsyntax.Body{}),
 			cmpopts.IgnoreFields(hclsyntax.Body{}, "Attributes", "Blocks"),
@@ -828,15 +830,18 @@ func Test_copy(t *testing.T) {
 		},
 	}
 
-	opt := cmpopts.IgnoreUnexported(PluginConfig{})
+	opts := []cmp.Option{
+		cmpopts.IgnoreUnexported(RuleConfig{}),
+		cmpopts.IgnoreUnexported(PluginConfig{}),
+	}
 	for _, tc := range cases {
 		ret := cfg.copy()
-		if !cmp.Equal(cfg, ret, opt) {
-			t.Fatalf("The copied config doesn't match original: Diff=%s", cmp.Diff(cfg, ret, opt))
+		if !cmp.Equal(cfg, ret, opts...) {
+			t.Fatalf("The copied config doesn't match original: Diff=%s", cmp.Diff(cfg, ret, opts...))
 		}
 
 		tc.SideEffect(ret)
-		if cmp.Equal(cfg, ret, opt) {
+		if cmp.Equal(cfg, ret, opts...) {
 			t.Fatalf("The original was changed when updating `%s`", tc.Name)
 		}
 	}

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -375,6 +375,11 @@ func (r *Runner) DecodeRuleConfig(ruleName string, val interface{}) error {
 	return nil
 }
 
+// RuleConfig returns the corresponding rule configuration
+func (r *Runner) RuleConfig(ruleName string) *RuleConfig {
+	return r.config.Rules[ruleName]
+}
+
 func (r *Runner) emitIssue(issue *Issue) {
 	if annotations, ok := r.annotations[issue.Range.Filename]; ok {
 		for _, annotation := range annotations {


### PR DESCRIPTION
To cut out the `aws_resource_missing_tags` rule into a plugin, this PR adds a new runner API, called `RuleConfig`.

This API returns an encoded HCL format rule config like the plugin configuration. See also https://github.com/terraform-linters/tflint/pull/967
On the plugin side, they can decode the rule config and reflects it into the config structure defined in the rule implementation using `gohcl.DecodeBody`.

See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/82