### PR TITLE
config: Add `plugin_dir` config

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -17,7 +17,7 @@ func (cli *CLI) init(opts Options) int {
 	}
 
 	for _, pluginCfg := range cfg.Plugins {
-		installCfg := tfplugin.NewInstallConfig(pluginCfg)
+		installCfg := tfplugin.NewInstallConfig(cfg, pluginCfg)
 
 		// If version or source is not set, you need to install it manually
 		if installCfg.ManuallyInstalled() {

--- a/docs/user-guide/config.md
+++ b/docs/user-guide/config.md
@@ -9,6 +9,8 @@ The config file is written in [HCL](https://github.com/hashicorp/hcl). An exampl
 
 ```hcl
 config {
+  plugin_dir = "~/.tflint.d/plugins"
+
   module = true
   force = false
   disabled_by_default = false
@@ -38,6 +40,10 @@ You can also use another file as a config file with the `--config` option:
 ```
 $ tflint --config other_config.hcl
 ```
+
+### `plugin_dir`
+
+Set the plugin directory. The default is `~/.tflint.d/plugins` (or `./.tflint.d/plugins`). See also [Configuring Plugins](plugins.md#advanced-usage)
 
 ### `module`
 

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -54,6 +54,14 @@ Plugin developer's PGP public signing key. When this attribute is set, TFLint wi
 
 Plugins under the terraform-linters organization (AWS/GCP/Azure ruleset plugins) can use the built-in signing key, so this attribute can be omitted.
 
+## Plugin directory
+
+Plugins are usually installed under `~/.tflint.d/plugins`. Exceptionally, if you already have `./.tflint.d/plugins` in your working directory, it will be installed there.
+
+The automatically installed plugins are placed as `[plugin dir]/[source]/[version]/tflint-ruleset-[name]`. (`tflint-ruleset-[name].exe` in Windows).
+
+If you want to change the plugin directory, you can change this with the [`plugin_dir`](config.md#plugin_dir) or `TFLINT_PLUGIN_DIR` environment variable.
+
 ## Avoiding rate limiting
 
 When you install plugins with `tflint --init`, call the GitHub API to get release metadata. This is typically an unauthenticated request with a rate limit of 60 requests per hour.
@@ -64,7 +72,7 @@ This limitation can be a problem if you need to run `--init` frequently, such as
 
 It's also a good idea to cache the plugin directory, as TFLint will only send requests if plugins aren't installed. See also the [setup-tflint's example](https://github.com/terraform-linters/setup-tflint#usage).
 
-## Advanced Usage
+## Manual installation
 
 You can also install the plugin manually. This is mainly useful for plugin development and for plugins that are not published on GitHub. In that case, omit the `source` and `version` attributes.
 
@@ -74,6 +82,4 @@ plugin "foo" {
 }
 ```
 
-When the plugin is enabled, TFLint invokes the `tflint-ruleset-<NAME>` (`tflint-ruleset-<NAME>.exe` on Windows) binary in the `~/.tflint.d/plugins` (or `./.tflint.d/plugins`) directory. So you should move the binary into the directory in advance.
-
-You can also change the plugin directory with the `TFLINT_PLUGIN_DIR` environment variable.
+When the plugin is enabled, TFLint invokes the `tflint-ruleset-[name]` (`tflint-ruleset-[name].exe` on Windows) binary in the plugin directory (For instance, `~/.tflint.d/plugins/tflint-ruleset-[name]`). So you should move the binary into the directory in advance.

--- a/plugin/install.go
+++ b/plugin/install.go
@@ -20,13 +20,16 @@ import (
 // InstallConfig is a config for plugin installation.
 // This is a wrapper for PluginConfig and manages naming conventions
 // and directory names for installation.
+// Note that need a global config to manage installation directory.
 type InstallConfig struct {
+	globalConfig *tflint.Config
+
 	*tflint.PluginConfig
 }
 
 // NewInstallConfig returns a new InstallConfig from passed PluginConfig.
-func NewInstallConfig(config *tflint.PluginConfig) *InstallConfig {
-	return &InstallConfig{PluginConfig: config}
+func NewInstallConfig(config *tflint.Config, pluginCfg *tflint.PluginConfig) *InstallConfig {
+	return &InstallConfig{globalConfig: config, PluginConfig: pluginCfg}
 }
 
 // ManuallyInstalled returns whether the plugin should be installed manually.
@@ -71,7 +74,7 @@ func (c *InstallConfig) AssetName() string {
 //   - The signature file must be binary OpenPGP format
 //
 func (c *InstallConfig) Install() (string, error) {
-	dir, err := getPluginDir()
+	dir, err := getPluginDir(c.globalConfig)
 	if err != nil {
 		return "", fmt.Errorf("Failed to get plugin dir: %w", err)
 	}

--- a/plugin/install_test.go
+++ b/plugin/install_test.go
@@ -12,7 +12,7 @@ func Test_Install(t *testing.T) {
 	PluginRoot = t.TempDir()
 	defer func() { PluginRoot = original }()
 
-	config := NewInstallConfig(&tflint.PluginConfig{
+	config := NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{
 		Name:        "aws",
 		Enabled:     true,
 		Version:     "0.4.0",

--- a/plugin/signature_test.go
+++ b/plugin/signature_test.go
@@ -19,22 +19,22 @@ func Test_GetSigningKey(t *testing.T) {
 	}{
 		{
 			Name:     "no signing key",
-			Config:   NewInstallConfig(&tflint.PluginConfig{SigningKey: ""}),
+			Config:   NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: ""}),
 			Expected: "",
 		},
 		{
 			Name:     "configured singing key",
-			Config:   NewInstallConfig(&tflint.PluginConfig{SigningKey: testSigningKey}),
+			Config:   NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: testSigningKey}),
 			Expected: testSigningKey,
 		},
 		{
 			Name:     "bulit-in signing key",
-			Config:   NewInstallConfig(&tflint.PluginConfig{SigningKey: "", SourceOwner: "terraform-linters"}),
+			Config:   NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: "", SourceOwner: "terraform-linters"}),
 			Expected: builtinSigningKey,
 		},
 		{
 			Name:     "bulit-in signing key and configured signing key",
-			Config:   NewInstallConfig(&tflint.PluginConfig{SigningKey: testSigningKey, SourceOwner: "terraform-linters"}),
+			Config:   NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: testSigningKey, SourceOwner: "terraform-linters"}),
 			Expected: testSigningKey,
 		},
 	}
@@ -57,22 +57,22 @@ func Test_HasSigningKey(t *testing.T) {
 	}{
 		{
 			Name:     "no signing key",
-			Config:   NewInstallConfig(&tflint.PluginConfig{SigningKey: ""}),
+			Config:   NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: ""}),
 			Expected: false,
 		},
 		{
 			Name:     "configured singing key",
-			Config:   NewInstallConfig(&tflint.PluginConfig{SigningKey: testSigningKey}),
+			Config:   NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: testSigningKey}),
 			Expected: true,
 		},
 		{
 			Name:     "bulit-in signing key",
-			Config:   NewInstallConfig(&tflint.PluginConfig{SigningKey: "", SourceOwner: "terraform-linters"}),
+			Config:   NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: "", SourceOwner: "terraform-linters"}),
 			Expected: true,
 		},
 		{
 			Name:     "bulit-in signing key and configured signing key",
-			Config:   NewInstallConfig(&tflint.PluginConfig{SigningKey: testSigningKey, SourceOwner: "terraform-linters"}),
+			Config:   NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: testSigningKey, SourceOwner: "terraform-linters"}),
 			Expected: true,
 		},
 	}
