### PR TITLE
Remove global deep checking options

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -156,5 +156,11 @@ func unknownOptionHandler(option string, arg flags.SplitArgument, args []string)
 	if option == "ignore-rule" {
 		return []string{}, errors.New("`ignore-rule` option was removed in v0.12.0. Please use `--disable-rule` instead")
 	}
+	if option == "deep" {
+		return []string{}, errors.New("`deep` option was removed in v0.23.0. Deep checking is now a feature of the AWS plugin, so please configure the plugin instead")
+	}
+	if option == "aws-access-key" || option == "aws-secret-key" || option == "aws-profile" || option == "aws-creds-file" || option == "aws-region" {
+		return []string{}, fmt.Errorf("`%s` option was removed in v0.23.0. AWS rules are provided by the AWS plugin, so please configure the plugin instead", option)
+	}
 	return []string{}, fmt.Errorf("`%s` is unknown option. Please run `tflint --help`", option)
 }

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -101,6 +101,42 @@ func TestCLIRun__noIssuesFound(t *testing.T) {
 			Stderr:  "`ignore-rule` option was removed in v0.12.0. Please use `--disable-rule` instead",
 		},
 		{
+			Name:    "removed `--deep` option",
+			Command: "./tflint --deep",
+			Status:  ExitCodeError,
+			Stderr:  "`deep` option was removed in v0.23.0. Deep checking is now a feature of the AWS plugin, so please configure the plugin instead",
+		},
+		{
+			Name:    "removed `--aws-access-key` option",
+			Command: "./tflint --aws-access-key AWS_ACCESS_KEY_ID",
+			Status:  ExitCodeError,
+			Stderr:  "`aws-access-key` option was removed in v0.23.0. AWS rules are provided by the AWS plugin, so please configure the plugin instead",
+		},
+		{
+			Name:    "removed `--aws-secret-key` option",
+			Command: "./tflint --aws-secret-key AWS_SECRET_ACCESS_KEY",
+			Status:  ExitCodeError,
+			Stderr:  "`aws-secret-key` option was removed in v0.23.0. AWS rules are provided by the AWS plugin, so please configure the plugin instead",
+		},
+		{
+			Name:    "removed `--aws-profile` option",
+			Command: "./tflint --aws-profile AWS_PROFILE",
+			Status:  ExitCodeError,
+			Stderr:  "`aws-profile` option was removed in v0.23.0. AWS rules are provided by the AWS plugin, so please configure the plugin instead",
+		},
+		{
+			Name:    "removed `--aws-creds-file` option",
+			Command: "./tflint --aws-creds-file FILE",
+			Status:  ExitCodeError,
+			Stderr:  "`aws-creds-file` option was removed in v0.23.0. AWS rules are provided by the AWS plugin, so please configure the plugin instead",
+		},
+		{
+			Name:    "removed `--aws-region` option",
+			Command: "./tflint --aws-region us-east-1",
+			Status:  ExitCodeError,
+			Stderr:  "`aws-region` option was removed in v0.23.0. AWS rules are provided by the AWS plugin, so please configure the plugin instead",
+		},
+		{
 			Name:    "invalid options",
 			Command: "./tflint --unknown",
 			Status:  ExitCodeError,

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
-	"github.com/terraform-linters/tflint/client"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -22,12 +21,6 @@ type Options struct {
 	Varfiles       []string `long:"var-file" description:"Terraform variable file name" value-name:"FILE"`
 	Variables      []string `long:"var" description:"Set a Terraform variable" value-name:"'foo=bar'"`
 	Module         bool     `long:"module" description:"Inspect modules"`
-	Deep           bool     `long:"deep" description:"Enable deep check mode"`
-	AwsAccessKey   string   `long:"aws-access-key" description:"AWS access key used in deep check mode" value-name:"ACCESS_KEY"`
-	AwsSecretKey   string   `long:"aws-secret-key" description:"AWS secret key used in deep check mode" value-name:"SECRET_KEY"`
-	AwsProfile     string   `long:"aws-profile" description:"AWS shared credential profile name used in deep check mode" value-name:"PROFILE"`
-	AwsCredsFile   string   `long:"aws-creds-file" description:"AWS shared credentials file path used in deep checking" value-name:"FILE"`
-	AwsRegion      string   `long:"aws-region" description:"AWS region used in deep check mode" value-name:"REGION"`
 	Force          bool     `long:"force" description:"Return zero exit status even if issues found"`
 	NoColor        bool     `long:"no-color" description:"Disable colorized output"`
 	LogLevel       string   `long:"loglevel" description:"Change the loglevel" choice:"trace" choice:"debug" choice:"info" choice:"warn" choice:"error" default:"none"`
@@ -54,7 +47,6 @@ func (opts *Options) toConfig() *tflint.Config {
 
 	log.Printf("[DEBUG] CLI Options")
 	log.Printf("[DEBUG]   Module: %t", opts.Module)
-	log.Printf("[DEBUG]   DeepCheck: %t", opts.Deep)
 	log.Printf("[DEBUG]   Force: %t", opts.Force)
 	log.Printf("[DEBUG]   IgnoreModules: %#v", ignoreModules)
 	log.Printf("[DEBUG]   EnableRules: %#v", opts.EnableRules)
@@ -94,16 +86,8 @@ func (opts *Options) toConfig() *tflint.Config {
 	}
 
 	return &tflint.Config{
-		Module:    opts.Module,
-		DeepCheck: opts.Deep,
-		Force:     opts.Force,
-		AwsCredentials: client.AwsCredentials{
-			AccessKey: opts.AwsAccessKey,
-			SecretKey: opts.AwsSecretKey,
-			Profile:   opts.AwsProfile,
-			CredsFile: opts.AwsCredsFile,
-			Region:    opts.AwsRegion,
-		},
+		Module:            opts.Module,
+		Force:             opts.Force,
 		IgnoreModules:     ignoreModules,
 		Varfiles:          varfiles,
 		Variables:         opts.Variables,

--- a/cmd/option_test.go
+++ b/cmd/option_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	hcl "github.com/hashicorp/hcl/v2"
 	flags "github.com/jessevdk/go-flags"
-	"github.com/terraform-linters/tflint/client"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -28,25 +27,7 @@ func Test_toConfig(t *testing.T) {
 			Command: "./tflint --module",
 			Expected: &tflint.Config{
 				Module:            true,
-				DeepCheck:         false,
 				Force:             false,
-				AwsCredentials:    client.AwsCredentials{},
-				IgnoreModules:     map[string]bool{},
-				Varfiles:          []string{},
-				Variables:         []string{},
-				DisabledByDefault: false,
-				Rules:             map[string]*tflint.RuleConfig{},
-				Plugins:           map[string]*tflint.PluginConfig{},
-			},
-		},
-		{
-			Name:    "--deep",
-			Command: "./tflint --deep",
-			Expected: &tflint.Config{
-				Module:            false,
-				DeepCheck:         true,
-				Force:             false,
-				AwsCredentials:    client.AwsCredentials{},
 				IgnoreModules:     map[string]bool{},
 				Varfiles:          []string{},
 				Variables:         []string{},
@@ -60,68 +41,7 @@ func Test_toConfig(t *testing.T) {
 			Command: "./tflint --force",
 			Expected: &tflint.Config{
 				Module:            false,
-				DeepCheck:         false,
 				Force:             true,
-				AwsCredentials:    client.AwsCredentials{},
-				IgnoreModules:     map[string]bool{},
-				Varfiles:          []string{},
-				Variables:         []string{},
-				DisabledByDefault: false,
-				Rules:             map[string]*tflint.RuleConfig{},
-				Plugins:           map[string]*tflint.PluginConfig{},
-			},
-		},
-		{
-			Name:    "AWS static credentials",
-			Command: "./tflint --aws-access-key AWS_ACCESS_KEY_ID --aws-secret-key AWS_SECRET_ACCESS_KEY --aws-region us-east-1",
-			Expected: &tflint.Config{
-				Module:    false,
-				DeepCheck: false,
-				Force:     false,
-				AwsCredentials: client.AwsCredentials{
-					AccessKey: "AWS_ACCESS_KEY_ID",
-					SecretKey: "AWS_SECRET_ACCESS_KEY",
-					Region:    "us-east-1",
-				},
-				IgnoreModules:     map[string]bool{},
-				Varfiles:          []string{},
-				Variables:         []string{},
-				DisabledByDefault: false,
-				Rules:             map[string]*tflint.RuleConfig{},
-				Plugins:           map[string]*tflint.PluginConfig{},
-			},
-		},
-		{
-			Name:    "AWS shared credentials",
-			Command: "./tflint --aws-profile production --aws-region us-east-1",
-			Expected: &tflint.Config{
-				Module:    false,
-				DeepCheck: false,
-				Force:     false,
-				AwsCredentials: client.AwsCredentials{
-					Profile: "production",
-					Region:  "us-east-1",
-				},
-				IgnoreModules:     map[string]bool{},
-				Varfiles:          []string{},
-				Variables:         []string{},
-				DisabledByDefault: false,
-				Rules:             map[string]*tflint.RuleConfig{},
-				Plugins:           map[string]*tflint.PluginConfig{},
-			},
-		},
-		{
-			Name:    "AWS shared credentials in another file",
-			Command: "./tflint --aws-creds-file ~/.aws/myapp --aws-profile production --aws-region us-east-1",
-			Expected: &tflint.Config{
-				Module:    false,
-				DeepCheck: false,
-				Force:     false,
-				AwsCredentials: client.AwsCredentials{
-					CredsFile: "~/.aws/myapp",
-					Profile:   "production",
-					Region:    "us-east-1",
-				},
 				IgnoreModules:     map[string]bool{},
 				Varfiles:          []string{},
 				Variables:         []string{},
@@ -135,9 +55,7 @@ func Test_toConfig(t *testing.T) {
 			Command: "./tflint --ignore-module module1,module2",
 			Expected: &tflint.Config{
 				Module:            false,
-				DeepCheck:         false,
 				Force:             false,
-				AwsCredentials:    client.AwsCredentials{},
 				IgnoreModules:     map[string]bool{"module1": true, "module2": true},
 				Varfiles:          []string{},
 				Variables:         []string{},
@@ -151,9 +69,7 @@ func Test_toConfig(t *testing.T) {
 			Command: "./tflint --ignore-module module1 --ignore-module module2",
 			Expected: &tflint.Config{
 				Module:            false,
-				DeepCheck:         false,
 				Force:             false,
-				AwsCredentials:    client.AwsCredentials{},
 				IgnoreModules:     map[string]bool{"module1": true, "module2": true},
 				Varfiles:          []string{},
 				Variables:         []string{},
@@ -167,9 +83,7 @@ func Test_toConfig(t *testing.T) {
 			Command: "./tflint --var-file example1.tfvars,example2.tfvars",
 			Expected: &tflint.Config{
 				Module:            false,
-				DeepCheck:         false,
 				Force:             false,
-				AwsCredentials:    client.AwsCredentials{},
 				IgnoreModules:     map[string]bool{},
 				Varfiles:          []string{"example1.tfvars", "example2.tfvars"},
 				Variables:         []string{},
@@ -183,9 +97,7 @@ func Test_toConfig(t *testing.T) {
 			Command: "./tflint --var-file example1.tfvars --var-file example2.tfvars",
 			Expected: &tflint.Config{
 				Module:            false,
-				DeepCheck:         false,
 				Force:             false,
-				AwsCredentials:    client.AwsCredentials{},
 				IgnoreModules:     map[string]bool{},
 				Varfiles:          []string{"example1.tfvars", "example2.tfvars"},
 				Variables:         []string{},
@@ -199,9 +111,7 @@ func Test_toConfig(t *testing.T) {
 			Command: "./tflint --var foo=bar --var bar=baz",
 			Expected: &tflint.Config{
 				Module:            false,
-				DeepCheck:         false,
 				Force:             false,
-				AwsCredentials:    client.AwsCredentials{},
 				IgnoreModules:     map[string]bool{},
 				Varfiles:          []string{},
 				Variables:         []string{"foo=bar", "bar=baz"},
@@ -215,9 +125,7 @@ func Test_toConfig(t *testing.T) {
 			Command: "./tflint --enable-rule aws_instance_invalid_type --enable-rule aws_instance_previous_type",
 			Expected: &tflint.Config{
 				Module:            false,
-				DeepCheck:         false,
 				Force:             false,
-				AwsCredentials:    client.AwsCredentials{},
 				IgnoreModules:     map[string]bool{},
 				Varfiles:          []string{},
 				Variables:         []string{},
@@ -242,9 +150,7 @@ func Test_toConfig(t *testing.T) {
 			Command: "./tflint --disable-rule aws_instance_invalid_type --disable-rule aws_instance_previous_type",
 			Expected: &tflint.Config{
 				Module:            false,
-				DeepCheck:         false,
 				Force:             false,
-				AwsCredentials:    client.AwsCredentials{},
 				IgnoreModules:     map[string]bool{},
 				Varfiles:          []string{},
 				Variables:         []string{},
@@ -269,9 +175,7 @@ func Test_toConfig(t *testing.T) {
 			Command: "./tflint --only aws_instance_invalid_type",
 			Expected: &tflint.Config{
 				Module:            false,
-				DeepCheck:         false,
 				Force:             false,
-				AwsCredentials:    client.AwsCredentials{},
 				IgnoreModules:     map[string]bool{},
 				Varfiles:          []string{},
 				Variables:         []string{},

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -75,28 +75,6 @@ func NewRunner(c *Config, files map[string]*hcl.File, ants map[string]Annotation
 		config:      c,
 	}
 
-	// Initialize client for the root runner
-	if c.DeepCheck && cfg.Path.IsRoot() {
-		// FIXME: Alias providers are not considered
-		providerConfig, err := NewProviderConfig(
-			cfg.Module.ProviderConfigs["aws"],
-			runner,
-			client.AwsProviderBlockSchema,
-		)
-		if err != nil {
-			return nil, err
-		}
-		creds, err := client.ConvertToCredentials(providerConfig)
-		if err != nil {
-			return nil, err
-		}
-
-		runner.AwsClient, err = client.NewAwsClient(c.AwsCredentials.Merge(creds))
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return runner, nil
 }
 

--- a/tflint/test-fixtures/config/aws_credentials.hcl
+++ b/tflint/test-fixtures/config/aws_credentials.hcl
@@ -1,0 +1,9 @@
+config {
+  aws_credentials = {
+    access_key              = "AWS_ACCESS_KEY"
+    secret_key              = "AWS_SECRET_KEY"
+    region                  = "us-east-1"
+    profile                 = "production"
+    shared_credentials_file = "~/.aws/myapp"
+  }
+}

--- a/tflint/test-fixtures/config/config.hcl
+++ b/tflint/test-fixtures/config/config.hcl
@@ -1,15 +1,6 @@
 config {
   module = true
-  deep_check = true
   force = true
-
-  aws_credentials = {
-    access_key              = "AWS_ACCESS_KEY"
-    secret_key              = "AWS_SECRET_KEY"
-    region                  = "us-east-1"
-    profile                 = "production"
-    shared_credentials_file = "~/.aws/myapp"
-  }
 
   ignore_module = {
     "github.com/terraform-linters/example-module" = true

--- a/tflint/test-fixtures/config/deep_check.hcl
+++ b/tflint/test-fixtures/config/deep_check.hcl
@@ -1,0 +1,3 @@
+config {
+  deep_check = true
+}

--- a/tflint/test-fixtures/config/fallback.hcl
+++ b/tflint/test-fixtures/config/fallback.hcl
@@ -1,11 +1,4 @@
 config {
-  deep_check = true
   force = true
   disabled_by_default = true
-
-  aws_credentials = {
-    access_key = "AWS_ACCESS_KEY"
-    secret_key = "AWS_SECRET_KEY"
-    region     = "us-east-1"
-  }
 }

--- a/tflint/test-fixtures/config/terraform_version.hcl
+++ b/tflint/test-fixtures/config/terraform_version.hcl
@@ -1,10 +1,3 @@
 config {
   terraform_version = "0.12.13"
-  deep_check = true
-
-  aws_credentials = {
-    access_key = "AWS_ACCESS_KEY"
-    secret_key = "AWS_SECRET_KEY"
-    region     = "us-east-1"
-  }
 }


### PR DESCRIPTION
As AWS rules migrated to plugins in https://github.com/terraform-linters/tflint/pull/1009, remove the global deep checking option and AWS credentials configuration.

I plan to remove the relevant AWS rules implementation in another pull request.