### PR TITLE
plugin: Pass types to EvalExpr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/spf13/afero v1.2.2 // matches version used by terraform
-	github.com/terraform-linters/tflint-plugin-sdk v0.8.1
-	github.com/terraform-linters/tflint-ruleset-aws v0.3.0
+	github.com/terraform-linters/tflint-plugin-sdk v0.8.2-0.20210320093036-ae6749e72de0
+	github.com/terraform-linters/tflint-ruleset-aws v0.3.1-0.20210320093704-d770eccc81e0
 	github.com/zclconf/go-cty v1.8.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 )

--- a/go.sum
+++ b/go.sum
@@ -217,7 +217,6 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -303,8 +302,6 @@ github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f h1:UdxlrJz4JOnY8W+Db
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
-github.com/hashicorp/hcl/v2 v2.8.2/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
-github.com/hashicorp/hcl/v2 v2.9.0 h1:7kJiMiKBqGHASbDJuFAMlpRMJLyhuLg/IsU/3EzwniA=
 github.com/hashicorp/hcl/v2 v2.9.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/hcl/v2 v2.9.1 h1:eOy4gREY0/ZQHNItlfuEZqtcQbXIxzojlP301hDpnac=
 github.com/hashicorp/hcl/v2 v2.9.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
@@ -312,8 +309,6 @@ github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/memberlist v0.1.0/go.mod h1:ncdBp14cuox2iFOq3kDiquKU6fqsTBc3W6JvZwjxxsE=
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
-github.com/hashicorp/terraform v0.14.7 h1:mSi9ghIb7K1uAIdg+JgcdEdmk4zzgZAFNjJ3aJb0LCs=
-github.com/hashicorp/terraform v0.14.7/go.mod h1:sRTcqhXPHnxp/zjhVkxTYCiluMzUqV8IWikuglTrz6o=
 github.com/hashicorp/terraform v0.14.8 h1:m2ytUbgJCAfySARVCd5cjbcMHhtfaozNaDDOFxpZBXk=
 github.com/hashicorp/terraform v0.14.8/go.mod h1:K/LAcRZgbGdSBY+3NB9qdLSPkkFdZ+bTrbzpZ65p4BY=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7 h1:Pc5TCv9mbxFN6UVX0LH6CpQrdTM5YjbVI2w15237Pjk=
@@ -510,10 +505,10 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
-github.com/terraform-linters/tflint-plugin-sdk v0.8.1 h1:KklKztWgRzvZLSi77GFU2y/jaA/e+OUWEV3bdouzPWw=
-github.com/terraform-linters/tflint-plugin-sdk v0.8.1/go.mod h1:A/6/RIqmPGmLWnI1JZef2Tyzw7/MFTl6t6G0BH9qALA=
-github.com/terraform-linters/tflint-ruleset-aws v0.3.0 h1:M8cUzg9D/jsUv5DNJfr6wkqBwg2uuqdyLVZETLPjxrk=
-github.com/terraform-linters/tflint-ruleset-aws v0.3.0/go.mod h1:oul4oBuTUwb1hvNmU/tIKuL/XtU6MF7V9KGihhEWhU8=
+github.com/terraform-linters/tflint-plugin-sdk v0.8.2-0.20210320093036-ae6749e72de0 h1:l7vh5uxgLwz/gzAZ+XNtfvHFMTrWLXCj0/MA0M0FAJA=
+github.com/terraform-linters/tflint-plugin-sdk v0.8.2-0.20210320093036-ae6749e72de0/go.mod h1:S6/UsMO6q2MYYf2br2WdlfFsJuZt6/AnswSA79NRJeE=
+github.com/terraform-linters/tflint-ruleset-aws v0.3.1-0.20210320093704-d770eccc81e0 h1:BBAiX+/HM3Ki0R9PAPYraTqBRa7x2XInt4so1GiT7xY=
+github.com/terraform-linters/tflint-ruleset-aws v0.3.1-0.20210320093704-d770eccc81e0/go.mod h1:4SUg8GyLOar23dJSGZThHVoMooZFYW615aO2aSAxh9k=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210128214539-ac3363c699ef/go.mod h1:2FJRHL/0yjp+iYXWoW2v4U80Zkz+mGHsHOB/Jdbw7AI=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tombuildsstuff/giovanni v0.12.0/go.mod h1:qJ5dpiYWkRsuOSXO8wHbee7+wElkLNfWVolcf59N84E=
@@ -539,7 +534,6 @@ github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLE
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
-github.com/zclconf/go-cty v1.7.1/go.mod h1:VDR4+I79ubFBGm1uJac1226K5yANQFHeauxPBoP54+o=
 github.com/zclconf/go-cty v1.8.0 h1:s4AvqaeQzJIu3ndv4gVIhplVD0krU+bgrcLSVUnaWuA=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=

