### PR TITLE
cmd: Change exit status

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -19,8 +19,8 @@ import (
 
 // Exit codes are int values that represent an exit code for a particular error.
 const (
-	ExitCodeOK    int = 0
-	ExitCodeError int = 1 + iota
+	ExitCodeOK int = iota
+	ExitCodeError
 	ExitCodeIssuesFound
 )
 

--- a/docs/user-guide/config.md
+++ b/docs/user-guide/config.md
@@ -52,8 +52,8 @@ CLI flag: `--force`
 Return zero exit status even if issues found. TFLint returns the following exit statuses on exit by default:
 
 - 0: No issues found
-- 2: Errors occurred
-- 3: No errors occurred, but issues found
+- 1: Errors occurred
+- 2: No errors occurred, but issues found
 
 ## `disabled_by_default`
 


### PR DESCRIPTION
Fixes #528 

Change the exit status to what I originally intended.

Before:

- 0: No issues found
- 2: Errors occurred
- 3: No errors occurred, but issues found

After:

- 0: No issues found
- 1: Errors occurred
- 2: No errors occurred, but issues found

This is clearly a breaking change, but due to its natural behavior, it may be worth accepting.