### PR TITLE
install: allow passing `$TFLINT_INSTALL_PATH`

### DIFF
--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         submodules: true
     - name: Append to /bin to Windows $PATH
-      if: ${{ matrix.os == 'windows' }}
+      if: ${{ startsWith(matrix.os, 'windows') }}
       run: echo /bin >> "$GITHUB_PATH"
       shell: bash
     - name: Install latest version

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -23,11 +23,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Append to /bin to Windows $PATH
-      if: ${{ startsWith(matrix.os, 'windows') }}
-      shell: powershell
-      run: |
-        echo "$($(Get-Location).Drive.Root)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Install latest version
       run: |
         ./install_linux.sh

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -22,7 +22,7 @@ jobs:
         submodules: true
     - name: Append to /bin to Windows $PATH
       if: ${{ startsWith(matrix.os, 'windows') }}
-      run: echo "$pwd.drive.name\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Appendbash
+      run: echo "$pwd.drive.name\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Install latest version
       run: |
         ./install_linux.sh

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -22,18 +22,18 @@ jobs:
         submodules: true
     - name: Install latest version
       run: |
-        install_linux.sh
+        ./install_linux.sh
         tflint -v
     - name: Install specific version
       env:
         TFLINT_VERSION: v0.15.0
       run: |
-        install_linux.sh
+        ./install_linux.sh
         tflint -v
     - name: Install to custom path
       run: |
         sudo mkdir -p "$TFLINT_INSTALL_PATH"
-        install_linux.sh
+        ./install_linux.sh
         "$TFLINT_INSTALL_PATH/tflint" -v
       env:
         TFLINT_INSTALL_PATH: /custom/tflint
@@ -51,11 +51,11 @@ jobs:
         apk add bash curl unzip
     - name: Install latest version
       run: |
-        install_linux.sh
+        ./install_linux.sh
         tflint -v
     - name: Install specific version
       env:
         TFLINT_VERSION: v0.15.0
       run: |
-        install_linux.sh
+        ./install_linux.sh
         tflint -v

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -22,7 +22,8 @@ jobs:
         submodules: true
     - name: Append to /bin to Windows $PATH
       if: ${{ startsWith(matrix.os, 'windows') }}
-      run: echo "$pwd.drive.name\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      run: |
+        echo "$($(Get-Location).Drive.Root)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Install latest version
       run: |
         echo "$PATH"

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -23,11 +23,20 @@ jobs:
     - name: Install latest version
       run: |
         bash install_linux.sh
+        tflint -v
     - name: Install specific version
       env:
         TFLINT_VERSION: v0.15.0
       run: |
         bash install_linux.sh
+        tflint -v
+    - name: Install to custom path
+      run: |
+        mkdir "$TFLINT_INSTALL_PATH"
+        bash install_linux.sh
+        "$TFLINT_INSTALL_PATH/tflint" -v
+      env:
+        TFLINT_INSTALL_PATH: /custom/tflint
   container:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -20,6 +20,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Append to /bin to Windows $PATH
+      if: ${{ matrix.os == 'windows' }}
+      run: echo /bin >> "$GITHUB_PATH"
+      shell: bash
     - name: Install latest version
       run: |
         ./install_linux.sh

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -25,6 +25,7 @@ jobs:
       run: echo "$pwd.drive.name\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Install latest version
       run: |
+        echo "$PATH"
         ./install_linux.sh
         tflint -v
     - name: Install specific version

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -7,9 +7,7 @@ on:
   pull_request:
     branches:
       - master
-defaults:
-  run:
-    shell: bash
+
 jobs:
   vm:
     name: ${{ matrix.os }}
@@ -17,6 +15,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -7,7 +7,9 @@ on:
   pull_request:
     branches:
       - master
-
+defaults:
+  run:
+    shell: bash
 jobs:
   vm:
     name: ${{ matrix.os }}
@@ -22,11 +24,11 @@ jobs:
         submodules: true
     - name: Append to /bin to Windows $PATH
       if: ${{ startsWith(matrix.os, 'windows') }}
+      shell: powershell
       run: |
         echo "$($(Get-Location).Drive.Root)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Install latest version
       run: |
-        echo "$PATH"
         ./install_linux.sh
         tflint -v
     - name: Install specific version

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -35,11 +35,10 @@ jobs:
         tflint -v
     - name: Install to custom path
       run: |
-        sudo mkdir -p "$TFLINT_INSTALL_PATH"
         ./install_linux.sh
-        "$TFLINT_INSTALL_PATH/tflint" -v
+        ./tflint" -v
       env:
-        TFLINT_INSTALL_PATH: /custom/tflint
+        TFLINT_INSTALL_PATH: ${{ github.workspace }}
       shell: bash
   container:
     runs-on: ubuntu-latest

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -35,10 +35,11 @@ jobs:
         tflint -v
     - name: Install to custom path
       run: |
