### PR TITLE
`terraform_required_providers`: ignore builtin providers

### DIFF
--- a/rules/terraformrules/terraform_required_providers_test.go
+++ b/rules/terraformrules/terraform_required_providers_test.go
@@ -247,6 +247,21 @@ data "terraform_remote_state" "foo" {}
 `,
 			Expected: tflint.Issues{},
 		},
+		{
+			Name: "builtin provider",
+			Content: `
+terraform {
+	required_providers {
+		test = {
+			source = "terraform.io/builtin/test"
+		}
+	}
+}
+
+resource "test_assertions" "foo" {}
+`,
+			Expected: tflint.Issues{},
+		},
 	}
 
 	rule := NewTerraformRequiredProvidersRule()


### PR DESCRIPTION
Terraform has a system for built-in providers that are bundled with Terraform itself, most notably the `terraform` provider that handles `terraform_remote_state`. The [module testing experiment](https://www.terraform.io/language/modules/testing-experiment) uses a similar built-in provider. However, the `test` provider must also be specified in `required_providers` (unlike `terraform`), which causes the required provider version rule to report it as un-versioned. Built-in providers, by definition, cannot be versioned independent of Terraform.

Turns out the `addrs` package provides an API for checking this for a given provider. Using `IsBuiltIn` eliminates the need to check `name == "terraform"` and handles all built-in providers current and future.

Closes #1280