### PR TITLE
Build Docker image for linux/aarch64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         platforms: ${{ matrix.platform }}
+        load: true
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         platform:
         - linux/amd64
-        - linux/aarch64
+        - linux/arm64/v8
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,11 +11,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform:
-        - linux/amd64
-        - linux/arm64/v8
+    env:
+      # Comma-delimited list of platforms to build for.
+      # See https://github.com/docker-library/official-images#multiple-architectures
+      DOCKER_PLATFORMS: linux/amd64,linux/arm64/v8
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -24,7 +23,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
       with:
-        platforms: ${{ matrix.platform }}
+        platforms: ${{ env.DOCKER_PLATFORMS }}
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Docker meta
@@ -41,10 +40,23 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
-        platforms: ${{ matrix.platform }}
-        load: true
+        platforms: ${{ env.DOCKER_PLATFORMS }}
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-    - name: docker run
-      run: docker run --platform ${{ matrix.platform }} ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }} -v
+    - name: Test
+      # NOTE(ivy): Docker Buildx doesn't support the --load flag when multiple
+      # platforms are specified but since pull requests aren't pushed, it's
+      # necessary to "re-run" the build (everything's already cached) to load
+      # each individual platform. When "docker manifest" is production-ready
+      # this will no longer be necessary.
+      run: |
+        platforms=(${DOCKER_PLATFORMS//,/ })
+        for p in "${platforms[@]}"; do
+          docker buildx build \
+            --load \
+            --platform "$p" \
+            --tag ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }} \
+            .
+          docker run --platform "$p" ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }} -v
+        done

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,6 @@ jobs:
       with:
         platforms: ${{ matrix.platform }}
     - name: Set up Docker Buildx
-      id: buildx
       uses: docker/setup-buildx-action@v1
     - name: Docker meta
       id: meta

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,11 +11,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+        - linux/amd64
+        - linux/aarch64
     steps:
     - name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: ${{ matrix.platform }}
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v3
@@ -30,8 +42,9 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
+        platforms: ${{ matrix.platform }}
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
     - name: docker run
-      run: docker run ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }} -v
+      run: docker run --platform ${{ matrix.platform }} ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }} -v


### PR DESCRIPTION
I noticed there's only a Docker image for `linux/amd64` and wanted to propose adding support for `linux/aarch64`. It's pretty useful to me as an Apple M1 and Docker Desktop user since I can get native performance out of tflint and avoid potential hiccups with x86_64 emulation. 😄 