### PR TITLE
Added rule to check "this" name for single resource of a type

### DIFF
--- a/docs/rules/terraform_naming_this.md
+++ b/docs/rules/terraform_naming_this.md
@@ -1,0 +1,36 @@
+# terraform_naming_this
+
+Enforces that resources are named "this" if only a single resource of this type is present.
+
+This rule is based on point 2 from the [Terraform Best Practices for naming](https://www.terraform-best-practices.com/naming)
+
+## Example
+
+```hcl
+resource "aws_s3_bucket" "wrong_name" {
+  bucket = "test-bucket"
+}
+```
+
+```
+$ tflint
+1 issue(s) found:
+
+Notice: Found only one resource of type `aws_s3_bucket`, therefore the resource name should be `this` but was `wrong_name` (terraform_naming_this)
+
+  on main.tf line 1:
+   1: resource "aws_s3_bucket" "wrong_name" {
+
+Reference: https://github.com/terraform-linters/tflint/blob/v0.23.1/docs/rules/terraform_naming_this.md
+
+```
+
+## How To Fix
+
+Change the resource name to "this".
+
+```hcl
+resource "aws_s3_bucket" "this" {
+  bucket = "test-bucket"
+}
+```

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -23,6 +23,7 @@ var DefaultRules = []Rule{
 	terraformrules.NewTerraformDocumentedVariablesRule(),
 	terraformrules.NewTerraformModulePinnedSourceRule(),
 	terraformrules.NewTerraformNamingConventionRule(),
+	terraformrules.NewTerraformNamingThisRule(),
 	terraformrules.NewTerraformStandardModuleStructureRule(),
 	terraformrules.NewTerraformTypedVariablesRule(),
 	terraformrules.NewTerraformRequiredVersionRule(),

--- a/rules/terraformrules/terraform_naming_this.go
+++ b/rules/terraformrules/terraform_naming_this.go
@@ -1,0 +1,66 @@
+package terraformrules
+
+import (
+	"fmt"
+
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+// TerraformNamingThisRule checks whether blocks follow naming convention
+type TerraformNamingThisRule struct{}
+
+// NewTerraformNamingThisRule returns new rule with default attributes
+func NewTerraformNamingThisRule() *TerraformNamingThisRule {
+	return &TerraformNamingThisRule{}
+}
+
+// Name returns the rule name
+func (r *TerraformNamingThisRule) Name() string {
+	return "terraform_naming_this"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformNamingThisRule) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *TerraformNamingThisRule) Severity() string {
+	return tflint.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *TerraformNamingThisRule) Link() string {
+	return tflint.ReferenceLink(r.Name())
+}
+
+// Check checks whether blocks follow naming convention
+func (r *TerraformNamingThisRule) Check(runner *tflint.Runner) error {
+	if !runner.TFConfig.Path.IsRoot() {
+		// This rule does not evaluate child modules.
+		return nil
+	}
+	managedResources := runner.TFConfig.Module.ManagedResources
+
+	// Group resources
+	countPerType := make(map[string]int)
+	for _, resource := range managedResources {
+		val, _ := countPerType[resource.Type]
+		countPerType[resource.Type] = val + 1
+	}
+
+	// Find resources with wrong name
+	for _, resource := range managedResources {
+		amount, _ := countPerType[resource.Type]
+
+		if amount == 1 && resource.Name != "this" {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("Found only one resource of type `%s`, therefore the resource name should be `this` but was `%s`", resource.Type, resource.Name),
+				resource.DeclRange,
+			)
+		}
+	}
+
+	return nil
+}

--- a/rules/terraformrules/terraform_naming_this.go
+++ b/rules/terraformrules/terraform_naming_this.go
@@ -45,8 +45,7 @@ func (r *TerraformNamingThisRule) Check(runner *tflint.Runner) error {
 	// Group resources
 	countPerType := make(map[string]int)
 	for _, resource := range managedResources {
-		val, _ := countPerType[resource.Type]
-		countPerType[resource.Type] = val + 1
+		countPerType[resource.Type]++
 	}
 
 	// Find resources with wrong name

--- a/rules/terraformrules/terraform_naming_this_test.go
+++ b/rules/terraformrules/terraform_naming_this_test.go
@@ -1,0 +1,70 @@
+package terraformrules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_TerraformNamingThisRule(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		JSON     bool
+		Expected tflint.Issues
+	}{
+		{
+			Name: "single resource with wrong name",
+			Content: `
+resource "test_type" "wrong_name" {}
+`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformNamingThisRule(),
+					Message: "Found only one resource of type `test_type`, therefore the resource name should be `this` but was `wrong_name`",
+					Range: hcl.Range{
+						Filename: "main.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1},
+						End:      hcl.Pos{Line: 2, Column: 34},
+					},
+				},
+			},
+		},
+		{
+			Name: "single resource with correct name",
+			Content: `
+resource "test_type" "this" {}
+`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "multiple resources of same type with correct name",
+			Content: `
+resource "test_type" "a" {}
+
+resource "test_type" "b" {}
+`,
+			Expected: tflint.Issues{},
+		},
+	}
+
+	rule := NewTerraformNamingThisRule()
+
+	for _, tc := range cases {
+		filename := "main.tf"
+		if tc.JSON {
+			filename += ".json"
+		}
+
+		t.Run(tc.Name, func(t *testing.T) {
+			runner := tflint.TestRunner(t, map[string]string{filename: tc.Content})
+
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
+
+			tflint.AssertIssues(t, tc.Expected, runner.Issues)
+		})
+	}
+}


### PR DESCRIPTION
This rule checks for point 2 from the [Terraform Best Practices for naming](https://www.terraform-best-practices.com/naming)

Resource name should be named this if there is no more descriptive and general name available, or if resource module creates single resource of this type (eg, there is single resource of type aws_nat_gateway and multiple resources of typeaws_route_table, so aws_nat_gateway should be named this and aws_route_table should have more descriptive names - like private, public, database).