### PR TITLE
Remove bundled AWS plugin language from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ If you are using an AWS/Azure/GCP provider, it is a good idea to install the plu
 - [Microsoft Azure](https://github.com/terraform-linters/tflint-ruleset-azurerm)
 - [Google Cloud Platform](https://github.com/terraform-linters/tflint-ruleset-google)
 
-For AWS users, you can use the bundled plugin built into the TFLint binary without installing the plugin separately for backward compatibility.
-
 Rules for the Terraform Language is built into the TFLint binary, so you don't need to install any plugins. Please see [Rules](docs/rules) for a list of available rules.
 
 If you want to extend TFLint with other plugins, you can declare the plugins in the config file and easily install them with `tflint --init`.

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -54,10 +54,6 @@ Plugin developer's PGP public signing key. When this attribute is set, TFLint wi
 
 Plugins under the terraform-linters organization (AWS/GCP/Azure ruleset plugins) can use the built-in signing key, so this attribute can be omitted.
 
-## Compatibility Notice
-
-AWS plugin is bundled with the TFLint binary for backward compatibility, so you can use it without installing it separately. And it is automatically enabled when your Terraform configuration requires AWS provider.
-
 ## Avoiding rate limiting
 
 When you install plugins with `tflint --init`, call the GitHub API to get release metadata. This is typically an unauthenticated request with a rate limit of 60 requests per hour.


### PR DESCRIPTION
Relates to #1160, the AWS plugin must be explicitly installed