### PR TITLE
go: cache builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,11 @@ jobs:
     - name: Restore Cache
       uses: actions/cache@v2.1.3
       with:
-        path: ~/go/pkg/mod
+        path: |-
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          %LocalAppData%\go-build
         key: ${{ matrix.os }}-go-${{ hashFiles('go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-


### PR DESCRIPTION
Cache the results of Go builds in addition to modules. This should speed up the initial `go test` run in the `build` job.