### PR TITLE
terraform_module_pinned_source: support additional default_branches

### DIFF
--- a/docs/rules/terraform_module_pinned_source.md
+++ b/docs/rules/terraform_module_pinned_source.md
@@ -100,7 +100,7 @@ Warning: Module source "git://hashicorp.com/consul.git" is not pinned (terraform
 
 Reference: https://github.com/terraform-linters/tflint/blob/v0.15.0/docs/rules/terraform_module_pinned_source.md
 
-Warning: Module source "git://hashicorp.com/consul.git?ref=feature" uses a ref which is not a version string (terraform_module_pinned_source)
+Warning: Module source "git://hashicorp.com/consul.git?ref=feature" uses a ref which is not a semantic version string (terraform_module_pinned_source)
 
   on template.tf line 6:
    6:   source = "git://hashicorp.com/consul.git?ref=feature"

--- a/docs/rules/terraform_module_pinned_source.md
+++ b/docs/rules/terraform_module_pinned_source.md
@@ -8,13 +8,17 @@ Name | Default | Value
 --- | --- | ---
 enabled | true | Boolean
 style | `flexible` | `flexible`, `semver`
+default_branches | `["master", "main", "default", "develop"]` | 
 
 ```hcl
 rule "terraform_module_pinned_source" {
   enabled = true
   style = "flexible"
+  default_branches = ["dev"]
 }
 ```
+
+Configured `default_branches` will be appended to the defaults rather than overriding them.
 
 ## Example
 

--- a/docs/rules/terraform_module_pinned_source.md
+++ b/docs/rules/terraform_module_pinned_source.md
@@ -55,14 +55,14 @@ Warning: Module source "git://hashicorp.com/consul.git" is not pinned (terraform
 
 Reference: https://github.com/terraform-linters/tflint/blob/v0.15.0/docs/rules/terraform_module_pinned_source.md
 
-Warning: Module source "git://hashicorp.com/consul.git?ref=master" uses default ref "master" (terraform_module_pinned_source)
+Warning: Module source "git://hashicorp.com/consul.git?ref=master" uses a default branch as ref (master) (terraform_module_pinned_source)
 
   on template.tf line 6:
    6:   source = "git://hashicorp.com/consul.git?ref=master"
 
 Reference: https://github.com/terraform-linters/tflint/blob/v0.15.0/docs/rules/terraform_module_pinned_source.md
 
-Warning: Module source "hg::http://hashicorp.com/consul.hg?rev=default" uses default rev "default" (terraform_module_pinned_source)
+Warning: Module source "hg::http://hashicorp.com/consul.hg?rev=default" uses a default branch as rev (default) (terraform_module_pinned_source)
 
   on template.tf line 10:
   10:   source = "hg::http://hashicorp.com/consul.hg?rev=default"

--- a/rules/terraformrules/terraform_module_pinned_source.go
+++ b/rules/terraformrules/terraform_module_pinned_source.go
@@ -121,7 +121,7 @@ func (r *TerraformModulePinnedSourceRule) checkRevision(runner *tflint.Runner, m
 			if value == branch {
 				runner.EmitIssue(
 					r,
-					fmt.Sprintf("Module source \"%s\" uses default %s \"%s\"", module.SourceAddr, key, branch),
+					fmt.Sprintf("Module source \"%s\" uses a default branch as %s (%s)", module.SourceAddr, key, branch),
 					module.SourceAddrRange,
 				)
 

--- a/rules/terraformrules/terraform_module_pinned_source_test.go
+++ b/rules/terraformrules/terraform_module_pinned_source_test.go
@@ -51,7 +51,7 @@ module "default_git" {
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"git://hashicorp.com/consul.git?ref=master\" uses default ref \"master\"",
+					Message: "Module source \"git://hashicorp.com/consul.git?ref=master\" uses a default branch as ref (master)",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},
@@ -82,7 +82,7 @@ rule "terraform_module_pinned_source" {
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"git://hashicorp.com/consul.git?ref=pinned\" uses a ref which is not a version string",
+					Message: "Module source \"git://hashicorp.com/consul.git?ref=pinned\" uses a ref which is not a semantic version string",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},
@@ -162,7 +162,7 @@ module "default_git" {
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"github.com/hashicorp/consul.git?ref=master\" uses default ref \"master\"",
+					Message: "Module source \"github.com/hashicorp/consul.git?ref=master\" uses a default branch as ref (master)",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},
@@ -201,7 +201,7 @@ rule "terraform_module_pinned_source" {
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"github.com/hashicorp/consul.git?ref=pinned\" uses a ref which is not a version string",
+					Message: "Module source \"github.com/hashicorp/consul.git?ref=pinned\" uses a ref which is not a semantic version string",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},
@@ -250,7 +250,7 @@ module "default_git" {
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"bitbucket.org/hashicorp/tf-test-git.git?ref=master\" uses default ref \"master\"",
+					Message: "Module source \"bitbucket.org/hashicorp/tf-test-git.git?ref=master\" uses a default branch as ref (master)",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},
@@ -281,7 +281,7 @@ rule "terraform_module_pinned_source" {
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"bitbucket.org/hashicorp/tf-test-git.git?ref=pinned\" uses a ref which is not a version string",
+					Message: "Module source \"bitbucket.org/hashicorp/tf-test-git.git?ref=pinned\" uses a ref which is not a semantic version string",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},
@@ -351,7 +351,7 @@ module "default_generic_git_https" {
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"git::https://hashicorp.com/consul.git?ref=master\" uses default ref \"master\"",
+					Message: "Module source \"git::https://hashicorp.com/consul.git?ref=master\" uses a default branch as ref (master)",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},
@@ -370,7 +370,7 @@ module "default_generic_git_ssh" {
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"git::ssh://git@github.com/owner/repo.git?ref=master\" uses default ref \"master\"",
+					Message: "Module source \"git::ssh://git@github.com/owner/repo.git?ref=master\" uses a default branch as ref (master)",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},
@@ -396,6 +396,29 @@ module "pinned_generic_git_ssh" {
 }
 `,
 			Expected: tflint.Issues{},
+		},
+		{
+			Name: "github module reference is unpinned via custom branches",
+			Content: `
+module "pinned_git" {
+  source = "github.com/hashicorp/consul.git?ref=foo"
+}`,
+			Config: `
+rule "terraform_module_pinned_source" {
+  enabled = true
+  default_branches = ["foo"]
+}`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformModulePinnedSourceRule(),
+					Message: "Module source \"github.com/hashicorp/consul.git?ref=foo\" uses a default branch as ref (foo)",
+					Range: hcl.Range{
+						Filename: "module.tf",
+						Start:    hcl.Pos{Line: 3, Column: 12},
+						End:      hcl.Pos{Line: 3, Column: 53},
+					},
+				},
+			},
 		},
 		{
 			Name: "mercurial module is not pinned",
@@ -424,7 +447,7 @@ module "default_mercurial" {
 			Expected: tflint.Issues{
 				{
 					Rule:    NewTerraformModulePinnedSourceRule(),
-					Message: "Module source \"hg::http://hashicorp.com/consul.hg?rev=default\" uses default rev \"default\"",
+					Message: "Module source \"hg::http://hashicorp.com/consul.hg?rev=default\" uses a default branch as rev (default)",
 					Range: hcl.Range{
 						Filename: "module.tf",
 						Start:    hcl.Pos{Line: 3, Column: 12},


### PR DESCRIPTION
Expands the list of default branches and allows users to configure additional branch names via config. Adapted from #1123. 

```hcl
rule "terraform_module_pinned_source" {
  enabled = true
  default_branches = ["dev"]
}
```

```hcl
module "unpinned" {
  source = "git://hashicorp.com/consul.git?ref=dev"
}
```

```
Warning: Module source "git://hashicorp.com/consul.git?ref=dev" uses a default branch as ref (dev) (terraform_module_pinned_source)
```


Closes #1123