### PR TITLE
Expose Files() runner method to Server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20181119182933-0c7d621186c1
 	github.com/sourcegraph/jsonrpc2 v0.0.0-20190106185902-35a74f039c6a
 	github.com/spf13/afero v1.2.2 // matches version used by terraform
-	github.com/terraform-linters/tflint-plugin-sdk v0.8.2
+	github.com/terraform-linters/tflint-plugin-sdk v0.8.3-0.20210614125323-8364139f3745
 	github.com/terraform-linters/tflint-ruleset-aws v0.4.1
 	github.com/zclconf/go-cty v1.8.3
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a

--- a/go.sum
+++ b/go.sum
@@ -544,8 +544,9 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
-github.com/terraform-linters/tflint-plugin-sdk v0.8.2 h1:A46VFbdBH8K1JwFjC4X5hbW35oL6gIoRxjlzzz27q7I=
 github.com/terraform-linters/tflint-plugin-sdk v0.8.2/go.mod h1:UsVDOw0Urg0POULWugZ6XFzWJ6i0NaTFYtlYrQe4Auw=
+github.com/terraform-linters/tflint-plugin-sdk v0.8.3-0.20210614125323-8364139f3745 h1:Pfug/EdNJFp82PJh1EjOCrF4sXIR+MA/K5Xsgdja2Ek=
+github.com/terraform-linters/tflint-plugin-sdk v0.8.3-0.20210614125323-8364139f3745/go.mod h1:UsVDOw0Urg0POULWugZ6XFzWJ6i0NaTFYtlYrQe4Auw=
 github.com/terraform-linters/tflint-ruleset-aws v0.4.1 h1:g+c6nrHl09W2RmSbEZG4UtIVKVknERHPTMQysukuTsk=
 github.com/terraform-linters/tflint-ruleset-aws v0.4.1/go.mod h1:OoFdm8gUCOiKHlhvZQ1/r8EhGF75aYUM/URrBFjIXus=
 github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210603220658-c16ad68fc0b6/go.mod h1:9t9ETRrldqJ/AI5x4zJYywM0ykXJR2PmaSj/ir0lJjY=

--- a/plugin/server.go
+++ b/plugin/server.go
@@ -134,6 +134,20 @@ func (s *Server) File(req *tfplugin.FileRequest, resp *tfplugin.FileResponse) er
 	return nil
 }
 
+// Files returns the corresponding hcl.File representation (in bytes) of all Terraform
+// configuration in the module directory.
+func (s *Server) Files(req *tfplugin.FilesRequest, resp *tfplugin.FilesResponse) error {
+	*resp = tfplugin.FilesResponse{
+		Files: map[string][]byte{},
+		Err:   nil,
+	}
+
+	for name, file := range s.runner.Files() {
+		resp.Files[name] = file.Bytes
+	}
+	return nil
+}
+
 // RootProvider returns the provider configuration on the root module as tfplugin.Provider
 func (s *Server) RootProvider(req *tfplugin.RootProviderRequest, resp *tfplugin.RootProviderResponse) error {
 	provider, exists := s.rootRunner.TFConfig.Module.ProviderConfigs[req.Name]


### PR DESCRIPTION
**Abstract**

This PR exposes `Files()` method to [tflint-plugin-sdk](https://github.com/terraform-linters/tflint-plugin-sdk/issues/118). Current implementation already has the `File(filename string)` method exposed.

**Rationale**

Linting is the process of spotting potential errors. These errors can cause problems not only during the code execution but also to the business logic. Clean and organised files are often mandatory to maintainability. Some rules, however, make sense to one specific project or company. [tflint-plugin-sdk](https://github.com/terraform-linters/tflint-plugin-sdk) helps to extend _**tflint**_ in a way where each company can implement their own set of rules. 

**Use cases**

This PR exposes the `Files()` method in order to allow the developer to create more low-level/business-specific rules. A few examples are:
 - Checks if the body of a provider is empty, where the company does not allow it.
 - Keeps blocks in alphabetical order, when needed, for cleansing aspects.
 - Helps to stick to business-defined naming conventions.
 - Helps to block cross-environment actions, dev to prod and vice-versa.

Arguably, some of these rules can be achieved in other ways, but once we can extend _tflinf_ in plugins, I think its utilisation is correct in these cases. This PR depends on https://github.com/terraform-linters/tflint-plugin-sdk/pull/122/files already merged.

**Closes:** 
- https://github.com/terraform-linters/tflint-plugin-sdk/issues/118
 - https://github.com/terraform-linters/tflint-plugin-sdk/issues/119

Any improvement that you guys think to this PR, I will be happy to change.