+        mkdir "$TFLINT_INSTALL_PATH"
         ./install_linux.sh
-        ./tflint" -v
+        "$TFLINT_INSTALL_PATH/tflint" -v
       env:
-        TFLINT_INSTALL_PATH: ${{ github.workspace }}
+        TFLINT_INSTALL_PATH: ${{ github.workspace }}/install-path
       shell: bash
   container:
     runs-on: ubuntu-latest

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -22,8 +22,7 @@ jobs:
         submodules: true
     - name: Append to /bin to Windows $PATH
       if: ${{ startsWith(matrix.os, 'windows') }}
-      run: echo /bin >> "$GITHUB_PATH"
-      shell: bash
+      run: echo "$pwd.drive.name\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Appendbash
     - name: Install latest version
       run: |
         ./install_linux.sh

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -32,7 +32,7 @@ jobs:
         tflint -v
     - name: Install to custom path
       run: |
-        mkdir -p "$TFLINT_INSTALL_PATH"
+        sudo mkdir -p "$TFLINT_INSTALL_PATH"
         bash install_linux.sh
         "$TFLINT_INSTALL_PATH/tflint" -v
       env:

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -22,21 +22,22 @@ jobs:
         submodules: true
     - name: Install latest version
       run: |
-        bash install_linux.sh
+        install_linux.sh
         tflint -v
     - name: Install specific version
       env:
         TFLINT_VERSION: v0.15.0
       run: |
-        bash install_linux.sh
+        install_linux.sh
         tflint -v
     - name: Install to custom path
       run: |
         sudo mkdir -p "$TFLINT_INSTALL_PATH"
-        bash install_linux.sh
+        install_linux.sh
         "$TFLINT_INSTALL_PATH/tflint" -v
       env:
         TFLINT_INSTALL_PATH: /custom/tflint
+      shell: bash
   container:
     runs-on: ubuntu-latest
     container:
@@ -50,9 +51,11 @@ jobs:
         apk add bash curl unzip
     - name: Install latest version
       run: |
-        bash install_linux.sh
+        install_linux.sh
+        tflint -v
     - name: Install specific version
       env:
         TFLINT_VERSION: v0.15.0
       run: |
-        bash install_linux.sh
+        install_linux.sh
+        tflint -v

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -32,7 +32,7 @@ jobs:
         tflint -v
     - name: Install to custom path
       run: |
-        mkdir "$TFLINT_INSTALL_PATH"
+        mkdir -p "$TFLINT_INSTALL_PATH"
         bash install_linux.sh
         "$TFLINT_INSTALL_PATH/tflint" -v
       env:

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -85,7 +85,7 @@ else
 fi
 
 echo "Cleaning /tmp/tflint.zip and /tmp/tflint ..."
-rm /tmp/tflint.zip /tmp/tflint
+rm -f /tmp/tflint.zip /tmp/tflint
 
 echo -e "\n\n===================================================="
 echo "Current tflint version"

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -54,30 +54,33 @@ echo -e "\n\n===================================================="
 echo "Unpacking /tmp/tflint.zip ..."
 unzip -u /tmp/tflint.zip -d /tmp/
 if [[ $os == "windows"* ]]; then
-  echo "Installing /tmp/tflint to /bin..."
-  mv /tmp/tflint /bin/
+  dest="${TFLINT_INSTALL_PATH:-/bin}/"
+  echo "Installing /tmp/tflint to ${dest}..."
+  mv /tmp/tflint "$dest"
   retVal=$?
   if [ $retVal -ne 0 ]; then
     echo "Failed to install tflint"
     exit $retVal
   else
-    echo "tflint installed at /bin/ successfully"
+    echo "tflint installed at ${dest} successfully"
   fi
 else
-  echo "Installing /tmp/tflint to /usr/local/bin..."
+  dest="${TFLINT_INSTALL_PATH:-/usr/local/bin}/"
+  echo "Installing /tmp/tflint to ${dest}..."
   
   if [[ "$(id -u)" == 0 ]]; then SUDO=""; else
     SUDO="sudo";
   fi
 
-  $SUDO mkdir -p /usr/local/bin
-  $SUDO install -b -c -v /tmp/tflint /usr/local/bin/
+  
+  $SUDO mkdir -p "$dest"
+  $SUDO install -b -c -v /tmp/tflint "$dest"
   retVal=$?
   if [ $retVal -ne 0 ]; then
     echo "Failed to install tflint"
     exit $retVal
   else
-    echo "tflint installed at /usr/local/bin/ successfully"
+    echo "tflint installed at ${dest} successfully"
   fi
 fi
 


### PR DESCRIPTION
Supports a custom install path, `$TFLINT_INSTALL_PATH`, with the previous path as the default. 

Fixes #1182