--- a/integrationtest/bundled/bundled_test.go
+++ b/integrationtest/bundled/bundled_test.go
@@ -57,6 +57,12 @@ func TestBundledPlugin(t *testing.T) {
 			Command: "tflint --format json --force",
 			Dir:     "disabled-rules",
 		},
+		{
+			// Regression: https://github.com/terraform-linters/tflint-ruleset-aws/issues/48
+			Name:    "cty-based-eval",
+			Command: "tflint --format json --force",
+			Dir:     "cty-based-eval",
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/integrationtest/bundled/cty-based-eval/.tflint.hcl
+++ b/integrationtest/bundled/cty-based-eval/.tflint.hcl
@@ -1,0 +1,4 @@
+rule "aws_resource_missing_tags" {
+  enabled = true
+  tags = ["Environment", "Name", "Type"]
+}

--- a/integrationtest/bundled/cty-based-eval/result.json
+++ b/integrationtest/bundled/cty-based-eval/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_resource_missing_tags",
+        "severity": "info",
+        "link": "https://github.com/terraform-linters/tflint-ruleset-aws/blob/v0.3.0/docs/rules/aws_resource_missing_tags.md"
+      },
+      "message": "The resource is missing the following tags: \"Environment\", \"Name\", \"Type\".",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 5,
+          "column": 1
+        },
+        "end": {
+          "line": 5,
+          "column": 41
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/bundled/cty-based-eval/template.tf
+++ b/integrationtest/bundled/cty-based-eval/template.tf
@@ -1,0 +1,7 @@
+variable "tags" {
+  default = []
+}
+
+resource "aws_autoscaling_group" "group" {
+  tags = var.tags
+}

--- a/plugin/server.go
+++ b/plugin/server.go
@@ -7,7 +7,6 @@ import (
 	client "github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	tfplugin "github.com/terraform-linters/tflint-plugin-sdk/tflint/client"
 	"github.com/terraform-linters/tflint/tflint"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // Server is a RPC server for responding to requests from plugins
@@ -179,7 +178,7 @@ func (s *Server) EvalExpr(req *tfplugin.EvalExprRequest, resp *tfplugin.EvalExpr
 		return diags
 	}
 
-	val, err := s.runner.EvalExpr(expr, req.Ret, cty.Type{})
+	val, err := s.runner.EvalExpr(expr, req.Ret, req.Type)
 	if err != nil {
 		err = wrapError(err)
 	}
@@ -194,7 +193,7 @@ func (s *Server) EvalExprOnRootCtx(req *tfplugin.EvalExprRequest, resp *tfplugin
 		return diags
 	}
 
-	val, err := s.rootRunner.EvalExpr(expr, req.Ret, cty.Type{})
+	val, err := s.rootRunner.EvalExpr(expr, req.Ret, req.Type)
 	if err != nil {
 		err = wrapError(err)
 	}


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/83
See also https://github.com/terraform-linters/tflint-ruleset-aws/issues/48

In https://github.com/terraform-linters/tflint-plugin-sdk/pull/83, `EvalExprRequest` contains a detailed type, but TFLint server  doesn't use the passed type. This PR fixes this issue so that the value can be evaluated based on the type.