### PR TITLE
Fix gob encoder error on unknown value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/spf13/afero v1.2.2 // matches version used by terraform
-	github.com/terraform-linters/tflint-plugin-sdk v0.7.1
+	github.com/terraform-linters/tflint-plugin-sdk v0.7.2-0.20210122131937-06d5c0a30889
 	github.com/terraform-linters/tflint-ruleset-aws v0.1.2
 	github.com/zclconf/go-cty v1.7.1
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/spf13/afero v1.2.2 // matches version used by terraform
-	github.com/terraform-linters/tflint-plugin-sdk v0.7.2-0.20210122131937-06d5c0a30889
+	github.com/terraform-linters/tflint-plugin-sdk v0.7.2-0.20210123071514-b11b475d5d1a
 	github.com/terraform-linters/tflint-ruleset-aws v0.1.2
 	github.com/zclconf/go-cty v1.7.1
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b

--- a/go.sum
+++ b/go.sum
@@ -564,6 +564,8 @@ github.com/terraform-linters/tflint-plugin-sdk v0.7.1 h1:niUaK6UDwn0TN/o9s5x0dwa
 github.com/terraform-linters/tflint-plugin-sdk v0.7.1/go.mod h1:W7TLf8fDD55uivE/vbOI5FqeQm7EEj/VKfnkWloUx0g=
 github.com/terraform-linters/tflint-plugin-sdk v0.7.2-0.20210122131937-06d5c0a30889 h1:RWAk9FkP4EPtCJWhc6jfCffxB10i5GFZRmhmuKMStrA=
 github.com/terraform-linters/tflint-plugin-sdk v0.7.2-0.20210122131937-06d5c0a30889/go.mod h1:W7TLf8fDD55uivE/vbOI5FqeQm7EEj/VKfnkWloUx0g=
+github.com/terraform-linters/tflint-plugin-sdk v0.7.2-0.20210123071514-b11b475d5d1a h1:E74Ws22HjB8ZklWBGI8WYAU9htTxsVj4ZCa/91G/ofA=
+github.com/terraform-linters/tflint-plugin-sdk v0.7.2-0.20210123071514-b11b475d5d1a/go.mod h1:W7TLf8fDD55uivE/vbOI5FqeQm7EEj/VKfnkWloUx0g=
 github.com/terraform-linters/tflint-ruleset-aws v0.1.2 h1:7ecjcx7d59mqmdzFZ8dQ23u8p5tXlFm80H/89zqe6f8=
 github.com/terraform-linters/tflint-ruleset-aws v0.1.2/go.mod h1:0EnwgqFqsZVxfa2KcWgL4L7ZxNlI3GxgHXqQtlov6ds=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201218215723-9c9a116a857f/go.mod h1:2B6zmpR+B4j3Ah6DV3rngOxmPhQXIuVf2b5PDYvc1zo=

--- a/go.sum
+++ b/go.sum
@@ -562,6 +562,8 @@ github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYo
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
 github.com/terraform-linters/tflint-plugin-sdk v0.7.1 h1:niUaK6UDwn0TN/o9s5x0dwaqW1eahzLOmoYaC5myz5w=
 github.com/terraform-linters/tflint-plugin-sdk v0.7.1/go.mod h1:W7TLf8fDD55uivE/vbOI5FqeQm7EEj/VKfnkWloUx0g=
+github.com/terraform-linters/tflint-plugin-sdk v0.7.2-0.20210122131937-06d5c0a30889 h1:RWAk9FkP4EPtCJWhc6jfCffxB10i5GFZRmhmuKMStrA=
+github.com/terraform-linters/tflint-plugin-sdk v0.7.2-0.20210122131937-06d5c0a30889/go.mod h1:W7TLf8fDD55uivE/vbOI5FqeQm7EEj/VKfnkWloUx0g=
 github.com/terraform-linters/tflint-ruleset-aws v0.1.2 h1:7ecjcx7d59mqmdzFZ8dQ23u8p5tXlFm80H/89zqe6f8=
 github.com/terraform-linters/tflint-ruleset-aws v0.1.2/go.mod h1:0EnwgqFqsZVxfa2KcWgL4L7ZxNlI3GxgHXqQtlov6ds=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20201218215723-9c9a116a857f/go.mod h1:2B6zmpR+B4j3Ah6DV3rngOxmPhQXIuVf2b5PDYvc1zo=

