### PR TITLE
rule: terraform_unused_required_providers

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -79,6 +79,6 @@ These rules suggest to better ways.
 |[terraform_naming_convention](terraform_naming_convention.md)||
 |[terraform_required_version](terraform_required_version.md)||
 |[terraform_required_providers](terraform_required_providers.md)||
-|[terraform_unused_required_providers](terraform_required_providers.md)||
+|[terraform_unused_required_providers](terraform_unused_required_providers.md)||
 |[terraform_standard_module_structure](terraform_standard_module_structure.md)||
 |[terraform_workspace_remote](terraform_workspace_remote.md)|✔|

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -79,5 +79,6 @@ These rules suggest to better ways.
 |[terraform_naming_convention](terraform_naming_convention.md)||
 |[terraform_required_version](terraform_required_version.md)||
 |[terraform_required_providers](terraform_required_providers.md)||
+|[terraform_unused_required_providers](terraform_required_providers.md)||
 |[terraform_standard_module_structure](terraform_standard_module_structure.md)||
 |[terraform_workspace_remote](terraform_workspace_remote.md)|✔|

--- a/docs/rules/terraform_unused_required_providers.md
+++ b/docs/rules/terraform_unused_required_providers.md
@@ -1,0 +1,64 @@
+# terraform_unused_required_providers
+
+Check that all `required_providers` are used in the module.
+
+## Configuration
+
+```hcl
+rule "terraform_unused_required_providers" {
+  enabled = true
+}
+```
+
+## Examples
+
+```hcl
+terraform {
+  required_providers {
+    null = {
+      source = "hashicorp/null"
+    }
+  }
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Warning: provider 'null' is declared in required_providers but not used by the module (terraform_unused_required_providers)
+
+  on main.tf line 3:
+   3:     null = {
+   4:       source = "hashicorp/null"
+   5:     }
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.22.0/docs/rules/terraform_unused_required_providers.md
+```
+
+## Why
+
+The `required_providers` block should specify providers used directly by the given Terraform module. Terraform will download all specified providers during `terraform init`. If all resources for a given provider are removed but the `required_providers` entry remains, Terraform will continue to download the provider.
+
+In general, each module should specify its own provider requirements for each provider it uses. Terraform will traverse the module graph and find a suitable version for all providers, or error if modules require conflicting versions. 
+
+## How To Fix
+
+If the provider is no longer used, remove it from the `required_providers` block. 
+
+If the provider is used in one or more child modules but not directly in the module where TFLint was invoked, cut and paste the provider requirement into those modules.
+
+If the provider is used in one or more child modules and you'd prefer to define a single requirement, you can ignore the warning:
+
+```tf
+terraform {
+  required_providers {
+    # tflint-ignore: terraform_unused_required_providers
+    null = {
+      source = "hashicorp/null"
+    }
+  }
+}
+```
+
+This will affect your ability to run `terraform` directly in the child module, especially if you use providers outside the default `hashicorp` namespace or specify a `version` for required providers ([recommended](./terraform_required_providers.md)).

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -50,6 +50,7 @@ var manualDefaultRules = []Rule{
 	terraformrules.NewTerraformRequiredProvidersRule(),
 	terraformrules.NewTerraformWorkspaceRemoteRule(),
 	terraformrules.NewTerraformUnusedDeclarationsRule(),
+	terraformrules.NewTerraformUnusedRequiredProvidersRule(),
 	terraformrules.NewTerraformCommentSyntaxRule(),
 }
 

