### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"testing"
 )
 
 func TestMain(m *testing.M) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	os.Exit(m.Run())
 }

--- a/integrationtest/bundled/bundled_test.go
+++ b/integrationtest/bundled/bundled_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	os.Exit(m.Run())
 }
 
@@ -116,9 +116,9 @@ func TestBundledPlugin(t *testing.T) {
 			var b []byte
 			var err error
 			if runtime.GOOS == "windows" && IsWindowsResultExist() {
-				b, err = ioutil.ReadFile(filepath.Join(testDir, "result_windows.json"))
+				b, err = os.ReadFile(filepath.Join(testDir, "result_windows.json"))
 			} else {
-				b, err = ioutil.ReadFile(filepath.Join(testDir, "result.json"))
+				b, err = os.ReadFile(filepath.Join(testDir, "result.json"))
 			}
 			if err != nil {
 				t.Fatal(err)

--- a/integrationtest/inspection/inspection_test.go
+++ b/integrationtest/inspection/inspection_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	os.Exit(m.Run())
 }
 
@@ -127,9 +127,9 @@ func TestIntegration(t *testing.T) {
 		var b []byte
 		var err error
 		if runtime.GOOS == "windows" && IsWindowsResultExist() {
-			b, err = ioutil.ReadFile(filepath.Join(testDir, "result_windows.json"))
+			b, err = os.ReadFile(filepath.Join(testDir, "result_windows.json"))
 		} else {
-			b, err = ioutil.ReadFile(filepath.Join(testDir, "result.json"))
+			b, err = os.ReadFile(filepath.Join(testDir, "result.json"))
 		}
 		if err != nil {
 			t.Fatal(err)

--- a/integrationtest/langserver/langserver_test.go
+++ b/integrationtest/langserver/langserver_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -118,7 +117,7 @@ func withinTempDir(t *testing.T, test func(dir string)) {
 		}
 	}()
 
-	dir, err := ioutil.TempDir("", "withinTempDir")
+	dir, err := os.MkdirTemp("", "withinTempDir")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integrationtest/langserver/text_document_did_change_test.go
+++ b/integrationtest/langserver/text_document_did_change_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -13,7 +13,7 @@ import (
 
 func Test_textDocumentDidChange(t *testing.T) {
 	withinFixtureDir(t, "workdir", func(dir string) {
-		src, err := ioutil.ReadFile(dir + "/main.tf")
+		src, err := os.ReadFile(dir + "/main.tf")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -66,7 +66,7 @@ resource "aws_instance" "foo" {
 		}
 
 		// Assert no changes for actual files
-		changedSrc, err := ioutil.ReadFile(dir + "/main.tf")
+		changedSrc, err := os.ReadFile(dir + "/main.tf")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/integrationtest/langserver/text_document_did_open_test.go
+++ b/integrationtest/langserver/text_document_did_open_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -13,7 +13,7 @@ import (
 
 func Test_textDocumentDidOpen(t *testing.T) {
 	withinFixtureDir(t, "workdir", func(dir string) {
-		src, err := ioutil.ReadFile(dir + "/main.tf")
+		src, err := os.ReadFile(dir + "/main.tf")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -89,7 +89,7 @@ func didOpenResponse(uri lsp.DocumentURI, t *testing.T) string {
 
 func Test_textDocumentDidOpen_pathFunctions(t *testing.T) {
 	withinFixtureDir(t, "path_functions", func(dir string) {
-		src, err := ioutil.ReadFile(dir + "/main.tf")
+		src, err := os.ReadFile(dir + "/main.tf")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/integrationtest/langserver/workspace_did_change_watched_files_test.go
+++ b/integrationtest/langserver/workspace_did_change_watched_files_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -41,10 +40,10 @@ rule "aws_instance_example_type" {
     enabled = false
 }`
 
-		if err := ioutil.WriteFile(dir+"/main.tf", []byte(content), os.ModePerm); err != nil {
+		if err := os.WriteFile(dir+"/main.tf", []byte(content), os.ModePerm); err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(dir+"/.tflint.hcl", []byte(config), os.ModePerm); err != nil {
+		if err := os.WriteFile(dir+"/.tflint.hcl", []byte(config), os.ModePerm); err != nil {
 			t.Fatal(err)
 		}
 		uri := pathToURI(dir + "/main.tf")
@@ -73,7 +72,7 @@ rule "aws_instance_example_type" {
 			fmt.Fprint(stdin, initializeRequest())
 			fmt.Fprint(stdin, didOpenRequest(uri, content, t))
 			// Change config file from outside of LSP
-			_ = ioutil.WriteFile(dir+"/.tflint.hcl", []byte(changedConfig), os.ModePerm)
+			_ = os.WriteFile(dir+"/.tflint.hcl", []byte(changedConfig), os.ModePerm)
 			fmt.Fprint(stdin, toJSONRPC2(string(req)))
 			fmt.Fprint(stdin, shutdownRequest())
 			fmt.Fprint(stdin, exitRequest())
@@ -100,7 +99,7 @@ resource "aws_instance" "foo" {
 variable "instance_type" {}
 `
 
-		if err := ioutil.WriteFile(dir+"/main.tf", []byte(content), os.ModePerm); err != nil {
+		if err := os.WriteFile(dir+"/main.tf", []byte(content), os.ModePerm); err != nil {
 			t.Fatal(err)
 		}
 		uri := pathToURI(dir + "/main.tf")
@@ -108,7 +107,7 @@ variable "instance_type" {}
 		valueFile := `
 instance_type = "t1.2xlarge"
 `
-		if err := ioutil.WriteFile(dir+"/terraform.tfvars", []byte(valueFile), os.ModePerm); err != nil {
+		if err := os.WriteFile(dir+"/terraform.tfvars", []byte(valueFile), os.ModePerm); err != nil {
 			t.Fatal(err)
 		}
 
@@ -120,7 +119,7 @@ plugin "testing" {
 plugin "aws" {
     enabled = false
 }`
-		if err := ioutil.WriteFile(dir+"/.tflint.hcl", []byte(config), os.ModePerm); err != nil {
+		if err := os.WriteFile(dir+"/.tflint.hcl", []byte(config), os.ModePerm); err != nil {
 			t.Fatal(err)
 		}
 

--- a/plugin/install.go
+++ b/plugin/install.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -182,7 +181,7 @@ func (c *InstallConfig) downloadToTempFile(asset *github.ReleaseAsset) (*os.File
 		return nil, err
 	}
 
-	file, err := ioutil.TempFile("", "tflint-download-temp-file-*")
+	file, err := os.CreateTemp("", "tflint-download-temp-file-*")
 	if err != nil {
 		return nil, err
 	}

--- a/rules/terraformrules/terraform_module_pinned_source_test.go
+++ b/rules/terraformrules/terraform_module_pinned_source_test.go
@@ -1,7 +1,6 @@
 package terraformrules
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -538,7 +537,7 @@ func loadConfigfromTempFile(t *testing.T, content string) *tflint.Config {
 		return tflint.EmptyConfig()
 	}
 
-	tmpfile, err := ioutil.TempFile("", "terraform_module_pinned_source")
+	tmpfile, err := os.CreateTemp("", "terraform_module_pinned_source")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rules/terraformrules/terraform_module_version_test.go
+++ b/rules/terraformrules/terraform_module_version_test.go
@@ -2,7 +2,6 @@ package terraformrules
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -241,7 +240,7 @@ func loadConfigfromModuleVersionTempFile(t *testing.T, content string) *tflint.C
 		return tflint.EmptyConfig()
 	}
 
-	tmpfile, err := ioutil.TempFile("", "terraform_module_version")
+	tmpfile, err := os.CreateTemp("", "terraform_module_version")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rules/terraformrules/terraform_naming_convention_test.go
+++ b/rules/terraformrules/terraform_naming_convention_test.go
@@ -2,7 +2,6 @@ package terraformrules
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -2899,7 +2898,7 @@ func loadConfigFromNamingConventionTempFile(t *testing.T, content string) *tflin
 		return tflint.EmptyConfig()
 	}
 
-	tmpfile, err := ioutil.TempFile("", "terraform_naming_convention")
+	tmpfile, err := os.CreateTemp("", "terraform_naming_convention")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rules/terraformrules/terraformrules_test.go
+++ b/rules/terraformrules/terraformrules_test.go
@@ -1,13 +1,13 @@
 package terraformrules
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"testing"
 )
 
 func TestMain(m *testing.M) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	os.Exit(m.Run())
 }

--- a/terraform/lang/funcs/filesystem.go
+++ b/terraform/lang/funcs/filesystem.go
@@ -3,7 +3,7 @@ package funcs
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"unicode/utf8"
@@ -378,7 +378,7 @@ func readFileBytes(baseDir, path string) ([]byte, error) {
 		return nil, err
 	}
 
-	src, err := ioutil.ReadAll(f)
+	src, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s", path)
 	}

--- a/tflint/annotation_test.go
+++ b/tflint/annotation_test.go
@@ -2,7 +2,6 @@ package tflint
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,7 +23,7 @@ func Test_NewAnnotations(t *testing.T) {
 		}
 	}()
 
-	src, err := ioutil.ReadFile(filepath.Join(currentDir, "test-fixtures", "annotations", "resource.tf"))
+	src, err := os.ReadFile(filepath.Join(currentDir, "test-fixtures", "annotations", "resource.tf"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tflint/terraform.go
+++ b/tflint/terraform.go
@@ -3,7 +3,6 @@ package tflint
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -136,7 +135,7 @@ func getTFWorkspace() string {
 		return envVar
 	}
 
-	envData, _ := ioutil.ReadFile(filepath.Join(getTFDataDir(), "environment"))
+	envData, _ := os.ReadFile(filepath.Join(getTFDataDir(), "environment"))
 	current := string(bytes.TrimSpace(envData))
 	if current != "" {
 		log.Printf("[INFO] environment file found: %s", current)

--- a/tflint/tflint_test.go
+++ b/tflint/tflint_test.go
@@ -1,7 +1,7 @@
 package tflint
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since tflint has been upgraded to Go 1.17 (#1188), this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.