### PR TITLE
remove precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,0 @@
-repos:
-- repo: git://github.com/dnephin/pre-commit-golang
-  rev: master
-  hooks:
-    - id: go-fmt

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,0 @@
-- id: tflint
-  name: Terraform Lint
-  description: TFLint is a Terraform linter focused on possible errors, best practices, and so on.
-  language: golang
-  entry: tflint
-  types: [terraform]


### PR DESCRIPTION
* Having a `go fmt` hook isn't that important, most users integrate this somewhere in their editor
* TFLint does not need to offer this if it's not straightforward and well-maintained. Someone contributed this in 2019 and it's not been touched.

Meanwhile, there are actively maintained suites of hooks out there with good support for TFLint, users should head there.

https://github.com/antonbabenko/pre-commit-terraform