### PR TITLE
Fix crash when passed --enable-rule with a configured rule

### DIFF
--- a/integrationtest/bundled/bundled_test.go
+++ b/integrationtest/bundled/bundled_test.go
@@ -69,6 +69,12 @@ func TestBundledPlugin(t *testing.T) {
 			Command: "tflint --format json --force",
 			Dir:     "map-attribute",
 		},
+		{
+			// Regression: https://github.com/terraform-linters/tflint/issues/1103
+			Name:    "rule config with --enable-rule",
+			Command: "tflint --enable-rule aws_s3_bucket_name --format json --force",
+			Dir:     "rule-config",
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -361,8 +361,9 @@ func mergeRuleMap(a, b map[string]*RuleConfig, bDisabledByDefault bool) map[stri
 		// @see https://github.com/hashicorp/hcl/blob/v2.5.0/merged.go#L132-L135
 		if prevConfig, exists := ret[k]; exists && v.Body.MissingItemRange().Filename == "<empty>" {
 			ret[k] = v
-			// Do not override body
+			// Do not override body and file
 			ret[k].Body = prevConfig.Body
+			ret[k].file = prevConfig.file
 		} else {
 			ret[k] = v
 		}


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1103

This PR fixes a crash when enabling a rule that requires config such as `aws_s3_bucket_name` with `--enable-rule`.

When rules are enabled from CLI, the pseudo rule configs are merged into the real configs. This should be ignored when merging, as pseudo rule configs have no reference to files.