### PR TITLE
plugin: Add `IsNullExpr` API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/spf13/afero v1.4.1
-	github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201214165213-827cf110e0a9
+	github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201219154003-09b2270d9de5
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201118192700-9cc6324740c9
 	github.com/zclconf/go-cty v1.7.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
-github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201214165213-827cf110e0a9 h1:ADqZANXUwQzsBtG4nuaz8qGjXsetvHgk67Fr2OmRJs4=
-github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201214165213-827cf110e0a9/go.mod h1:EMiQwq0IiBwylbSgx53sdPBRhOHEXrjXhrD0x5C8SjY=
+github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201219154003-09b2270d9de5 h1:PCwAYfajRygdxp9gtEu6SDfbN9jm2X/TjDgetlf9fck=
+github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201219154003-09b2270d9de5/go.mod h1:EMiQwq0IiBwylbSgx53sdPBRhOHEXrjXhrD0x5C8SjY=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201118192700-9cc6324740c9 h1:0u9SqTq2nbof0t+7xqfI8Ejhmooe3Qqe09fobOCZY6g=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201118192700-9cc6324740c9/go.mod h1:sToOUnPCXFPwMljH57zM6uOI3q1YVREy4GSlg1Wm8/Y=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/plugin/server.go
+++ b/plugin/server.go
@@ -175,6 +175,18 @@ func (s *Server) EvalExprOnRootCtx(req *tfplugin.EvalExprRequest, resp *tfplugin
 	return nil
 }
 
+// IsNullExpr returns the result of determining whether the expression is null or not.
+func (s *Server) IsNullExpr(req *tfplugin.IsNullExprRequest, resp *tfplugin.IsNullExprResponse) error {
+	expr, diags := tflint.ParseExpression(req.Expr, req.Range.Filename, req.Range.Start)
+	if diags.HasErrors() {
+		return diags
+	}
+
+	ret, err := s.runner.IsNullExpr(expr)
+	*resp = tfplugin.IsNullExprResponse{Ret: ret, Err: err}
+	return nil
+}
+
 // EmitIssue reflects a issue to the Runner
 func (s *Server) EmitIssue(req *tfplugin.EmitIssueRequest, resp *interface{}) error {
 	if req.Expr != nil {


### PR DESCRIPTION
To cut out some rules into a plugin, this PR adds the `IsNullExpr` API. This is a wrapper of the `runner.IsNullExpr`.

See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/85