### PR TITLE
tflint: Inherit config when plugins are enabled from CLI

### DIFF
--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -558,6 +558,66 @@ func Test_Merge(t *testing.T) {
 				Plugins: map[string]*PluginConfig{},
 			},
 		},
+		{
+			Name: "merge plugin config with CLI-based config",
+			Base: &Config{
+				Module:            false,
+				Force:             false,
+				IgnoreModules:     map[string]bool{},
+				Varfiles:          []string{},
+				Variables:         []string{},
+				DisabledByDefault: false,
+				Rules:             map[string]*RuleConfig{},
+				Plugins: map[string]*PluginConfig{
+					"aws": {
+						Name:        "aws",
+						Enabled:     false,
+						Version:     "0.1.0",
+						Source:      "github.com/terraform-linters/tflint-ruleset-aws",
+						SigningKey:  "key",
+						Body:        file1.Body,
+						SourceOwner: "terraform-linters",
+						SourceRepo:  "tflint-ruleset-aws",
+					},
+				},
+			},
+			Other: &Config{
+				Module:            false,
+				Force:             false,
+				IgnoreModules:     map[string]bool{},
+				Varfiles:          []string{},
+				Variables:         []string{},
+				DisabledByDefault: false,
+				Rules:             map[string]*RuleConfig{},
+				Plugins: map[string]*PluginConfig{
+					"aws": {
+						Name:    "aws",
+						Enabled: true,
+					},
+				},
+			},
+			Expected: &Config{
+				Module:            false,
+				Force:             false,
+				IgnoreModules:     map[string]bool{},
+				Varfiles:          []string{},
+				Variables:         []string{},
+				DisabledByDefault: false,
+				Rules:             map[string]*RuleConfig{},
+				Plugins: map[string]*PluginConfig{
+					"aws": {
+						Name:        "aws",
+						Enabled:     true, // overridden
+						Version:     "0.1.0",
+						Source:      "github.com/terraform-linters/tflint-ruleset-aws",
+						SigningKey:  "key",
+						Body:        file1.Body,
+						SourceOwner: "terraform-linters",
+						SourceRepo:  "tflint-ruleset-aws",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1242

When enabling a plugin with `--enable-plugin`, plugin config such as version will be lost. This patch fixes the bug.