### PR TITLE
docker: remove unused build tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.15-alpine3.12 as builder
 
-RUN apk --no-cache add git make gcc musl-dev zip
+RUN apk add --no-cache make
 
 WORKDIR /tflint
-ADD . /tflint
+COPY . /tflint
 RUN make build
 
 FROM alpine:3.12 as prod


### PR DESCRIPTION
Signed-off-by: Pujan Shah <pujan14@gmail.com>

Removed unused build tools from dockerfile and added default argument to image with CMD