### PR TITLE
Log at INFO level when TFLint cannot statically evaluate an expression

### DIFF
--- a/plugin/encode.go
+++ b/plugin/encode.go
@@ -7,9 +7,9 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/experiments"
 	tfplugin "github.com/terraform-linters/tflint-plugin-sdk/tflint/client"
-	"github.com/zclconf/go-cty/cty/msgpack"
-	"github.com/zclconf/go-cty/cty/json"
 	"github.com/terraform-linters/tflint/tflint"
+	"github.com/zclconf/go-cty/cty/json"
+	"github.com/zclconf/go-cty/cty/msgpack"
 )
 
 func (s *Server) encodeConfig(config *tfconfigs.Config) (*tfplugin.Config, error) {

--- a/plugin/server_test.go
+++ b/plugin/server_test.go
@@ -304,7 +304,7 @@ func Test_EvalExpr_errors(t *testing.T) {
 	expected := client.Error{
 		Code:    client.UnknownValueError,
 		Level:   client.WarningLevel,
-		Message: "Unknown value found in template.tf:1; Please use environment variables or tfvars to set the value",
+		Message: "Unknown value found in template.tf:1. TFLint can only evaluate provided variables and skips dynamic values.",
 		Cause:   nil,
 	}
 	if !cmp.Equal(expected, resp.Err) {
@@ -410,20 +410,20 @@ resource "aws_s3_bucket" "bar" {
 
 	expected := &tfplugin.Config{
 		Module: &tfplugin.Module{
-			SourceDir: ".",
-			CoreVersionConstraints: []string{},
+			SourceDir:                   ".",
+			CoreVersionConstraints:      []string{},
 			CoreVersionConstraintRanges: []hcl.Range{},
-			ActiveExperiments: experiments.Set{},
-			ProviderConfigs: map[string]*tfplugin.Provider{},
+			ActiveExperiments:           experiments.Set{},
+			ProviderConfigs:             map[string]*tfplugin.Provider{},
 			ProviderRequirements: &tfplugin.RequiredProviders{
 				RequiredProviders: map[string]*tfplugin.RequiredProvider{},
 			},
 			ProviderLocalNames: map[addrs.Provider]string{},
-			ProviderMetas: map[addrs.Provider]*tfplugin.ProviderMeta{},
-			Variables: map[string]*tfplugin.Variable{},
-			Locals: map[string]*tfplugin.Local{},
-			Outputs: map[string]*tfplugin.Output{},
-			ModuleCalls: map[string]*tfplugin.ModuleCall{},
+			ProviderMetas:      map[addrs.Provider]*tfplugin.ProviderMeta{},
+			Variables:          map[string]*tfplugin.Variable{},
+			Locals:             map[string]*tfplugin.Local{},
+			Outputs:            map[string]*tfplugin.Output{},
+			ModuleCalls:        map[string]*tfplugin.ModuleCall{},
 			ManagedResources: map[string]*tfplugin.Resource{
 				"aws_instance.foo": {
 					Mode: addrs.ManagedResourceMode,

--- a/plugin/server_test.go
+++ b/plugin/server_test.go
@@ -304,7 +304,7 @@ func Test_EvalExpr_errors(t *testing.T) {
 	expected := client.Error{
 		Code:    client.UnknownValueError,
 		Level:   client.WarningLevel,
-		Message: "Unknown value found in template.tf:1. TFLint can only evaluate provided variables and skips dynamic values.",
+		Message: "Unknown value found in template.tf:1",
 		Cause:   nil,
 	}
 	if !cmp.Equal(expected, resp.Err) {

--- a/tflint/runner_eval.go
+++ b/tflint/runner_eval.go
@@ -70,7 +70,7 @@ func (r *Runner) EvalExpr(expr hcl.Expression, ret interface{}, wantType cty.Typ
 				expr.Range().Start.Line,
 			),
 		}
-		log.Printf("[WARN] %s. TFLint ignores unevaluable expressions.", err)
+		log.Printf("[INFO] %s. TFLint ignores unevaluable expressions.", err)
 		return cty.NullVal(cty.NilType), err
 	}
 
@@ -120,7 +120,7 @@ func (r *Runner) EvalExpr(expr hcl.Expression, ret interface{}, wantType cty.Typ
 					expr.Range().Start.Line,
 				),
 			}
-			log.Printf("[WARN] %s. TFLint can only evaluate provided variables and skips dynamic values.", err)
+			log.Printf("[INFO] %s. TFLint can only evaluate provided variables and skips dynamic values.", err)
 			return false, err
 		}
 
@@ -134,7 +134,7 @@ func (r *Runner) EvalExpr(expr hcl.Expression, ret interface{}, wantType cty.Typ
 					expr.Range().Start.Line,
 				),
 			}
-			log.Printf("[WARN] %s. TFLint ignores expressions with null values.", err)
+			log.Printf("[INFO] %s. TFLint ignores expressions with null values.", err)
 			return false, err
 		}
 
@@ -176,7 +176,7 @@ func (r *Runner) EvaluateBlock(block *hcl.Block, schema *configschema.Block, ret
 				block.DefRange.Start.Line,
 			),
 		}
-		log.Printf("[WARN] %s. TFLint ignores unevaluable blocks.", err)
+		log.Printf("[INFO] %s. TFLint ignores unevaluable blocks.", err)
 		return err
 	}
 
@@ -207,7 +207,7 @@ func (r *Runner) EvaluateBlock(block *hcl.Block, schema *configschema.Block, ret
 					block.DefRange.Start.Line,
 				),
 			}
-			log.Printf("[WARN] %s. TFLint can only evaluate provided variables and skips blocks with unknown values.", err)
+			log.Printf("[INFO] %s. TFLint can only evaluate provided variables and skips blocks with unknown values.", err)
 			return false, err
 		}
 

--- a/tflint/runner_eval_test.go
+++ b/tflint/runner_eval_test.go
@@ -444,7 +444,7 @@ resource "null_resource" "test" {
 			Error: Error{
 				Code:    UnknownValueError,
 				Level:   WarningLevel,
-				Message: "Unknown value found in main.tf:5; Please use environment variables or tfvars to set the value",
+				Message: "Unknown value found in main.tf:5",
 			},
 		},
 		{
@@ -552,7 +552,7 @@ resource "null_resource" "test" {
 			Error: Error{
 				Code:    UnknownValueError,
 				Level:   WarningLevel,
-				Message: "Unknown value found in main.tf:5; Please use environment variables or tfvars to set the value",
+				Message: "Unknown value found in main.tf:5",
 			},
 		},
 		{
@@ -719,7 +719,7 @@ resource "null_resource" "test" {
 			Error: Error{
 				Code:    UnknownValueError,
 				Level:   WarningLevel,
-				Message: "Unknown value found in main.tf:5; Please use environment variables or tfvars to set the value",
+				Message: "Unknown value found in main.tf:5",
 			},
 		},
 		{


### PR DESCRIPTION
See #1112. These are typically normal, e.g. references to data source or resource attributes, or even locals (#571). The logs are optionally available if users want to try to understand why TFLint can or cannot validate a particular usage. Logs are still for internal introspection only and most users should never see them.