### PR TITLE
deps: match afero version to terraform

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "github.com/spf13/afero"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
-	github.com/spf13/afero v1.4.1
+	github.com/spf13/afero v1.2.2 // matches version used by terraform
 	github.com/terraform-linters/tflint-plugin-sdk v0.6.1-0.20201228090821-2703210e0cdd
 	github.com/terraform-linters/tflint-ruleset-aws v0.0.0-20201228092536-f1c9d2669ff5
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201118192700-9cc6324740c9

--- a/go.sum
+++ b/go.sum
@@ -401,7 +401,6 @@ github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba/go.mod h1:ghbZsc
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -510,7 +509,6 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -543,9 +541,8 @@ github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1 h1:O1d7nVzpGmP5
 github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1/go.mod h1:tpps84QRlOVVLYk5QpKYX8Tr289D1v/UTWDLqeguiqM=
 github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a h1:jTZwOlrDhmk4Ez2vhWh7kA0eKUahp1lCO2uyM4fi/Qk=
 github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a/go.mod h1:eESpbCslcLDs8j2D7IEdGVgul7xuk9odqDTaor30IUU=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
-github.com/spf13/afero v1.4.1 h1:asw9sl74539yqavKaglDM5hFpdJVK0Y5Dr/JOgQ89nQ=
-github.com/spf13/afero v1.4.1/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -615,7 +612,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191202143827-86a70503ff7e/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
TFLint uses github.com/spf13/afero as a filesystem abstraction. Terraform's configuration loading APIs accept an afero filesystem interface. Implicitly, this means TFLint and Terraform should use the same version of afero, but previously haven't done so.

In https://github.com/terraform-linters/tflint/pull/1004, updating afero to 1.5 added a `Chown` method, meaning implementers need to define that method. But if you're expecting `v1.2.2` as Terraform is, you haven't implemented that. Whether this means `Chown` should have gone in v2, 🤷🏻. But it results in build errors:

```
$ make test
go run ./plugin/stub-generator
go test -timeout 5m $(go list ./... | grep -v test-fixtures | grep -v vendor | grep -v aws-sdk-go)
# github.com/hashicorp/terraform/configs/configload
../../go/pkg/mod/github.com/hashicorp/terraform@v0.14.3/configs/configload/loader_snapshot.go:52:29: cannot use fs (type snapshotFS) as type afero.Fs in argument to configs.NewParser:
	snapshotFS does not implement afero.Fs (missing Chown method)
../../go/pkg/mod/github.com/hashicorp/terraform@v0.14.3/configs/configload/loader_snapshot.go:57:28: cannot use fs (type snapshotFS) as type afero.Fs in field value:
	snapshotFS does not implement afero.Fs (missing Chown method)
../../go/pkg/mod/github.com/hashicorp/terraform@v0.14.3/configs/configload/loader_snapshot.go:212:5: cannot use snapshotFS literal (type snapshotFS) as type afero.Fs in assignment:
	snapshotFS does not implement afero.Fs (missing Chown method)
ok  	github.com/terraform-linters/tflint	1.199s
ok  	github.com/terraform-linters/tflint/client	0.190s
ok  	github.com/terraform-linters/tflint/cmd	0.697s
ok  	github.com/terraform-linters/tflint/formatter	0.194s
ok  	github.com/terraform-linters/tflint/langserver	0.701s
ok  	github.com/terraform-linters/tflint/plugin	0.998s
?   	github.com/terraform-linters/tflint/plugin/stub-generator	[no test files]
?   	github.com/terraform-linters/tflint/plugin/stub-generator/sources/bar	[no test files]
?   	github.com/terraform-linters/tflint/plugin/stub-generator/sources/example	[no test files]
?   	github.com/terraform-linters/tflint/plugin/stub-generator/sources/foo	[no test files]
ok  	github.com/terraform-linters/tflint/rules	0.617s
ok  	github.com/terraform-linters/tflint/rules/awsrules	0.686s
FAIL	github.com/terraform-linters/tflint/rules/awsrules/api [build failed]
?   	github.com/terraform-linters/tflint/rules/awsrules/generator	[no test files]
?   	github.com/terraform-linters/tflint/rules/awsrules/generator-utils	[no test files]
FAIL	github.com/terraform-linters/tflint/rules/awsrules/models [build failed]
?   	github.com/terraform-linters/tflint/rules/awsrules/tags	[no test files]
ok  	github.com/terraform-linters/tflint/rules/terraformrules	0.570s
ok  	github.com/terraform-linters/tflint/tflint	0.384s
FAIL
```

Since afero is a shared dependency, this adopts a version matching Terraform's and disables Dependabot on that dependency. 

Closes #1004