### PR TITLE
tflint: Fix panic when encoding empty body

### DIFF
--- a/tflint/terraform.go
+++ b/tflint/terraform.go
@@ -72,6 +72,7 @@ func ParseExpression(src []byte, filename string, start hcl.Pos) (hcl.Expression
 func HCLBodyRange(body hcl.Body, defRange hcl.Range) hcl.Range {
 	if strings.HasSuffix(defRange.Filename, ".tf") {
 		var bodyRange hcl.Range
+		bodyRange.Filename = defRange.Filename
 
 		// Estimate the range of the body from the range of all attributes and blocks.
 		hclBody, ok := body.(*hclsyntax.Body)
@@ -82,7 +83,6 @@ func HCLBodyRange(body hcl.Body, defRange hcl.Range) hcl.Range {
 			// As a result, plugins that use this range to get hcl.Body may have incorrect results.
 			// This issue will be fixed by changing the way of transffering the hcl.Body.
 			// See also https://github.com/terraform-linters/tflint-plugin-sdk/issues/89.
-			bodyRange.Filename = defRange.Filename
 			return bodyRange
 		}
 

--- a/tflint/terraform_test.go
+++ b/tflint/terraform_test.go
@@ -242,6 +242,33 @@ resource "null_resource" "foo" {
 	}
 }
 
+func Test_HCLBodyRange_emptyBody(t *testing.T) {
+	src := `ebs_block_device {}`
+
+	file, diags := hclsyntax.ParseConfig([]byte(src), "example.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+	body, diags := file.Body.Content(&hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{
+			{
+				Type: "ebs_block_device",
+			},
+		},
+	})
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+	block := body.Blocks[0]
+	got := HCLBodyRange(block.Body, block.DefRange)
+	expected := hcl.Range{Filename: "example.tf"}
+
+	opt := cmpopts.IgnoreFields(hcl.Pos{}, "Byte")
+	if !cmp.Equal(got, expected, opt) {
+		t.Fatalf("Diff=%s", cmp.Diff(got, expected, opt))
+	}
+}
+
 func Test_getTFDataDir(t *testing.T) {
 	cases := []struct {
 		Name     string


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint-plugin-sdk/issues/115

When encoding HCL bodies for sending to a plugin, the range of blocks is calculated from the contents of the body. However, if the body is empty, an empty range will be the return value of the `HCLBodyRange` func because there is no target range. Since the empty range doesn't have a filename, panic will occur when slicing source code bytes from the range:

https://github.com/terraform-linters/tflint/blob/015b01c7f149d11e253211a15a6db1e5b268c360/plugin/encode.go#L143

This PR avoids this panic by always setting the filename, even if the body is empty.