### PR TITLE
Fix panic on empty backend in Config()

### DIFF
--- a/plugin/encode.go
+++ b/plugin/encode.go
@@ -268,6 +268,10 @@ func (s *Server) encodeProvisioner(provisioner *tfconfigs.Provisioner) *tfplugin
 }
 
 func (s *Server) encodeBackend(backend *tfconfigs.Backend) *tfplugin.Backend {
+	if backend == nil {
+		return &tfplugin.Backend{}
+	}
+
 	configRange := tflint.HCLBodyRange(backend.Config, backend.DeclRange)
 	config := []byte{}
 	if configRange.Empty() {

--- a/plugin/encode.go
+++ b/plugin/encode.go
@@ -269,7 +269,7 @@ func (s *Server) encodeProvisioner(provisioner *tfconfigs.Provisioner) *tfplugin
 
 func (s *Server) encodeBackend(backend *tfconfigs.Backend) *tfplugin.Backend {
 	if backend == nil {
-		return &tfplugin.Backend{}
+		return nil
 	}
 
 	configRange := tflint.HCLBodyRange(backend.Config, backend.DeclRange)

--- a/plugin/server_test.go
+++ b/plugin/server_test.go
@@ -414,7 +414,6 @@ resource "aws_s3_bucket" "bar" {
 			CoreVersionConstraints: []string{},
 			CoreVersionConstraintRanges: []hcl.Range{},
 			ActiveExperiments: experiments.Set{},
-			Backend: &tfplugin.Backend{},
 			ProviderConfigs: map[string]*tfplugin.Provider{},
 			ProviderRequirements: &tfplugin.RequiredProviders{
 				RequiredProviders: map[string]*tfplugin.RequiredProvider{},

--- a/plugin/server_test.go
+++ b/plugin/server_test.go
@@ -8,6 +8,7 @@ import (
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/addrs"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/experiments"
 	client "github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	tfplugin "github.com/terraform-linters/tflint-plugin-sdk/tflint/client"
 	"github.com/terraform-linters/tflint/tflint"
@@ -356,5 +357,186 @@ func Test_EmitIssue(t *testing.T) {
 	}
 	if !cmp.Equal(expected, runner.Issues) {
 		t.Fatalf("Issue are not matched: %s", cmp.Diff(expected, runner.Issues))
+	}
+}
+
+func Test_Config(t *testing.T) {
+	source := `
+resource "aws_instance" "foo" {
+  provider = aws.west
+  count = 1
+
+  instance_type = "t2.micro"
+
+  connection {
+    type = "ssh"
+  }
+
+  provisioner "local-exec" {
+    command    = "chmod 600 ssh-key.pem"
+    when       = destroy
+    on_failure = continue
+
+    connection {
+      type = "ssh"
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = true
+    ignore_changes        = all
+  }
+}
+
+resource "aws_s3_bucket" "bar" {
+  bucket = "my-tf-test-bucket"
+  acl    = "private"
+}`
+
+	runner := tflint.TestRunner(t, map[string]string{"main.tf": source})
+	server := NewServer(runner, runner, map[string][]byte{"main.tf": []byte(source)})
+	req := &tfplugin.ConfigRequest{}
+	var resp tfplugin.ConfigResponse
+
+	err := server.Config(req, &resp)
+	if err != nil {
+		t.Fatalf("Unexpected error occurred: %s", err)
+	}
+
+	if resp.Err != nil {
+		t.Fatalf("The response has an unexpected error: %s", resp.Err)
+	}
+
+	expected := &tfplugin.Config{
+		Module: &tfplugin.Module{
+			SourceDir: ".",
+			CoreVersionConstraints: []string{},
+			CoreVersionConstraintRanges: []hcl.Range{},
+			ActiveExperiments: experiments.Set{},
+			Backend: &tfplugin.Backend{},
+			ProviderConfigs: map[string]*tfplugin.Provider{},
+			ProviderRequirements: &tfplugin.RequiredProviders{
+				RequiredProviders: map[string]*tfplugin.RequiredProvider{},
+			},
+			ProviderLocalNames: map[addrs.Provider]string{},
+			ProviderMetas: map[addrs.Provider]*tfplugin.ProviderMeta{},
+			Variables: map[string]*tfplugin.Variable{},
+			Locals: map[string]*tfplugin.Local{},
+			Outputs: map[string]*tfplugin.Output{},
+			ModuleCalls: map[string]*tfplugin.ModuleCall{},
+			ManagedResources: map[string]*tfplugin.Resource{
+				"aws_instance.foo": {
+					Mode: addrs.ManagedResourceMode,
+					Name: "foo",
+					Type: "aws_instance",
+					Config: []byte(`provider = aws.west
+  count = 1
+
+  instance_type = "t2.micro"
+
+  connection {
+    type = "ssh"
+  }
+
+  provisioner "local-exec" {
+    command    = "chmod 600 ssh-key.pem"
+    when       = destroy
+    on_failure = continue
+
+    connection {
+      type = "ssh"
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = true
+    ignore_changes        = all
+  }`),
+					ConfigRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 3, Column: 3}, End: hcl.Pos{Line: 26, Column: 4}},
+					Count:       []byte(`1`),
+					CountRange:  hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 4, Column: 11}, End: hcl.Pos{Line: 4, Column: 12}},
+
+					ProviderConfigRef: &configs.ProviderConfigRef{
+						Name:       "aws",
+						NameRange:  hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 3, Column: 14}, End: hcl.Pos{Line: 3, Column: 17}},
+						Alias:      "west",
+						AliasRange: &hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 3, Column: 17}, End: hcl.Pos{Line: 3, Column: 22}},
+					},
+					Provider: addrs.Provider{
+						Type:      "aws",
+						Namespace: "hashicorp",
+						Hostname:  "registry.terraform.io",
+					},
+
+					Managed: &tfplugin.ManagedResource{
+						Connection: &tfplugin.Connection{
+							Config:      []byte(`type = "ssh"`),
+							ConfigRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 9, Column: 5}, End: hcl.Pos{Line: 9, Column: 17}},
+							DeclRange:   hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 8, Column: 3}, End: hcl.Pos{Line: 8, Column: 13}},
+						},
+						Provisioners: []*tfplugin.Provisioner{
+							{
+								Type: "local-exec",
+								Config: []byte(`command    = "chmod 600 ssh-key.pem"
+    when       = destroy
+    on_failure = continue
+
+    connection {
+      type = "ssh"
+    }`),
+								ConfigRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 13, Column: 5}, End: hcl.Pos{Line: 19, Column: 6}},
+								Connection: &tfplugin.Connection{
+									Config:      []byte(`type = "ssh"`),
+									ConfigRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 18, Column: 7}, End: hcl.Pos{Line: 18, Column: 19}},
+									DeclRange:   hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 17, Column: 5}, End: hcl.Pos{Line: 17, Column: 15}},
+								},
+								When:      configs.ProvisionerWhenDestroy,
+								OnFailure: configs.ProvisionerOnFailureContinue,
+								DeclRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 12, Column: 3}, End: hcl.Pos{Line: 12, Column: 27}},
+								TypeRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 12, Column: 15}, End: hcl.Pos{Line: 12, Column: 27}},
+							},
+						},
+
+						CreateBeforeDestroy:    true,
+						PreventDestroy:         true,
+						IgnoreAllChanges:       true,
+						CreateBeforeDestroySet: true,
+						PreventDestroySet:      true,
+					},
+
+					DeclRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 2, Column: 1}, End: hcl.Pos{Line: 2, Column: 30}},
+					TypeRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 2, Column: 10}, End: hcl.Pos{Line: 2, Column: 24}},
+				},
+				"aws_s3_bucket.bar": {
+					Mode: addrs.ManagedResourceMode,
+					Name: "bar",
+					Type: "aws_s3_bucket",
+					Config: []byte(`bucket = "my-tf-test-bucket"
+  acl    = "private"`),
+					ConfigRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 30, Column: 3}, End: hcl.Pos{Line: 31, Column: 21}},
+
+					Provider: addrs.Provider{
+						Type:      "aws",
+						Namespace: "hashicorp",
+						Hostname:  "registry.terraform.io",
+					},
+
+					Managed: &tfplugin.ManagedResource{
+						Provisioners: []*tfplugin.Provisioner{},
+					},
+
+					DeclRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 29, Column: 1}, End: hcl.Pos{Line: 29, Column: 31}},
+					TypeRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 29, Column: 10}, End: hcl.Pos{Line: 29, Column: 25}},
+				},
+			},
+			DataResources: map[string]*tfplugin.Resource{},
+		},
+	}
+
+	opt := cmpopts.IgnoreFields(hcl.Pos{}, "Byte")
+	if !cmp.Equal(expected, resp.Config, opt) {
+		t.Fatalf("Config is not matched: %s", cmp.Diff(expected, resp.Config, opt))
 	}
 }


### PR DESCRIPTION
Config() method causes panic when used in plugins if backend config is non-existent

Related:
terraform-linters/tflint-plugin-sdk#95
