### PR TITLE
Bump tflint-plugin-sdk and bundled plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/spf13/afero v1.2.2 // matches version used by terraform
-	github.com/terraform-linters/tflint-plugin-sdk v0.8.0
-	github.com/terraform-linters/tflint-ruleset-aws v0.2.0
+	github.com/terraform-linters/tflint-plugin-sdk v0.8.1
+	github.com/terraform-linters/tflint-ruleset-aws v0.2.1
 	github.com/zclconf/go-cty v1.7.1
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 )

--- a/go.sum
+++ b/go.sum
@@ -552,10 +552,10 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
-github.com/terraform-linters/tflint-plugin-sdk v0.8.0 h1:+9LzYNTg+s+Lf9riNAa+0AaEdgaroD46ZmJwbAXzkFY=
-github.com/terraform-linters/tflint-plugin-sdk v0.8.0/go.mod h1:A/6/RIqmPGmLWnI1JZef2Tyzw7/MFTl6t6G0BH9qALA=
-github.com/terraform-linters/tflint-ruleset-aws v0.2.0 h1:bJS1leYt/ZXMDvMh4QUg6iGd7jONcs8vSnWd4lzn2r8=
-github.com/terraform-linters/tflint-ruleset-aws v0.2.0/go.mod h1:q/yMfaJVgeFcfUgJHFBtTEAHZ9nKz/xOCAvpJlCQt/8=
+github.com/terraform-linters/tflint-plugin-sdk v0.8.1 h1:KklKztWgRzvZLSi77GFU2y/jaA/e+OUWEV3bdouzPWw=
+github.com/terraform-linters/tflint-plugin-sdk v0.8.1/go.mod h1:A/6/RIqmPGmLWnI1JZef2Tyzw7/MFTl6t6G0BH9qALA=
+github.com/terraform-linters/tflint-ruleset-aws v0.2.1 h1:fT9oGCkqKh66gHXdoKKNMprzC+SzUIuZIhdTD0seSRQ=
+github.com/terraform-linters/tflint-ruleset-aws v0.2.1/go.mod h1:9WyZWmZoTC7ckUEOzoc32KuJCMi4rVI5ongnBmGk2k8=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210128214539-ac3363c699ef/go.mod h1:2FJRHL/0yjp+iYXWoW2v4U80Zkz+mGHsHOB/Jdbw7AI=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tombuildsstuff/giovanni v0.12.0/go.mod h1:qJ5dpiYWkRsuOSXO8wHbee7+wElkLNfWVolcf59N84E=

--- a/integrationtest/bundled/bundled_test.go
+++ b/integrationtest/bundled/bundled_test.go
@@ -51,6 +51,12 @@ func TestBundledPlugin(t *testing.T) {
 			Command: "tflint --format json --force",
 			Dir:     "heredoc",
 		},
+		{
+			// Regression: https://github.com/terraform-linters/tflint/issues/1054
+			Name:    "disabled-rules",
+			Command: "tflint --format json --force",
+			Dir:     "disabled-rules",
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/integrationtest/bundled/disabled-rules/.tflint.hcl
+++ b/integrationtest/bundled/disabled-rules/.tflint.hcl
@@ -1,0 +1,11 @@
+plugin "aws" {
+  enabled = true
+}
+
+rule "aws_instance_invalid_type" {
+  enabled = true
+}
+
+rule "aws_instance_previous_type" {
+  enabled = false
+}

--- a/integrationtest/bundled/disabled-rules/result.json
+++ b/integrationtest/bundled/disabled-rules/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_instance_invalid_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "\"t1.2xlarge\" is an invalid value as instance_type",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 2,
+          "column": 19
+        },
+        "end": {
+          "line": 2,
+          "column": 31
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/bundled/disabled-rules/template.tf
+++ b/integrationtest/bundled/disabled-rules/template.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "invalid" {
+  instance_type = "t1.2xlarge"
+}
+
+resource "aws_instance" "previous" {
+  instance_type = "t1.micro"
+}

--- a/integrationtest/bundled/rule-config/result.json
+++ b/integrationtest/bundled/rule-config/result.json
@@ -4,7 +4,7 @@
       "rule": {
         "name": "aws_s3_bucket_name",
         "severity": "warning",
-        "link": "https://github.com/terraform-linters/tflint-ruleset-aws/blob/v0.2.0/docs/rules/aws_s3_bucket_name.md"
+        "link": "https://github.com/terraform-linters/tflint-ruleset-aws/blob/v0.2.1/docs/rules/aws_s3_bucket_name.md"
       },
       "message": "Bucket name \"foo_bar\" does not match regex \"^[a-z\\-]+$\"",
       "range": {


### PR DESCRIPTION
- tflint-plugin-sdk
  - v0.8.0 => v0.8.1
- tflint-ruleset-aws
  - v0.2.0 => v0.2.1

This update includes a bugfix about https://github.com/terraform-linters/tflint/issues/1054.