### PR TITLE
build: Update GoReleaser version

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,27 @@
+name: goreleaser
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+    - name: goreleaser check
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        version: v0.178.0
+        args: check

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -25,8 +25,3 @@ jobs:
       with:
         version: v0.178.0
         args: check
-    - name: goreleaser build
-      uses: goreleaser/goreleaser-action@v2
-      with:
-        version: v0.178.0
-        args: build --snapshot

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -25,3 +25,8 @@ jobs:
       with:
         version: v0.178.0
         args: check
+    - name: goreleaser build
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        version: v0.178.0
+        args: build --snapshot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
       with:
         submodules: true
     - name: Set up Go
-      uses: actions/setup-go@v2.1.4
+      uses: actions/setup-go@v2
       with:
         go-version: 1.17
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        version: v0.169.0
+        version: v0.178.0
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GoReleaser v0.169.0 doesn't support darwin/arm64 build with Go 1.17.
https://github.com/goreleaser/goreleaser/issues/2412

As a result, v0.32.0 release doesn't include darwin/arm64 build. This PR updates the GoReleaser version to fix the issue.