### PR TITLE
formatter: Add support for --format compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,24 +67,24 @@ Usage:
   tflint [OPTIONS] [FILE or DIR...]
 
 Application Options:
-  -v, --version                                   Print TFLint version
-      --langserver                                Start language server
-  -f, --format=[default|json|checkstyle|junit]    Output format (default: default)
-  -c, --config=FILE                               Config file name (default: .tflint.hcl)
-      --ignore-module=SOURCE                      Ignore module sources
-      --enable-rule=RULE_NAME                     Enable rules from the command line
-      --disable-rule=RULE_NAME                    Disable rules from the command line
-      --only=RULE_NAME                            Enable only this rule, disabling all other defaults. Can be specified multiple times
-      --enable-plugin=PLUGIN_NAME                 Enable plugins from the command line
-      --var-file=FILE                             Terraform variable file name
-      --var='foo=bar'                             Set a Terraform variable
-      --module                                    Inspect modules
-      --force                                     Return zero exit status even if issues found
-      --no-color                                  Disable colorized output
-      --loglevel=[trace|debug|info|warn|error]    Change the loglevel (default: none)
+  -v, --version                                           Print TFLint version
+      --langserver                                        Start language server
+  -f, --format=[default|json|checkstyle|junit|compact]    Output format (default: default)
+  -c, --config=FILE                                       Config file name (default: .tflint.hcl)
+      --ignore-module=SOURCE                              Ignore module sources
+      --enable-rule=RULE_NAME                             Enable rules from the command line
+      --disable-rule=RULE_NAME                            Disable rules from the command line
+      --only=RULE_NAME                                    Enable only this rule, disabling all other defaults. Can be specified multiple times
+      --enable-plugin=PLUGIN_NAME                         Enable plugins from the command line
+      --var-file=FILE                                     Terraform variable file name
+      --var='foo=bar'                                     Set a Terraform variable
+      --module                                            Inspect modules
+      --force                                             Return zero exit status even if issues found
+      --no-color                                          Disable colorized output
+      --loglevel=[trace|debug|info|warn|error]            Change the loglevel (default: none)
 
 Help Options:
-  -h, --help                                      Show this help message
+  -h, --help                                              Show this help message
 
 ```
 

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -12,7 +12,7 @@ import (
 type Options struct {
 	Version        bool     `short:"v" long:"version" description:"Print TFLint version"`
 	Langserver     bool     `long:"langserver" description:"Start language server"`
-	Format         string   `short:"f" long:"format" description:"Output format" choice:"default" choice:"json" choice:"checkstyle" choice:"junit" default:"default"`
+	Format         string   `short:"f" long:"format" description:"Output format" choice:"default" choice:"json" choice:"checkstyle" choice:"junit" choice:"compact" default:"default"`
 	Config         string   `short:"c" long:"config" description:"Config file name" value-name:"FILE" default:".tflint.hcl"`
 	IgnoreModules  []string `long:"ignore-module" description:"Ignore module sources" value-name:"SOURCE"`
 	EnableRules    []string `long:"enable-rule" description:"Enable rules from the command line" value-name:"RULE_NAME"`

--- a/formatter/compact.go
+++ b/formatter/compact.go
@@ -1,0 +1,30 @@
+package formatter
+
+import (
+	"fmt"
+
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func (f *Formatter) compactPrint(issues tflint.Issues, tferr *tflint.Error, sources map[string][]byte) {
+	if len(issues) > 0 {
+		fmt.Fprintf(f.Stdout, "%d issue(s) found:\n\n", len(issues))
+	}
+
+	for _, issue := range issues {
+		fmt.Fprintf(
+			f.Stdout,
+			"%s:%d:%d: %s - %s (%s)\n",
+			issue.Range.Filename,
+			issue.Range.Start.Line,
+			issue.Range.Start.Column,
+			issue.Rule.Severity(),
+			issue.Message,
+			issue.Rule.Name(),
+		)
+	}
+
+	if tferr != nil {
+		f.printErrors(tferr, sources)
+	}
+}

--- a/formatter/compact_test.go
+++ b/formatter/compact_test.go
@@ -1,0 +1,54 @@
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_compactPrint(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Issues tflint.Issues
+		Error  *tflint.Error
+		Stdout string
+	}{
+		{
+			Name:   "no issues",
+			Issues: tflint.Issues{},
+			Stdout: "",
+		},
+		{
+			Name: "issues",
+			Issues: tflint.Issues{
+				{
+					Rule:    &testRule{},
+					Message: "test",
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+			},
+			Stdout: `1 issue(s) found:
+
+test.tf:1:1: Error - test (test_rule)
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		formatter := &Formatter{Stdout: stdout, Stderr: stderr}
+
+		formatter.compactPrint(tc.Issues, tc.Error, map[string][]byte{})
+
+		if stdout.String() != tc.Stdout {
+			t.Fatalf("Failed %s test: expected=%s, stdout=%s", tc.Name, tc.Stdout, stdout.String())
+		}
+	}
+}

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -26,6 +26,8 @@ func (f *Formatter) Print(issues tflint.Issues, err *tflint.Error, sources map[s
 		f.checkstylePrint(issues, err, sources)
 	case "junit":
 		f.junitPrint(issues, err, sources)
+	case "compact":
+		f.compactPrint(issues, err, sources)
 	default:
 		f.prettyPrint(issues, err, sources)
 	}


### PR DESCRIPTION
This PR adds a new formatter called `compact`. This is a simple output format that expresses an issue in one line, similar to the ESLint compact format:

```console
$ tflint -f compact
1 issue(s) found:

template.tf:11:19: Error - "invalid" is an invalid value as instance_type (aws_instance_invalid_type)
```

This format does not include the end line and end column, and the stacktrace for module arguments.

This is useful for regexp-based matching, such as the GitHub Actions problem matcher. See also https://github.com/terraform-linters/setup-tflint/issues/12