### PR TITLE
Adds SARIF as a supported output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,25 +96,25 @@ Usage:
   tflint [OPTIONS] [FILE or DIR...]
 
 Application Options:
-  -v, --version                                           Print TFLint version
-      --init                                              Install plugins
-      --langserver                                        Start language server
-  -f, --format=[default|json|checkstyle|junit|compact]    Output format (default: default)
-  -c, --config=FILE                                       Config file name (default: .tflint.hcl)
-      --ignore-module=SOURCE                              Ignore module sources
-      --enable-rule=RULE_NAME                             Enable rules from the command line
-      --disable-rule=RULE_NAME                            Disable rules from the command line
-      --only=RULE_NAME                                    Enable only this rule, disabling all other defaults. Can be specified multiple times
-      --enable-plugin=PLUGIN_NAME                         Enable plugins from the command line
-      --var-file=FILE                                     Terraform variable file name
-      --var='foo=bar'                                     Set a Terraform variable
-      --module                                            Inspect modules
-      --force                                             Return zero exit status even if issues found
-      --no-color                                          Disable colorized output
-      --loglevel=[trace|debug|info|warn|error]            Change the loglevel
+  -v, --version                                                 Print TFLint version
+      --init                                                    Install plugins
+      --langserver                                              Start language server
+  -f, --format=[default|json|checkstyle|junit|compact|sarif]    Output format (default: default)
+  -c, --config=FILE                                             Config file name (default: .tflint.hcl)
+      --ignore-module=SOURCE                                    Ignore module sources
+      --enable-rule=RULE_NAME                                   Enable rules from the command line
+      --disable-rule=RULE_NAME                                  Disable rules from the command line
+      --only=RULE_NAME                                          Enable only this rule, disabling all other defaults. Can be specified multiple times
+      --enable-plugin=PLUGIN_NAME                               Enable plugins from the command line
+      --var-file=FILE                                           Terraform variable file name
+      --var='foo=bar'                                           Set a Terraform variable
+      --module                                                  Inspect modules
+      --force                                                   Return zero exit status even if issues found
+      --no-color                                                Disable colorized output
+      --loglevel=[trace|debug|info|warn|error]                  Change the loglevel
 
 Help Options:
-  -h, --help                                              Show this help message
+  -h, --help                                                    Show this help message
 
 ```
 

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -13,7 +13,7 @@ type Options struct {
 	Version        bool     `short:"v" long:"version" description:"Print TFLint version"`
 	Init           bool     `long:"init" description:"Install plugins"`
 	Langserver     bool     `long:"langserver" description:"Start language server"`
-	Format         string   `short:"f" long:"format" description:"Output format" choice:"default" choice:"json" choice:"checkstyle" choice:"junit" choice:"compact" default:"default"`
+	Format         string   `short:"f" long:"format" description:"Output format" choice:"default" choice:"json" choice:"checkstyle" choice:"junit" choice:"compact" choice:"sarif" default:"default"`
 	Config         string   `short:"c" long:"config" description:"Config file name" value-name:"FILE" default:".tflint.hcl"`
 	IgnoreModules  []string `long:"ignore-module" description:"Ignore module sources" value-name:"SOURCE"`
 	EnableRules    []string `long:"enable-rule" description:"Enable rules from the command line" value-name:"RULE_NAME"`

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -28,6 +28,8 @@ func (f *Formatter) Print(issues tflint.Issues, err *tflint.Error, sources map[s
 		f.junitPrint(issues, err, sources)
 	case "compact":
 		f.compactPrint(issues, err, sources)
+	case "sarif":
+		f.sarifPrint(issues, err, sources)
 	default:
 		f.prettyPrint(issues, err, sources)
 	}

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -1,0 +1,54 @@
+package formatter
+
+import (
+	"fmt"
+
+	"github.com/owenrumney/go-sarif/sarif"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func (f *Formatter) sarifPrint(issues tflint.Issues, tferr *tflint.Error, sources map[string][]byte) {
+	report, err := sarif.New(sarif.Version210)
+	if err != nil {
+		panic(err)
+	}
+
+	run := sarif.NewRun("tflint", "https://github.com/terraform-linters/tflint")
+	report.AddRun(run)
+
+	for _, issue := range issues {
+		rule := run.AddRule(issue.Rule.Name()).WithHelpURI(issue.Rule.Link())
+
+		var level string
+		switch issue.Rule.Severity() {
+		case tflint.ERROR:
+			level = "error"
+		case tflint.NOTICE:
+			level = "note"
+		case tflint.WARNING:
+			level = "warning"
+		default:
+			panic(fmt.Errorf("Unexpected lint type: %s", issue.Rule.Severity()))
+		}
+
+		location := sarif.NewPhysicalLocation().
+			WithArtifactLocation(sarif.NewSimpleArtifactLocation(issue.Range.Filename)).
+			WithRegion(
+				sarif.NewRegion().
+					WithStartLine(issue.Range.Start.Line).
+					WithStartColumn(issue.Range.Start.Column).
+					WithEndLine(issue.Range.End.Line).
+					WithEndColumn(issue.Range.End.Column),
+			)
+
+		run.AddResult(rule.ID).
+			WithLevel(level).
+			WithLocation(sarif.NewLocationWithPhysicalLocation(location)).
+			WithMessage(sarif.NewTextMessage(issue.Message))
+	}
+
+	err = report.PrettyWrite(f.Stdout)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/formatter/sarif_test.go
+++ b/formatter/sarif_test.go
@@ -1,0 +1,109 @@
+package formatter
+
+import (
+	"bytes"
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_sarifPrint(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Issues tflint.Issues
+		Error  *tflint.Error
+		Stdout string
+	}{
+		{
+			Name:   "no issues",
+			Issues: tflint.Issues{},
+			Stdout: `{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "tflint",
+          "informationUri": "https://github.com/terraform-linters/tflint"
+        }
+      },
+      "results": []
+    }
+  ]
+}`,
+		},
+		{
+			Name: "issues",
+			Issues: tflint.Issues{
+				{
+					Rule:    &testRule{},
+					Message: "test",
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+			},
+			Stdout: `{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "tflint",
+          "informationUri": "https://github.com/terraform-linters/tflint",
+          "rules": [
+            {
+              "id": "test_rule",
+              "shortDescription": null,
+              "helpUri": "https://github.com"
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "test_rule",
+          "level": "error",
+          "message": {
+            "text": "test"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "test.tf"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 4
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}`,
+		},
+	}
+
+	for _, tc := range cases {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		formatter := &Formatter{Stdout: stdout, Stderr: stderr}
+
+		formatter.sarifPrint(tc.Issues, tc.Error, map[string][]byte{})
+
+		if stdout.String() != tc.Stdout {
+			t.Fatalf("Failed %s test: expected=%s, stdout=%s", tc.Name, tc.Stdout, stdout.String())
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/jstemmer/go-junit-report v0.9.1
 	github.com/mattn/go-colorable v0.1.9
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/owenrumney/go-sarif v1.0.11
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/sourcegraph/jsonrpc2 v0.1.0
 	github.com/spf13/afero v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuKHUCQ=
+github.com/owenrumney/go-sarif v1.0.11 h1:7k4TLSi6h3vAozSECjO0arcQoeUNDMgvA7LDac95sJo=
+github.com/owenrumney/go-sarif v1.0.11/go.mod h1:hTBFbxU7GuVRUvwMx+eStp9M/Oun4xHCS3vqpPvket8=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
@@ -304,6 +306,7 @@ github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLE
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zclconf/go-cty v1.8.4/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.9.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.9.1 h1:viqrgQwFl5UpSxc046qblj78wZXVDFnSOufaOTER+cc=
 github.com/zclconf/go-cty v1.9.1/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=


### PR DESCRIPTION
Adds [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.0/sarif-v2.0.html) as an output format. 

SARIF is nice as it is used (or understood) by GitHub code scanning as an input artifact, allowing Github to manage findings and annotate PRs, etc. I have found this very useful with tfsec, this PR is very much inspired by it.

The test suite crashes on my darwin system (though the formatter tests work fine). Fingers crossed they will run fine in GitHub actions, for now :)