@@ -116,7 +116,7 @@ dd536fed0ebe4c1115240574c5dd7a31b563d67bfe0d1111750438718f995d43  tflint-ruleset
 `
 	reader := strings.NewReader(target)
 
-	sigchecker := NewSignatureChecker(NewInstallConfig(&tflint.PluginConfig{SigningKey: builtinSigningKey}))
+	sigchecker := NewSignatureChecker(NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: builtinSigningKey}))
 	if err := sigchecker.Verify(reader, signature); err != nil {
 		t.Fatalf("Verify failed: %s", err)
 	}
@@ -160,28 +160,28 @@ dd536fed0ebe4c1115240574c5dd7a31b563d67bfe0d1111750438718f995d43  tflint-ruleset
 	}{
 		{
 			Name:      "invalid signature",
-			Config:    NewInstallConfig(&tflint.PluginConfig{SigningKey: builtinSigningKey}),
+			Config:    NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: builtinSigningKey}),
 			Target:    "broken",
 			Signature: signature,
 			Expected:  fmt.Errorf("openpgp: invalid signature: hash tag doesn't match"),
 		},
 		{
 			Name:      "no signing key",
-			Config:    NewInstallConfig(&tflint.PluginConfig{SigningKey: ""}),
+			Config:    NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: ""}),
 			Target:    target,
 			Signature: signature,
 			Expected:  fmt.Errorf("No signing key configured"),
 		},
 		{
 			Name:      "broken signing key",
-			Config:    NewInstallConfig(&tflint.PluginConfig{SigningKey: "broken"}),
+			Config:    NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: "broken"}),
 			Target:    target,
 			Signature: signature,
 			Expected:  fmt.Errorf("openpgp: invalid argument: no armored data found"),
 		},
 		{
 			Name:      "broken signature",
-			Config:    NewInstallConfig(&tflint.PluginConfig{SigningKey: builtinSigningKey}),
+			Config:    NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: builtinSigningKey}),
 			Target:    target,
 			Signature: brokenSignature,
 			Expected:  fmt.Errorf("openpgp: invalid data: tag byte does not have MSB set"),

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -33,6 +33,7 @@ type rawConfig struct {
 		Varfile           *[]string        `hcl:"varfile"`
 		Variables         *[]string        `hcl:"variables"`
 		DisabledByDefault *bool            `hcl:"disabled_by_default"`
+		PluginDir         *string          `hcl:"plugin_dir"`
 		// Removed options
 		TerraformVersion *string            `hcl:"terraform_version"`
 		IgnoreRule       *map[string]bool   `hcl:"ignore_rule"`
@@ -51,6 +52,7 @@ type Config struct {
 	Varfiles          []string
 	Variables         []string
 	DisabledByDefault bool
+	PluginDir         string
 	Rules             map[string]*RuleConfig
 	Plugins           map[string]*PluginConfig
 }
@@ -150,6 +152,9 @@ func (c *Config) Merge(other *Config) *Config {
 	}
 	if other.DisabledByDefault {
 		ret.DisabledByDefault = true
+	}
+	if other.PluginDir != "" {
+		ret.PluginDir = other.PluginDir
 	}
 
 	ret.IgnoreModules = mergeBoolMap(ret.IgnoreModules, other.IgnoreModules)
@@ -261,6 +266,7 @@ func (c *Config) copy() *Config {
 		Varfiles:          varfiles,
 		Variables:         variables,
 		DisabledByDefault: c.DisabledByDefault,
+		PluginDir:         c.PluginDir,
 		Rules:             rules,
 		Plugins:           plugins,
 	}
@@ -328,6 +334,7 @@ plugin "aws" {
 	log.Printf("[DEBUG]   Varfiles: %#v", cfg.Varfiles)
 	log.Printf("[DEBUG]   Variables: %#v", cfg.Variables)
 	log.Printf("[DEBUG]   DisabledByDefault: %#v", cfg.DisabledByDefault)
+	log.Printf("[DEBUG]   PluginDir: %s", cfg.PluginDir)
 	log.Printf("[DEBUG]   Rules: %#v", cfg.Rules)
 	log.Printf("[DEBUG]   Plugins: %#v", cfg.Plugins)
 
@@ -403,6 +410,9 @@ func (raw *rawConfig) toConfig() *Config {
 		}
 		if rc.Variables != nil {
 			ret.Variables = *rc.Variables
+		}
+		if rc.PluginDir != nil {
+			ret.PluginDir = *rc.PluginDir
 		}
 	}
 

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -38,6 +38,7 @@ func Test_LoadConfig(t *testing.T) {
 				Varfiles:          []string{"example1.tfvars", "example2.tfvars"},
 				Variables:         []string{"foo=bar", "bar=['foo']"},
 				DisabledByDefault: false,
+				PluginDir:         "~/.tflint.d/plugins",
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
@@ -239,6 +240,7 @@ func Test_Merge(t *testing.T) {
 		Varfiles:          []string{"example1.tfvars", "example2.tfvars"},
 		Variables:         []string{"foo=bar"},
 		DisabledByDefault: false,
+		PluginDir:         "./.tflint.d/plugins",
 		Rules: map[string]*RuleConfig{
 			"aws_instance_invalid_type": {
 				Name:    "aws_instance_invalid_type",
@@ -290,6 +292,7 @@ func Test_Merge(t *testing.T) {
 				Varfiles:          []string{"example1.tfvars", "example2.tfvars"},
 				Variables:         []string{"foo=bar"},
 				DisabledByDefault: false,
+				PluginDir:         "./.tflint.d/plugins",
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
@@ -323,6 +326,7 @@ func Test_Merge(t *testing.T) {
 				Varfiles:          []string{"example3.tfvars"},
 				Variables:         []string{"bar=baz"},
 				DisabledByDefault: false,
+				PluginDir:         "~/.tflint.d/plugins",
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_ami": {
 						Name:    "aws_instance_invalid_ami",
@@ -357,6 +361,7 @@ func Test_Merge(t *testing.T) {
 				Varfiles:          []string{"example1.tfvars", "example2.tfvars", "example3.tfvars"},
 				Variables:         []string{"foo=bar", "bar=baz"},
 				DisabledByDefault: false,
+				PluginDir:         "~/.tflint.d/plugins",
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
@@ -730,6 +735,7 @@ func Test_copy(t *testing.T) {
 		Varfiles:          []string{"example1.tfvars", "example2.tfvars"},
 		Variables:         []string{},
 		DisabledByDefault: true,
+		PluginDir:         "./.tflint.d/plugins",
 		Rules: map[string]*RuleConfig{
 			"aws_instance_invalid_type": {
 				Name:    "aws_instance_invalid_type",
@@ -772,6 +778,12 @@ func Test_copy(t *testing.T) {
 			Name: "DisabledByDefault",
 			SideEffect: func(c *Config) {
 				c.DisabledByDefault = false
+			},
+		},
+		{
+			Name: "PluginDir",
+			SideEffect: func(c *Config) {
+				c.PluginDir = "~/.tflint.d/plugins"
 			},
 		},
 		{

--- a/tflint/test-fixtures/config/config.hcl
+++ b/tflint/test-fixtures/config/config.hcl
@@ -1,4 +1,6 @@
 config {
+  plugin_dir = "~/.tflint.d/plugins"
+
   module = true
   force = true
 


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1198

This PR adds `plugin_dir` to the config schema. For example:

```hcl
config {
  plugin_dir = "./.tflint_plugins"
}
```

If `plugin_dir` is set, change the installation directory from `~/.tflint.d/plugins`. This is the same behavior as the `TFLINT_PLUGIN_DIR` environment variable, except that it can be explicitly declared in the config file.