--- a/plugin/encode.go
+++ b/plugin/encode.go
@@ -8,6 +8,7 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/experiments"
 	tfplugin "github.com/terraform-linters/tflint-plugin-sdk/tflint/client"
 	"github.com/zclconf/go-cty/cty/msgpack"
+	"github.com/zclconf/go-cty/cty/json"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -362,12 +363,13 @@ func (s *Server) encodeVariable(variable *tfconfigs.Variable) *tfplugin.Variable
 	}
 
 	defaultVal, _ := msgpack.Marshal(variable.Default, variable.Default.Type())
-
+	// We need to use json because cty.DynamicPseudoType cannot be encoded by gob
+	typeVal, _ := json.MarshalType(variable.Type)
 	return &tfplugin.Variable{
 		Name:        variable.Name,
 		Description: variable.Description,
 		Default:     defaultVal,
-		Type:        variable.Type,
+		Type:        typeVal,
 		ParsingMode: configs.VariableParsingMode(variable.ParsingMode),
 		Validations: validations,
 		Sensitive:   variable.Sensitive,

--- a/plugin/encode.go
+++ b/plugin/encode.go
@@ -7,6 +7,7 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/experiments"
 	tfplugin "github.com/terraform-linters/tflint-plugin-sdk/tflint/client"
+	"github.com/zclconf/go-cty/cty"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -360,10 +361,15 @@ func (s *Server) encodeVariable(variable *tfconfigs.Variable) *tfplugin.Variable
 		validations[i] = s.encodeVariableValidation(v)
 	}
 
