### PR TITLE
Tweak about Go 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine3.12 as builder
+FROM golang:1.16-alpine3.12 as builder
 
 RUN apk add --no-cache make
 

--- a/docs/developer-guide/building.md
+++ b/docs/developer-guide/building.md
@@ -1,6 +1,6 @@
 # Building TFLint
 
-Go 1.15 or higher is required to build TFLint from source code. Clone the source code and run the `make` command. Built binary will be placed in `dist` directory.
+Go 1.16 or higher is required to build TFLint from source code. Clone the source code and run the `make` command. Built binary will be placed in `dist` directory.
 
 ```console
 $ git clone https://github.com/terraform-linters/tflint.git


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/1062

Update to Go 1.16 for Dockefile and the developer guide.