### PR TITLE
Fix crash when passed --only with a configured rule

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -17,6 +17,11 @@ func (cli *CLI) inspect(opts Options, dir string, filterFiles []string) int {
 		cli.formatter.Print(tflint.Issues{}, tflint.NewContextError("Failed to load TFLint config", err), map[string][]byte{})
 		return ExitCodeError
 	}
+	if len(opts.Only) > 0 {
+		for _, rule := range cfg.Rules {
+			rule.Enabled = false
+		}
+	}
 	cfg = cfg.Merge(opts.toConfig())
 
 	// Setup loader

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,6 +18,11 @@ func (cli *CLI) printVersion(opts Options) int {
 		log.Printf("[ERROR] Failed to load TFLint config: %s", err)
 		return ExitCodeOK
 	}
+	if len(opts.Only) > 0 {
+		for _, rule := range cfg.Rules {
+			rule.Enabled = false
+		}
+	}
 	cfg = cfg.Merge(opts.toConfig())
 
 	cli.loader, err = tflint.NewLoader(afero.Afero{Fs: afero.NewOsFs()}, cfg)

--- a/integrationtest/bundled/bundled_test.go
+++ b/integrationtest/bundled/bundled_test.go
@@ -75,6 +75,11 @@ func TestBundledPlugin(t *testing.T) {
 			Command: "tflint --enable-rule aws_s3_bucket_name --format json --force",
 			Dir:     "rule-config",
 		},
+		{
+			Name:    "rule config with --only",
+			Command: "tflint --only aws_s3_bucket_name --format json --force",
+			Dir:     "rule-config",
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -26,6 +26,11 @@ func NewHandler(configPath string, cliConfig *tflint.Config) (jsonrpc2.Handler, 
 	if err != nil {
 		return nil, nil, err
 	}
+	if cliConfig.DisabledByDefault {
+		for _, rule := range cfg.Rules {
+			rule.Enabled = false
+		}
+	}
 	cfg = cfg.Merge(cliConfig)
 
 	// AWS plugin is automatically enabled for the backward compatibility.

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -147,7 +147,7 @@ func (c *Config) Merge(other *Config) *Config {
 	ret.Varfiles = append(ret.Varfiles, other.Varfiles...)
 	ret.Variables = append(ret.Variables, other.Variables...)
 
-	ret.Rules = mergeRuleMap(ret.Rules, other.Rules, other.DisabledByDefault)
+	ret.Rules = mergeRuleMap(ret.Rules, other.Rules)
 	ret.Plugins = mergePluginMap(ret.Plugins, other.Plugins)
 
 	return ret
@@ -332,27 +332,8 @@ func mergeBoolMap(a, b map[string]bool) map[string]bool {
 	return ret
 }
 
-func mergeRuleMap(a, b map[string]*RuleConfig, bDisabledByDefault bool) map[string]*RuleConfig {
+func mergeRuleMap(a, b map[string]*RuleConfig) map[string]*RuleConfig {
 	ret := map[string]*RuleConfig{}
-	if bDisabledByDefault {
-		for bK, bV := range b {
-			configRuleFound := false
-			for aK, aV := range a {
-				if aK == bK {
-					ret[bK] = bV
-					ret[bK].Body = aV.Body
-					ret[bK].Enabled = true
-					configRuleFound = true
-				}
-			}
-			if !configRuleFound {
-				ret[bK] = bV
-				ret[bK].Enabled = true
-			}
-		}
-		return ret
-	}
-
 	for k, v := range a {
 		ret[k] = v
 	}

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -385,7 +385,7 @@ func Test_Merge(t *testing.T) {
 					},
 					"aws_instance_invalid_ami": {
 						Name:    "aws_instance_invalid_ami",
-						Enabled: true,
+						Enabled: false,
 						Body:    file1.Body,
 					},
 				},
@@ -454,6 +454,11 @@ func Test_Merge(t *testing.T) {
 						Name:    "aws_instance_previous_type",
 						Enabled: true,
 						Body:    hcl.EmptyBody(),
+					},
+					"aws_instance_invalid_ami": {
+						Name:    "aws_instance_invalid_ami",
+						Enabled: false,
+						Body:    file1.Body,
 					},
 				},
 				Plugins: map[string]*PluginConfig{


### PR DESCRIPTION
Similar to https://github.com/terraform-linters/tflint/pull/1105, it is crashed when passed `--only` with a configured rule.

```
% tflint --only aws_s3_bucket_name
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x186a197]

goroutine 38 [running]:
github.com/terraform-linters/tflint/tflint.(*RuleConfig).Bytes(...)
        /Users/watanabekazuma/workspace/golang/src/github.com/wata727/tflint/tflint/config.go:430
github.com/terraform-linters/tflint/plugin.(*Server).RuleConfig(0xc00014de30, 0xc00017d7b0, 0xc0006ece70, 0x0, 0x0)
        /Users/watanabekazuma/workspace/golang/src/github.com/wata727/tflint/plugin/server.go:167 +0x1b7
reflect.Value.call(0xc0007056e0, 0xc00015cc80, 0x13, 0x2735c99, 0x4, 0xc000613f08, 0x3, 0x3, 0x26cf760, 0xc0004ac000, ...)
        /usr/local/Cellar/go/1.16/libexec/src/reflect/value.go:476 +0x8e7
reflect.Value.Call(0xc0007056e0, 0xc00015cc80, 0x13, 0xc000124708, 0x3, 0x3, 0x2a2d660, 0x100010000, 0xc00068d040)
        /usr/local/Cellar/go/1.16/libexec/src/reflect/value.go:337 +0xb9
net/rpc.(*service).call(0xc000702dc0, 0xc000701c70, 0xc0001406e0, 0xc0001406f0, 0xc000158780, 0xc0000509e0, 0x2213760, 0xc0
0017d7b0, 0x16, 0x22137a0, ...)
        /usr/local/Cellar/go/1.16/libexec/src/net/rpc/server.go:377 +0x189
created by net/rpc.(*Server).ServeCodec
        /usr/local/Cellar/go/1.16/libexec/src/net/rpc/server.go:474 +0x44d
```