### PR TITLE
Refactor terraform_module_pinned_source rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/terraform-linters/tflint
 go 1.16
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/fatih/color v1.10.0
 	github.com/golang/mock v1.5.0
 	github.com/google/go-cmp v0.5.5

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/terraform-linters/tflint
 go 1.16
 
 require (
-	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/fatih/color v1.10.0
 	github.com/golang/mock v1.5.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-github/v35 v35.2.0
-	github.com/hashicorp/go-getter v1.5.3 // indirect
+	github.com/hashicorp/go-getter v1.5.3
 	github.com/hashicorp/go-plugin v1.4.1
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl/v2 v2.10.0

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/mock v1.5.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-github/v35 v35.2.0
+	github.com/hashicorp/go-getter v1.5.3 // indirect
 	github.com/hashicorp/go-plugin v1.4.1
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl/v2 v2.10.0

--- a/go.sum
+++ b/go.sum
@@ -248,7 +248,9 @@ github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
+github.com/google/martian/v3 v3.0.0 h1:pMen7vLs8nvgEYhywH3KDWJIJTeEr2ULsVWHWYHQyBs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181127221834-b4f47329b966/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -294,7 +296,6 @@ github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/S
 github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320/go.mod h1:EiZBMaudVLy8fmjf9Npq1dq9RalhveqZG5w/yz3mHWs=
 github.com/hashicorp/go-getter v1.4.0/go.mod h1:7qxyCd8rBfcShwsvxgIguu4KbS3l8bUCwg2Umn7RjeY=
 github.com/hashicorp/go-getter v1.5.0/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
-github.com/hashicorp/go-getter v1.5.1 h1:lM9sM02nvEApQGFgkXxWbhfqtyN+AyhQmi+MaMdBDOI=
 github.com/hashicorp/go-getter v1.5.1/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
 github.com/hashicorp/go-getter v1.5.3 h1:NF5+zOlQegim+w/EUhSLh6QhXHmZMEeHLQzllkQ3ROU=
 github.com/hashicorp/go-getter v1.5.3/go.mod h1:BrrV/1clo8cCYu6mxvboYg+KutTiFnXjMEgDD8+i7ZI=

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,8 @@ github.com/hashicorp/go-getter v1.4.0/go.mod h1:7qxyCd8rBfcShwsvxgIguu4KbS3l8bUC
 github.com/hashicorp/go-getter v1.5.0/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
 github.com/hashicorp/go-getter v1.5.1 h1:lM9sM02nvEApQGFgkXxWbhfqtyN+AyhQmi+MaMdBDOI=
 github.com/hashicorp/go-getter v1.5.1/go.mod h1:a7z7NPPfNQpJWcn4rSWFtdrSldqLdLPEF3d8nFMsSLM=
+github.com/hashicorp/go-getter v1.5.3 h1:NF5+zOlQegim+w/EUhSLh6QhXHmZMEeHLQzllkQ3ROU=
+github.com/hashicorp/go-getter v1.5.3/go.mod h1:BrrV/1clo8cCYu6mxvboYg+KutTiFnXjMEgDD8+i7ZI=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.15.0 h1:qMuK0wxsoW4D0ddCCYwPSTm4KQv1X1ke3WmPWZ0Mvsk=
@@ -384,6 +386,8 @@ github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT
 github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.11.2 h1:MiK62aErc3gIiVEtyzKfeOHgW7atJb5g/KNX5m3c2nQ=
+github.com/klauspost/compress v1.11.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/go.sum
+++ b/go.sum
@@ -63,7 +63,10 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20190607011252-c5096ec8773d/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/rules/terraformrules/terraform_module_pinned_source.go
+++ b/rules/terraformrules/terraform_module_pinned_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"path/filepath"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/go-getter"
@@ -75,7 +76,7 @@ func (r *TerraformModulePinnedSourceRule) Check(runner *tflint.Runner) error {
 func (r *TerraformModulePinnedSourceRule) checkModule(runner *tflint.Runner, module *configs.ModuleCall, config terraformModulePinnedSourceRuleConfig) error {
 	log.Printf("[DEBUG] Walk `%s` attribute", module.Name+".source")
 
-	source, err := getter.Detect(module.SourceAddr, "", getter.Detectors)
+	source, err := getter.Detect(module.SourceAddr, filepath.Dir(module.DeclRange.Filename), getter.Detectors)
 	if err != nil {
 		return err
 	}

--- a/rules/terraformrules/terraform_module_pinned_source.go
+++ b/rules/terraformrules/terraform_module_pinned_source.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"log"
 	"net/url"
-	"regexp"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/go-getter"
 
 	"github.com/hashicorp/terraform/configs"
@@ -47,8 +47,6 @@ func (r *TerraformModulePinnedSourceRule) Severity() string {
 func (r *TerraformModulePinnedSourceRule) Link() string {
 	return tflint.ReferenceLink(r.Name())
 }
-
-var reSemver = regexp.MustCompile("v?\\d+\\.\\d+\\.\\d+$")
 
 // Check checks if module source version is pinned
 // Note that this rule is valid only for Git or Mercurial source
@@ -133,7 +131,8 @@ func (r *TerraformModulePinnedSourceRule) checkRevision(runner *tflint.Runner, m
 		}
 	// The "semver" style enforces to pin source like semantic versioning
 	case "semver":
-		if !reSemver.MatchString(value) {
+		_, err := semver.NewVersion(value)
+		if err != nil {
 			runner.EmitIssue(
 				r,
 				fmt.Sprintf("Module source \"%s\" uses a %s which is not a version string", module.SourceAddr, key),

--- a/rules/terraformrules/terraform_module_pinned_source.go
+++ b/rules/terraformrules/terraform_module_pinned_source.go
@@ -3,8 +3,10 @@ package terraformrules
 import (
 	"fmt"
 	"log"
+	"net/url"
 	"regexp"
-	"strings"
+
+	"github.com/hashicorp/go-getter"
 
 	"github.com/hashicorp/terraform/configs"
 	"github.com/terraform-linters/tflint/tflint"
@@ -46,20 +48,7 @@ func (r *TerraformModulePinnedSourceRule) Link() string {
 	return tflint.ReferenceLink(r.Name())
 }
 
-// ReGitHub matches a module source which is a GitHub repository
-// See https://www.terraform.io/docs/modules/sources.html#github
-var ReGitHub = regexp.MustCompile("(^github.com/(.+)/(.+)$)|(^git@github.com:(.+)/(.+)$)")
-
-// ReBitbucket matches a module source which is a Bitbucket repository
-// See https://www.terraform.io/docs/modules/sources.html#bitbucket
-var ReBitbucket = regexp.MustCompile("^bitbucket.org/(.+)/(.+)$")
-
-// ReGenericGit matches a module source which is a Git repository
-// See https://www.terraform.io/docs/modules/sources.html#generic-git-repository
-var ReGenericGit = regexp.MustCompile("(git://(.+)/(.+))|(git::https://(.+)/(.+))|(git::ssh://((.+)@)??(.+)/(.+)/(.+))")
-
-var reSemverReference = regexp.MustCompile("\\?ref=v?\\d+\\.\\d+\\.\\d+$")
-var reSemverRevision = regexp.MustCompile("\\?rev=v?\\d+\\.\\d+\\.\\d+$")
+var reSemver = regexp.MustCompile("v?\\d+\\.\\d+\\.\\d+$")
 
 // Check checks if module source version is pinned
 // Note that this rule is valid only for Git or Mercurial source
@@ -88,119 +77,66 @@ func (r *TerraformModulePinnedSourceRule) Check(runner *tflint.Runner) error {
 func (r *TerraformModulePinnedSourceRule) checkModule(runner *tflint.Runner, module *configs.ModuleCall, config terraformModulePinnedSourceRuleConfig) error {
 	log.Printf("[DEBUG] Walk `%s` attribute", module.Name+".source")
 
-	lower := strings.ToLower(module.SourceAddr)
-
-	if ReGitHub.MatchString(lower) || ReGenericGit.MatchString(lower) {
-		return r.checkGitSource(runner, module, config)
-	} else if ReBitbucket.MatchString(lower) {
-		return r.checkBitbucketSource(runner, module, config)
-	} else if strings.HasPrefix(lower, "hg::") {
-		return r.checkMercurialSource(runner, module, config)
+	source, err := getter.Detect(module.SourceAddr, "", getter.Detectors)
+	if err != nil {
+		return err
 	}
 
-	return nil
-}
-
-func (r *TerraformModulePinnedSourceRule) checkGitSource(runner *tflint.Runner, module *configs.ModuleCall, config terraformModulePinnedSourceRuleConfig) error {
-	lower := strings.ToLower(module.SourceAddr)
-
-	if strings.Contains(lower, "ref=") {
-		return r.checkRefSource(runner, module, config)
+	u, err := url.Parse(source)
+	if err != nil {
+		return err
 	}
 
-	runner.EmitIssue(
-		r,
-		fmt.Sprintf("Module source \"%s\" is not pinned", module.SourceAddr),
-		module.SourceAddrRange,
-	)
-	return nil
-}
+	switch u.Scheme {
+	case "git", "hg":
+	default:
+		return nil
+	}
 
-func (r *TerraformModulePinnedSourceRule) checkMercurialSource(runner *tflint.Runner, module *configs.ModuleCall, config terraformModulePinnedSourceRuleConfig) error {
-	lower := strings.ToLower(module.SourceAddr)
+	query := u.Query()
 
-	if strings.Contains(lower, "rev=") {
-		return r.checkRevSource(runner, module, config)
+	if ref := query.Get("ref"); ref != "" {
+		return r.checkRevision(runner, module, config, "ref", ref)
+	}
+
+	if rev := query.Get("rev"); rev != "" {
+		return r.checkRevision(runner, module, config, "rev", rev)
 	}
 
 	runner.EmitIssue(
 		r,
-		fmt.Sprintf("Module source \"%s\" is not pinned", module.SourceAddr),
+		fmt.Sprintf(`Module source "%s" is not pinned`, module.SourceAddr),
 		module.SourceAddrRange,
 	)
-	return nil
-}
-
-// Terraform can use a Bitbucket repo as Git or Mercurial.
-//
-// Note: Bitbucket is dropping Mercurial support in 2020, so this can be rolled into
-// checkGitSource after that happens.
-func (r *TerraformModulePinnedSourceRule) checkBitbucketSource(runner *tflint.Runner, module *configs.ModuleCall, config terraformModulePinnedSourceRuleConfig) error {
-	lower := strings.ToLower(module.SourceAddr)
-
-	if strings.Contains(lower, "ref=") {
-		return r.checkRefSource(runner, module, config)
-	} else if strings.Contains(lower, "rev=") {
-		return r.checkRevSource(runner, module, config)
-	} else {
-		runner.EmitIssue(
-			r,
-			fmt.Sprintf("Module source \"%s\" is not pinned", module.SourceAddr),
-			module.SourceAddrRange,
-		)
-	}
 
 	return nil
 }
 
-func (r *TerraformModulePinnedSourceRule) checkRefSource(runner *tflint.Runner, module *configs.ModuleCall, config terraformModulePinnedSourceRuleConfig) error {
-	lower := strings.ToLower(module.SourceAddr)
-
+func (r *TerraformModulePinnedSourceRule) checkRevision(runner *tflint.Runner, module *configs.ModuleCall, config terraformModulePinnedSourceRuleConfig, key string, value string) error {
 	switch config.Style {
 	// The "flexible" style enforces to pin source, except for the default branch
 	case "flexible":
-		if strings.Contains(lower, "ref=master") {
+		if key == "ref" && value == "master" {
 			runner.EmitIssue(
 				r,
-				fmt.Sprintf("Module source \"%s\" uses default ref \"master\"", module.SourceAddr),
+				fmt.Sprintf("Module source \"%s\" uses default %s \"master\"", module.SourceAddr, key),
+				module.SourceAddrRange,
+			)
+		}
+
+		if key == "rev" && value == "default" {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("Module source \"%s\" uses default %s \"default\"", module.SourceAddr, key),
 				module.SourceAddrRange,
 			)
 		}
 	// The "semver" style enforces to pin source like semantic versioning
 	case "semver":
-		if !reSemverReference.MatchString(lower) {
+		if !reSemver.MatchString(value) {
 			runner.EmitIssue(
 				r,
-				fmt.Sprintf("Module source \"%s\" uses a ref which is not a version string", module.SourceAddr),
-				module.SourceAddrRange,
-			)
-		}
-	default:
-		return fmt.Errorf("`%s` is invalid style", config.Style)
-	}
-
-	return nil
-}
-
-func (r *TerraformModulePinnedSourceRule) checkRevSource(runner *tflint.Runner, module *configs.ModuleCall, config terraformModulePinnedSourceRuleConfig) error {
-	lower := strings.ToLower(module.SourceAddr)
-
-	switch config.Style {
-	// The "flexible" style enforces to pin source, except for the default reference
-	case "flexible":
-		if strings.Contains(lower, "rev=default") {
-			runner.EmitIssue(
-				r,
-				fmt.Sprintf("Module source \"%s\" uses default rev \"default\"", module.SourceAddr),
-				module.SourceAddrRange,
-			)
-		}
-	// The "semver" style enforces to pin source like semantic versioning
-	case "semver":
-		if !reSemverRevision.MatchString(lower) {
-			runner.EmitIssue(
-				r,
-				fmt.Sprintf("Module source \"%s\" uses a rev which is not a version string", module.SourceAddr),
+				fmt.Sprintf("Module source \"%s\" uses a %s which is not a version string", module.SourceAddr, key),
 				module.SourceAddrRange,
 			)
 		}

--- a/rules/terraformrules/terraform_module_pinned_source.go
+++ b/rules/terraformrules/terraform_module_pinned_source.go
@@ -76,23 +76,26 @@ func (r *TerraformModulePinnedSourceRule) Check(runner *tflint.Runner) error {
 		return err
 	}
 
-	var err error
 	for _, module := range runner.TFConfig.Module.ModuleCalls {
-		log.Printf("[DEBUG] Walk `%s` attribute", module.Name+".source")
-
-		lower := strings.ToLower(module.SourceAddr)
-
-		if ReGitHub.MatchString(lower) || ReGenericGit.MatchString(lower) {
-			err = r.checkGitSource(runner, module, config)
-		} else if ReBitbucket.MatchString(lower) {
-			err = r.checkBitbucketSource(runner, module, config)
-		} else if strings.HasPrefix(lower, "hg::") {
-			err = r.checkMercurialSource(runner, module, config)
-		}
-
-		if err != nil {
+		if err := r.checkModule(runner, module, config); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (r *TerraformModulePinnedSourceRule) checkModule(runner *tflint.Runner, module *configs.ModuleCall, config terraformModulePinnedSourceRuleConfig) error {
+	log.Printf("[DEBUG] Walk `%s` attribute", module.Name+".source")
+
+	lower := strings.ToLower(module.SourceAddr)
+
+	if ReGitHub.MatchString(lower) || ReGenericGit.MatchString(lower) {
+		return r.checkGitSource(runner, module, config)
+	} else if ReBitbucket.MatchString(lower) {
+		return r.checkBitbucketSource(runner, module, config)
+	} else if strings.HasPrefix(lower, "hg::") {
+		return r.checkMercurialSource(runner, module, config)
 	}
 
 	return nil

--- a/rules/terraformrules/terraform_module_pinned_source_test.go
+++ b/rules/terraformrules/terraform_module_pinned_source_test.go
@@ -136,6 +136,24 @@ module "unpinned" {
 			},
 		},
 		{
+			Name: "github ssh module is not pinned",
+			Content: `
+module "unpinned" {
+  source = "git@github.com:hashicorp/consul.git"
+}`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformModulePinnedSourceRule(),
+					Message: "Module source \"git@github.com:hashicorp/consul.git\" is not pinned",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 49},
+					},
+				},
+			},
+		},
+		{
 			Name: "github module reference is default",
 			Content: `
 module "default_git" {
@@ -158,6 +176,14 @@ module "default_git" {
 			Content: `
 module "pinned_git" {
   source = "github.com/hashicorp/consul.git?ref=pinned"
+}`,
+			Expected: tflint.Issues{},
+		},
+		{
+			Name: "github ssh module is pinned",
+			Content: `
+module "unpinned" {
+  source = "git@github.com:hashicorp/consul.git?ref=pinned"
 }`,
 			Expected: tflint.Issues{},
 		},

--- a/rules/terraformrules/terraform_module_pinned_source_test.go
+++ b/rules/terraformrules/terraform_module_pinned_source_test.go
@@ -17,6 +17,14 @@ func Test_TerraformModulePinnedSource(t *testing.T) {
 		Expected tflint.Issues
 	}{
 		{
+			Name: "local module",
+			Content: `
+module "unpinned" {
+  source = "./local"
+}`,
+			Expected: tflint.Issues{},
+		},
+		{
 			Name: "git module is not pinned",
 			Content: `
 module "unpinned" {

--- a/rules/terraformrules/terraform_module_pinned_source_test.go
+++ b/rules/terraformrules/terraform_module_pinned_source_test.go
@@ -193,16 +193,16 @@ rule "terraform_module_pinned_source" {
 			Name: "bitbucket module is not pinned",
 			Content: `
 module "unpinned" {
-  source = "bitbucket.org/hashicorp/consul"
+  source = "bitbucket.org/hashicorp/tf-test-git"
 }`,
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"bitbucket.org/hashicorp/consul\" is not pinned",
+					Message: "Module source \"bitbucket.org/hashicorp/tf-test-git\" is not pinned",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},
-						End:      hcl.Pos{Line: 3, Column: 44},
+						End:      hcl.Pos{Line: 3, Column: 49},
 					},
 				},
 			},
@@ -211,34 +211,16 @@ module "unpinned" {
 			Name: "bitbucket git module reference is default",
 			Content: `
 module "default_git" {
-  source = "bitbucket.org/hashicorp/consul.git?ref=master"
+  source = "bitbucket.org/hashicorp/tf-test-git.git?ref=master"
 }`,
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"bitbucket.org/hashicorp/consul.git?ref=master\" uses default ref \"master\"",
+					Message: "Module source \"bitbucket.org/hashicorp/tf-test-git.git?ref=master\" uses default ref \"master\"",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},
-						End:      hcl.Pos{Line: 3, Column: 59},
-					},
-				},
-			},
-		},
-		{
-			Name: "bitbucket mercurial module reference is default",
-			Content: `
-module "default_git" {
-  source = "bitbucket.org/hg/mercurial?rev=default"
-}`,
-			Expected: tflint.Issues{
-				{
-					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"bitbucket.org/hg/mercurial?rev=default\" uses default rev \"default\"",
-					Range: hcl.Range{
-						Filename: "module.tf",
-						Start:    hcl.Pos{Line: 3, Column: 12},
-						End:      hcl.Pos{Line: 3, Column: 52},
+						End:      hcl.Pos{Line: 3, Column: 64},
 					},
 				},
 			},
@@ -247,7 +229,7 @@ module "default_git" {
 			Name: "bitbucket git module reference is pinned",
 			Content: `
 module "pinned_git" {
-  source = "bitbucket.org/hashicorp/consul.git?ref=pinned"
+  source = "bitbucket.org/hashicorp/tf-test-git.git?ref=pinned"
 }`,
 			Expected: tflint.Issues{},
 		},
@@ -255,7 +237,7 @@ module "pinned_git" {
 			Name: "bitbucket git module reference is pinned, but style is semver",
 			Content: `
 module "pinned_git" {
-  source = "bitbucket.org/hashicorp/consul.git?ref=pinned"
+  source = "bitbucket.org/hashicorp/tf-test-git.git?ref=pinned"
 }`,
 			Config: `
 rule "terraform_module_pinned_source" {
@@ -265,11 +247,11 @@ rule "terraform_module_pinned_source" {
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"bitbucket.org/hashicorp/consul.git?ref=pinned\" uses a ref which is not a version string",
+					Message: "Module source \"bitbucket.org/hashicorp/tf-test-git.git?ref=pinned\" uses a ref which is not a version string",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},
-						End:      hcl.Pos{Line: 3, Column: 59},
+						End:      hcl.Pos{Line: 3, Column: 64},
 					},
 				},
 			},
@@ -278,64 +260,12 @@ rule "terraform_module_pinned_source" {
 			Name: "bitbucket git module reference is pinned to semver",
 			Content: `
 module "pinned_git" {
-  source = "bitbucket.org/hashicorp/consul.git?ref=v1.2.3"
+  source = "bitbucket.org/hashicorp/tf-test-git.git?ref=v1.2.3"
 }`,
 			Config: `
 rule "terraform_module_pinned_source" {
   enabled = true
   style = "semver"
-}`,
-			Expected: tflint.Issues{},
-		},
-		{
-			Name: "bitbucket mercurial module reference is pinned",
-			Content: `
-module "pinned_git" {
-  source = "bitbucket.org/hg/mercurial?rev=pinned"
-}`,
-			Expected: tflint.Issues{},
-		},
-		{
-			Name: "bitbucket mercurial module reference is pinned, but style is semver",
-			Content: `
-module "pinned_git" {
-  source = "bitbucket.org/hg/mercurial?rev=pinned"
-}`,
-			Config: `
-rule "terraform_module_pinned_source" {
-  enabled = true
-  style = "semver"
-}`,
-			Expected: tflint.Issues{
-				{
-					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"bitbucket.org/hg/mercurial?rev=pinned\" uses a rev which is not a version string",
-					Range: hcl.Range{
-						Filename: "module.tf",
-						Start:    hcl.Pos{Line: 3, Column: 12},
-						End:      hcl.Pos{Line: 3, Column: 51},
-					},
-				},
-			},
-		},
-		{
-			Name: "bitbucket mercurial module reference is pinned to semver",
-			Content: `
-module "pinned_git" {
-  source = "bitbucket.org/hg/mercurial?rev=v1.2.3"
-}`,
-			Config: `
-rule "terraform_module_pinned_source" {
-  enabled = true
-  style = "semver"
-}`,
-			Expected: tflint.Issues{},
-		},
-		{
-			Name: "bitbucket mercurial module reference is pinned to semver (no leading v)",
-			Content: `
-module "pinned_git" {
-  source = "bitbucket.org/hg/mercurial?rev=1.2.3"
 }`,
 			Expected: tflint.Issues{},
 		},
@@ -505,13 +435,16 @@ rule "terraform_module_pinned_source" {
 	rule := NewTerraformModulePinnedSourceRule()
 
 	for _, tc := range cases {
-		runner := tflint.TestRunnerWithConfig(t, map[string]string{"module.tf": tc.Content}, loadConfigfromTempFile(t, tc.Config))
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			runner := tflint.TestRunnerWithConfig(t, map[string]string{"module.tf": tc.Content}, loadConfigfromTempFile(t, tc.Config))
 
-		if err := rule.Check(runner); err != nil {
-			t.Fatalf("Unexpected error occurred: %s", err)
-		}
+			if err := rule.Check(runner); err != nil {
+				t.Fatalf("Unexpected error occurred: %s", err)
+			}
 
-		tflint.AssertIssues(t, tc.Expected, runner.Issues)
+			tflint.AssertIssues(t, tc.Expected, runner.Issues)
+		})
 	}
 }
 


### PR DESCRIPTION
This PR refactors the `terraform_module_pinned_source` to remove:

* A lot of duplicated logic
* Complex regular expressions (replaced by URL/semver parsers)
* [Mercurial support](https://bitbucket.org/blog/sunsetting-mercurial-support-in-bitbucket) for Bitbucket, which they don't offer anymore

I'll bring in #1123 once I land this