### PR TITLE
plugin: Allow authenticated requests via GITHUB_TOKEN

### DIFF
--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -58,6 +58,16 @@ Plugins under the terraform-linters organization (AWS/GCP/Azure ruleset plugins)
 
 AWS plugin is bundled with the TFLint binary for backward compatibility, so you can use it without installing it separately. And it is automatically enabled when your Terraform configuration requires AWS provider.
 
+## Avoiding rate limiting
+
+When you install plugins with `tflint --init`, call the GitHub API to get release metadata. This is typically an unauthenticated request with a rate limit of 60 requests per hour.
+
+https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
+
+This limitation can be a problem if you need to run `--init` frequently, such as in CI environments. If you want to increase the rate limit, you can send an authenticated request by setting an OAuth2 access token in the `GITHUB_TOKEN` environment variable.
+
+It's also a good idea to cache the plugin directory, as TFLint will only send requests if plugins aren't installed. See also the [setup-tflint's example](https://github.com/terraform-linters/setup-tflint#usage).
+
 ## Advanced Usage
 
 You can also install the plugin manually. This is mainly useful for plugin development and for plugins that are not published on GitHub. In that case, omit the `source` and `version` attributes.

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/mod v0.4.2
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
+	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
 	golang.org/x/text v0.3.6
 	google.golang.org/api v0.34.0 // indirect


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/issues/1142

There is a rate limit of 60 requests per hour by default. This PR adds the ability to set the `GITHUB_TOKEN` environment variable, you can use the PAT or GitHub Actions' token, etc to increase the rate limit.