+	defaultVal := variable.Default
+	if !defaultVal.IsKnown() {
+		defaultVal = cty.Value{}
+	}
+
 	return &tfplugin.Variable{
 		Name:        variable.Name,
 		Description: variable.Description,
-		Default:     variable.Default,
+		Default:     defaultVal,
 		Type:        variable.Type,
 		ParsingMode: configs.VariableParsingMode(variable.ParsingMode),
 		Validations: validations,

--- a/plugin/encode.go
+++ b/plugin/encode.go
@@ -12,23 +12,28 @@ import (
 	"github.com/terraform-linters/tflint/tflint"
 )
 
-func (s *Server) encodeConfig(config *tfconfigs.Config) *tfplugin.Config {
+func (s *Server) encodeConfig(config *tfconfigs.Config) (*tfplugin.Config, error) {
 	var versionStr string
 	if config.Version != nil {
 		versionStr = config.Version.String()
 	}
 
+	module, err := s.encodeModule(config.Module)
+	if err != nil {
+		return nil, err
+	}
+
 	return &tfplugin.Config{
 		Path:            addrs.Module(config.Path),
-		Module:          s.encodeModule(config.Module),
+		Module:          module,
 		CallRange:       config.CallRange,
 		SourceAddr:      config.SourceAddr,
 		SourceAddrRange: config.SourceAddrRange,
 		Version:         versionStr,
-	}
+	}, nil
 }
 
-func (s *Server) encodeModule(module *tfconfigs.Module) *tfplugin.Module {
+func (s *Server) encodeModule(module *tfconfigs.Module) (*tfplugin.Module, error) {
 	versionConstraints := make([]string, len(module.CoreVersionConstraints))
 	versionConstraintRanges := make([]hcl.Range, len(module.CoreVersionConstraints))
 	for i, v := range module.CoreVersionConstraints {
@@ -58,7 +63,11 @@ func (s *Server) encodeModule(module *tfconfigs.Module) *tfplugin.Module {
 
 	variables := map[string]*tfplugin.Variable{}
 	for k, v := range module.Variables {
-		variables[k] = s.encodeVariable(v)
+		var err error
+		variables[k], err = s.encodeVariable(v)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	locals := map[string]*tfplugin.Local{}
@@ -107,7 +116,7 @@ func (s *Server) encodeModule(module *tfconfigs.Module) *tfplugin.Module {
 
 		ManagedResources: managed,
 		DataResources:    data,
-	}
+	}, nil
 }
 
 func (s *Server) encodeResource(resource *tfconfigs.Resource) *tfplugin.Resource {
@@ -356,15 +365,21 @@ func (s *Server) encodeProviderMeta(meta *tfconfigs.ProviderMeta) *tfplugin.Prov
 	}
 }
 
-func (s *Server) encodeVariable(variable *tfconfigs.Variable) *tfplugin.Variable {
+func (s *Server) encodeVariable(variable *tfconfigs.Variable) (*tfplugin.Variable, error) {
 	validations := make([]*tfplugin.VariableValidation, len(variable.Validations))
 	for i, v := range variable.Validations {
 		validations[i] = s.encodeVariableValidation(v)
 	}
 
-	defaultVal, _ := msgpack.Marshal(variable.Default, variable.Default.Type())
+	defaultVal, err := msgpack.Marshal(variable.Default, variable.Default.Type())
+	if err != nil {
+		return nil, err
+	}
 	// We need to use json because cty.DynamicPseudoType cannot be encoded by gob
-	typeVal, _ := json.MarshalType(variable.Type)
+	typeVal, err := json.MarshalType(variable.Type)
+	if err != nil {
+		return nil, err
+	}
 	return &tfplugin.Variable{
 		Name:        variable.Name,
 		Description: variable.Description,
@@ -378,7 +393,7 @@ func (s *Server) encodeVariable(variable *tfconfigs.Variable) *tfplugin.Variable
 		SensitiveSet:   variable.SensitiveSet,
 
 		DeclRange: variable.DeclRange,
-	}
+	}, nil
 }
 
 func (s *Server) encodeVariableValidation(validation *tfconfigs.VariableValidation) *tfplugin.VariableValidation {

--- a/plugin/encode.go
+++ b/plugin/encode.go
@@ -7,7 +7,7 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/experiments"
 	tfplugin "github.com/terraform-linters/tflint-plugin-sdk/tflint/client"
-	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/msgpack"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -361,10 +361,7 @@ func (s *Server) encodeVariable(variable *tfconfigs.Variable) *tfplugin.Variable
 		validations[i] = s.encodeVariableValidation(v)
 	}
 
-	defaultVal := variable.Default
-	if !defaultVal.IsKnown() {
-		defaultVal = cty.Value{}
-	}
+	defaultVal, _ := msgpack.Marshal(variable.Default, variable.Default.Type())
 
 	return &tfplugin.Variable{
 		Name:        variable.Name,

--- a/plugin/server.go
+++ b/plugin/server.go
@@ -97,8 +97,12 @@ func (s *Server) Backend(req *tfplugin.BackendRequest, resp *tfplugin.BackendRes
 
 // Config returns corresponding configs.Config as tfplugin.Config
 func (s *Server) Config(req *tfplugin.ConfigRequest, resp *tfplugin.ConfigResponse) error {
+	config, err := s.encodeConfig(s.runner.TFConfig)
+	if err != nil {
+		return err
+	}
 	*resp = tfplugin.ConfigResponse{
-		Config: s.encodeConfig(s.runner.TFConfig),
+		Config: config,
 	}
 
 	return nil


### PR DESCRIPTION
When using Config() method with `--module` option you can get cty.unknownType inside module variables without default values and following error:
```
13:39:46 server.go:418: rpc: gob error encoding body: error encoding cty.Value: gob: type not registered for interface: cty.unknownType
```
This fix forces cty.Value{} in case of unknown value