--- a/rules/terraformrules/terraform_unused_required_providers.go
+++ b/rules/terraformrules/terraform_unused_required_providers.go
@@ -54,13 +54,13 @@ func (r *TerraformUnusedRequiredProvidersRule) Check(runner *tflint.Runner) erro
 
 func (r *TerraformUnusedRequiredProvidersRule) checkProvider(runner *tflint.Runner, required *configs.RequiredProvider) {
 	for _, resource := range runner.TFConfig.Module.ManagedResources {
-		if required.Name == resource.Provider.Type {
+		if r.usesProvider(resource, required) {
 			return
 		}
 	}
 
 	for _, resource := range runner.TFConfig.Module.DataResources {
-		if required.Name == resource.Provider.Type {
+		if r.usesProvider(resource, required) {
 			return
 		}
 	}
@@ -76,4 +76,12 @@ func (r *TerraformUnusedRequiredProvidersRule) checkProvider(runner *tflint.Runn
 		fmt.Sprintf("provider '%s' is declared in required_providers but not used by the module", required.Name),
 		required.DeclRange,
 	)
+}
+
+func (r *TerraformUnusedRequiredProvidersRule) usesProvider(resource *configs.Resource, required *configs.RequiredProvider) bool {
+	if resource.ProviderConfigRef != nil {
+		return resource.ProviderConfigRef.Name == required.Name
+	}
+
+	return resource.Provider.Type == required.Name
 }

--- a/rules/terraformrules/terraform_unused_required_providers.go
+++ b/rules/terraformrules/terraform_unused_required_providers.go
@@ -1,0 +1,75 @@
+package terraformrules
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+// TerraformUnusedRequiredProvidersRule checks whether Terraform sets version constraints for all configured providers
+type TerraformUnusedRequiredProvidersRule struct{}
+
+// NewTerraformUnusedRequiredProvidersRule returns new rule with default attributes
+func NewTerraformUnusedRequiredProvidersRule() *TerraformUnusedRequiredProvidersRule {
+	return &TerraformUnusedRequiredProvidersRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformUnusedRequiredProvidersRule) Name() string {
+	return "terraform_unused_required_providers"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformUnusedRequiredProvidersRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *TerraformUnusedRequiredProvidersRule) Severity() string {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *TerraformUnusedRequiredProvidersRule) Link() string {
+	return tflint.ReferenceLink(r.Name())
+}
+
+//Check Checks whether provider required version is set
+func (r *TerraformUnusedRequiredProvidersRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+
+	log.Printf("[TRACE] Check `%s` rule for `%s` runner", r.Name(), runner.TFConfigPath())
+
+providers:
+	for _, required := range runner.TFConfig.Module.ProviderRequirements.RequiredProviders {
+		for _, resource := range runner.TFConfig.Module.ManagedResources {
+			if required.Name == resource.Provider.Type {
+				continue providers
+			}
+		}
+
+		for _, resource := range runner.TFConfig.Module.DataResources {
+			if required.Name == resource.Provider.Type {
+				continue providers
+			}
+		}
+
+		for _, provider := range runner.TFConfig.Module.ProviderConfigs {
+			if required.Name == provider.Name {
+				continue providers
+			}
+		}
+
+		runner.EmitIssue(
+			r,
+			fmt.Sprintf("provider '%s' is declared in required_providers but not used by the module", required.Name),
+			required.DeclRange,
+		)
+	}
+
+	return nil
+}

--- a/rules/terraformrules/terraform_unused_required_providers_test.go
+++ b/rules/terraformrules/terraform_unused_required_providers_test.go
@@ -1,0 +1,112 @@
+package terraformrules
+
+import (
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_TerraformUnusedRequiredProvidersRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected tflint.Issues
+	}{
+		{
+			Name:     "empty",
+			Content:  "",
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "used - resource",
+			Content: `
+				terraform {
+					required_providers {
+						null = {
+							source = "hashicorp/null"
+						}
+					}
+				}
+
+				resource "null_resource" "foo" {}
+			`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "used - data source",
+			Content: `
+				terraform {
+					required_providers {
+						null = {
+							source = "hashicorp/null"
+						}
+					}
+				}
+
+				resource "null_data_source" "foo" {}
+			`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "used - provider",
+			Content: `
+				terraform {
+					required_providers {
+						null = {
+							source = "hashicorp/null"
+						}
+					}
+				}
+
+				provider "null" {}
+			`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "unused",
+			Content: `
+				terraform {
+					required_providers {
+						null = {
+							source = "hashicorp/null"
+						}
+					}
+				}
+			`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformUnusedRequiredProvidersRule(),
+					Message: "provider 'null' is declared in required_providers but not used by the module",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 14,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 8,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rule := NewTerraformUnusedRequiredProvidersRule()
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.Name, func(t *testing.T) {
+			runner := tflint.TestRunner(t, map[string]string{"module.tf": tc.Content})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			tflint.AssertIssues(t, tc.Expected, runner.Issues)
+		})
+	}
+}

--- a/rules/terraformrules/terraform_unused_required_providers_test.go
+++ b/rules/terraformrules/terraform_unused_required_providers_test.go
@@ -49,6 +49,40 @@ func Test_TerraformUnusedRequiredProvidersRule(t *testing.T) {
 			Expected: tflint.Issues{},
 		},
 		{
+			Name: "used - resource provider override",
+			Content: `
+				terraform {
+					required_providers {
+						custom-null = {
+							source = "custom/null"
+						}
+					}
+				}
+
+				resource "null_resource" "foo" {
+					provider = custom-null
+				}
+			`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "used - data source provider override",
+			Content: `
+				terraform {
+					required_providers {
+						custom-null = {
+							source = "custom/null"
+						}
+					}
+				}
+
+				resource "null_data_source" "foo" {
+					provider = custom-null
+				}
+			`,
+			Expected: tflint.Issues{},
+		},
+		{
 			Name: "used - provider",
 			Content: `
 				terraform {
@@ -72,6 +106,43 @@ func Test_TerraformUnusedRequiredProvidersRule(t *testing.T) {
 							source = "hashicorp/null"
 						}
 					}
+				}
+			`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformUnusedRequiredProvidersRule(),
+					Message: "provider 'null' is declared in required_providers but not used by the module",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start: hcl.Pos{
+							Line:   4,
+							Column: 14,
+						},
+						End: hcl.Pos{
+							Line:   6,
+							Column: 8,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "unused - override",
+			Content: `
+				terraform {
+					required_providers {
+						null = {
+							source = "hashicorp/null"
+						}
+
+						custom-null = {
+							source = "custom/null"
+						}
+					}
+				}
+
+				resource "null_resource" "foo" {
+					provider = custom-null
 				}
 			`,
 			Expected: tflint.Issues{


### PR DESCRIPTION
As a complement to the "required providers" rule, this adds a rule that detects unused required providers. This ends up being slightly more complicated in the wild, since technically it's valid to put all your provider requirements in the root module, but it means `terraform init` may not work in child modules.

In theory this rule could also walk down the module tree looking for provider use, but I haven't implemented that here. This rule is disabled by default and users who specify required providers directly in each module can just turn it on.