### PR TITLE
plugin: log when `GITHUB_TOKEN` is set

### DIFF
--- a/plugin/install.go
+++ b/plugin/install.go
@@ -244,7 +244,7 @@ func newGitHubClient(ctx context.Context) *github.Client {
 	if token == "" {
 		return github.NewClient(nil)
 	}
-	
+
 	log.Printf("[DEBUG] GITHUB_TOKEN set, plugin requests to the GitHub API will be authenticated")
 
 	ts := oauth2.StaticTokenSource(

--- a/plugin/install.go
+++ b/plugin/install.go
@@ -244,6 +244,8 @@ func newGitHubClient(ctx context.Context) *github.Client {
 	if token == "" {
 		return github.NewClient(nil)
 	}
+	
+	log.Printf("[DEBUG] GITHUB_TOKEN set, plugin requests to the GitHub API will be authenticated")
 
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},


### PR DESCRIPTION
Helps users identify when they have set GitHub credentials that will be used for plugin downloads. If those credentials are invalid, subsequent requests will receive a 401.

Closes #1268