### PR TITLE
terraform_module_pinned_source: do not assume gitlab URLs are git protocol

### DIFF
--- a/rules/terraformrules/terraform_module_pinned_source.go
+++ b/rules/terraformrules/terraform_module_pinned_source.go
@@ -78,7 +78,15 @@ func (r *TerraformModulePinnedSourceRule) Check(runner *tflint.Runner) error {
 func (r *TerraformModulePinnedSourceRule) checkModule(runner *tflint.Runner, module *configs.ModuleCall, config terraformModulePinnedSourceRuleConfig) error {
 	log.Printf("[DEBUG] Walk `%s` attribute", module.Name+".source")
 
-	source, err := getter.Detect(module.SourceAddr, filepath.Dir(module.DeclRange.Filename), getter.Detectors)
+	source, err := getter.Detect(module.SourceAddr, filepath.Dir(module.DeclRange.Filename), []getter.Detector{
+		// https://github.com/hashicorp/terraform/blob/51b0aee36cc2145f45f5b04051a01eb6eb7be8bf/internal/getmodules/getter.go#L30-L52
+		new(getter.GitHubDetector),
+		new(getter.GitDetector),
+		new(getter.BitBucketDetector),
+		new(getter.GCSDetector),
+		new(getter.S3Detector),
+		new(getter.FileDetector),
+	})
 	if err != nil {
 		return err
 	}

--- a/rules/terraformrules/terraform_module_pinned_source_test.go
+++ b/rules/terraformrules/terraform_module_pinned_source_test.go
@@ -510,7 +510,7 @@ rule "terraform_module_pinned_source" {
 			Content: `
 module "m" {
   source = "gitlab.com/namespace/module_name/module_system"
-	version = "1.0.0"
+  version = "1.0.0"
 }`,
 			Expected: tflint.Issues{},
 		},

--- a/rules/terraformrules/terraform_module_pinned_source_test.go
+++ b/rules/terraformrules/terraform_module_pinned_source_test.go
@@ -505,6 +505,15 @@ rule "terraform_module_pinned_source" {
 				},
 			},
 		},
+		{
+			Name: "gitlab registry module",
+			Content: `
+module "m" {
+  source = "gitlab.com/namespace/module_name/module_system"
+	version = "1.0.0"
+}`,
+			Expected: tflint.Issues{},
+		},
 	}
 
 	rule := NewTerraformModulePinnedSourceRule()


### PR DESCRIPTION
When using all of `go-getter`'s default detectors, GitLab URLs are detected and assumed to be Git URLs. This is not the case for users of GitLab's hosted Terraform registry:

https://docs.gitlab.com/ee/user/packages/terraform_module_registry/

It's also not how Terraform parses those URLs, which is the intent of the rule. Now the implementation matches Terraform.

Closes #1226 