### PR TITLE
tflint: Remove duplicate variable references

### DIFF
--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -370,17 +370,17 @@ func prepareVariableValues(config *configs.Config, variables ...terraform.InputV
 	return variableValues
 }
 
-func listVarRefs(expr hcl.Expression) []addrs.InputVariable {
+func listVarRefs(expr hcl.Expression) map[string]addrs.InputVariable {
 	refs, diags := lang.ReferencesInExpr(expr)
 	if diags.HasErrors() {
 		// Maybe this is bug
 		panic(diags.Err())
 	}
 
-	ret := []addrs.InputVariable{}
+	ret := map[string]addrs.InputVariable{}
 	for _, ref := range refs {
 		if varRef, ok := ref.Subject.(addrs.InputVariable); ok {
-			ret = append(ret, varRef)
+			ret[varRef.String()] = varRef
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1063

`lang.ReferencesInExpr` returns variable references for the number of variable calls. In most cases, this is not a problem, but access to elements of the map also counts as a variable call, so multiple references may be returned for the same variable.

This PR avoids returning multiple references to the same variable by returning a map instead of a slice.