### PR TITLE
pass --loglevel to plugins as TFLINT_LOG

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -63,6 +63,8 @@ func (cli *CLI) Run(args []string) int {
 	level := os.Getenv("TFLINT_LOG")
 	if opts.LogLevel != "" {
 		level = opts.LogLevel
+		// Pass log level to plugin processes
+		os.Setenv("TFLINT_LOG", level)
 	}
 	log.SetOutput(&logutils.LevelFilter{
 		Levels:   []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"},


### PR DESCRIPTION
Per https://github.com/terraform-linters/tflint-ruleset-aws/issues/69#issuecomment-784701244, when users set a log level via `--loglevel`, plugin processes do not reflect this input. This passes it via `TFLINT_LOG`.

Longer term, removing `--loglevel` altogether would prevent this from being an issue. Terraform does not have a log level flag, perhaps in part in recognition that environment variables fit better with external plugin processes.