### PR TITLE
feat(rules): detect branch names "main", "develop"

### DIFF
--- a/docs/rules/terraform_module_pinned_source.md
+++ b/docs/rules/terraform_module_pinned_source.md
@@ -8,11 +8,13 @@ Name | Default | Value
 --- | --- | ---
 enabled | true | Boolean
 style | `flexible` | `flexible`, `semver`
+default_ref_regexp | `master` | A regular expression
 
 ```hcl
 rule "terraform_module_pinned_source" {
   enabled = true
   style = "flexible"
+  default_ref_regexp = "master|main|develop"
 }
 ```
 
@@ -67,9 +69,11 @@ Reference: https://github.com/terraform-linters/tflint/blob/v0.15.0/docs/rules/t
 
 ```
 
+For `ref=` sources, the default branches to deny are those matched by the regular expression `default_ref_regexp`, which defaults to `master`.
+
 ### style = "semver"
 
-In the "semver" style, all sources must be pinned to semantic version reference. This is stricter than the "flexible" style.
+In the "semver" style, all sources must be pinned to semantic version reference. This is stricter than the "flexible" style. The `default_ref_regexp` setting is ignored altogether.
 
 ```hcl
 module "unpinned" {

--- a/rules/terraformrules/terraform_module_pinned_source.go
+++ b/rules/terraformrules/terraform_module_pinned_source.go
@@ -58,6 +58,7 @@ var ReBitbucket = regexp.MustCompile("^bitbucket.org/(.+)/(.+)$")
 // See https://www.terraform.io/docs/modules/sources.html#generic-git-repository
 var ReGenericGit = regexp.MustCompile("(git://(.+)/(.+))|(git::https://(.+)/(.+))|(git::ssh://((.+)@)??(.+)/(.+)/(.+))")
 
+var reBadBranchReference = regexp.MustCompile("ref=(master|main|develop)($|\\&)")
 var reSemverReference = regexp.MustCompile("\\?ref=v?\\d+\\.\\d+\\.\\d+$")
 var reSemverRevision = regexp.MustCompile("\\?rev=v?\\d+\\.\\d+\\.\\d+$")
 
@@ -156,10 +157,11 @@ func (r *TerraformModulePinnedSourceRule) checkRefSource(runner *tflint.Runner, 
 	switch config.Style {
 	// The "flexible" style enforces to pin source, except for the default branch
 	case "flexible":
-		if strings.Contains(lower, "ref=master") {
+		matches := reBadBranchReference.FindStringSubmatch(lower)
+		if len(matches) >= 2 {
 			runner.EmitIssue(
 				r,
-				fmt.Sprintf("Module source \"%s\" uses default ref \"master\"", module.SourceAddr),
+				fmt.Sprintf("Module source \"%s\" uses default ref \"%s\"", module.SourceAddr, matches[1]),
 				module.SourceAddrRange,
 			)
 		}

--- a/rules/terraformrules/terraform_module_pinned_source_test.go
+++ b/rules/terraformrules/terraform_module_pinned_source_test.go
@@ -35,7 +35,7 @@ module "unpinned" {
 			},
 		},
 		{
-			Name: "git module reference is default",
+			Name: "git module reference is master",
 			Content: `
 module "default_git" {
   source = "git://hashicorp.com/consul.git?ref=master"
@@ -51,6 +51,32 @@ module "default_git" {
 					},
 				},
 			},
+		},
+		{
+			Name: "git module reference is main",
+			Content: `
+module "default_git" {
+  source = "git://hashicorp.com/consul.git?ref=main&depth=99"
+}`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformModulePinnedSourceRule(),
+					Message: "Module source \"git://hashicorp.com/consul.git?ref=main&depth=99\" uses default ref \"main\"",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 62},
+					},
+				},
+			},
+		},
+		{
+			Name: "git module reference is master's-feature-branch",
+			Content: `
+module "default_git" {
+  source = "git://hashicorp.com/consul.git?ref=master's-feature-branch"
+}`,
+			Expected: tflint.Issues{},
 		},
 		{
 			Name: "git module reference is pinned",

--- a/rules/terraformrules/terraform_module_pinned_source_test.go
+++ b/rules/terraformrules/terraform_module_pinned_source_test.go
@@ -56,7 +56,35 @@ module "default_git" {
 			Name: "git module reference is main",
 			Content: `
 module "default_git" {
+  source = "git://hashicorp.com/consul.git?ref=main"
+}`,
+			Config: `
+rule "terraform_module_pinned_source" {
+  enabled = true
+  default_ref_regexp = "master|main|develop"
+}`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformModulePinnedSourceRule(),
+					Message: "Module source \"git://hashicorp.com/consul.git?ref=main\" uses default ref \"main\"",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 53},
+					},
+				},
+			},
+		},
+		{
+			Name: "git module reference is main with another url parameter",
+			Content: `
+module "default_git" {
   source = "git://hashicorp.com/consul.git?ref=main&depth=99"
+}`,
+			Config: `
+rule "terraform_module_pinned_source" {
+  enabled = true
+  default_ref_regexp = "master|main|develop"
 }`,
 			Expected: tflint.Issues{
 				{


### PR DESCRIPTION
It's true that the repo's default branch is mostly named "master", but
two notable additional names are "main" and "develop". All three are
equally unwanted when used in a ref=.

In most git implementations (including GitHub) you are free to set any
branch name as default, but these 3 names cover probably 99% of cases
as far as I've seen personally in the wild.

This change is backward-compatible with the TF modules based on these
two branches.

How do I know I should expect URL-like behavior such as
`example.com?ref=a&depth=5` here? Peeking at Terraform source code, it is
using go-getter library. Checking its docs confirms the format:

https://pkg.go.dev/github.com/hashicorp/go-getter