### PR TITLE
docs: linking terraform_module_version rule docs

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -10,7 +10,7 @@ Rules are usually provided by ruleset plugins, but the rules for the Terraform L
 |[terraform_documented_outputs](terraform_documented_outputs.md)|Disallow `output` declarations without description||
 |[terraform_documented_variables](terraform_documented_variables.md)|Disallow `variable` declarations without description||
 |[terraform_module_pinned_source](terraform_module_pinned_source.md)|Disallow specifying a git or mercurial repository as a module source without pinning to a version|✔|
-|terraform_module_version|Checks that Terraform modules sourced from a registry specify a version|✔|
+|[terraform_module_version](terraform_module_version.md)|Checks that Terraform modules sourced from a registry specify a version|✔|
 |[terraform_naming_convention](terraform_naming_convention.md)|Enforces naming conventions for resources, data sources, etc||
 |[terraform_required_providers](terraform_required_providers.md)|Require that all providers have version constraints through required_providers||
 |[terraform_required_version](terraform_required_version.md)|Disallow `terraform` declarations without require_version||


### PR DESCRIPTION
added in https://github.com/terraform-linters/tflint/pull/1182