### PR TITLE
`terraform_unused_required_providers`: handle module provider overrides

### DIFF
--- a/rules/terraformrules/terraform_unused_required_providers.go
+++ b/rules/terraformrules/terraform_unused_required_providers.go
@@ -71,6 +71,14 @@ func (r *TerraformUnusedRequiredProvidersRule) checkProvider(runner *tflint.Runn
 		}
 	}
 
+	for _, module := range runner.TFConfig.Module.ModuleCalls {
+		for _, provider := range module.Providers {
+			if provider.InParent.Name == required.Name {
+				return
+			}
+		}
+	}
+
 	runner.EmitIssue(
 		r,
 		fmt.Sprintf("provider '%s' is declared in required_providers but not used by the module", required.Name),


### PR DESCRIPTION
When a required provider is passed down to a module, the `terraform_unused_required_providers` rule still reports the provider as unused. This checks all provider configurations _explicitly_ passed into modules and counts those required providers as used. 

It remains a lint error to declare a required provider when it is _implicitly_ inherited by the child module, as that declaration is the child's responsibility.

Closes #1189