### PR TITLE
Versions are stored with a preceeding "v"

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -41,7 +41,7 @@ else
 fi
 
 echo "Downloading TFLint $version"
-curl -L -o /tmp/tflint.zip "https://github.com/terraform-linters/tflint/releases/download/${version}/tflint_${os}.zip"
+curl -L -o /tmp/tflint.zip "https://github.com/terraform-linters/tflint/releases/download/v${version}/tflint_${os}.zip"
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo "Failed to download tflint_${os}.zip"


### PR DESCRIPTION
I was getting the same error as #880 when installing as part of a docker build. Taking a look, it appears that a missing 'v' was causing a 404. 