### PR TITLE
json,sarif: print structured error data

### DIFF
--- a/formatter/compact.go
+++ b/formatter/compact.go
@@ -25,6 +25,6 @@ func (f *Formatter) compactPrint(issues tflint.Issues, tferr *tflint.Error, sour
 	}
 
 	if tferr != nil {
-		f.printErrors(tferr, sources)
+		f.prettyPrintErrors(tferr, sources)
 	}
 }

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -21,7 +21,7 @@ func (f *Formatter) Print(issues tflint.Issues, tferr *tflint.Error, sources map
 
 	if tferr != nil {
 		if diags, ok := tferr.Cause.(hcl.Diagnostics); ok {
-			tferr.Cause = tflint.ConfigParseError{Detail: diags}
+			tferr.Cause = tflint.TerraformConfigParseError{Diags: diags}
 		}
 	}
 

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -31,7 +31,7 @@ func (f *Formatter) Print(issues tflint.Issues, tferr *tflint.Error, sources map
 	case "json":
 		f.jsonPrint(issues, tferr)
 	case "checkstyle":
-		f.checkstylePrint(issues, tferr)
+		f.checkstylePrint(issues, tferr, sources)
 	case "junit":
 		f.junitPrint(issues, tferr, sources)
 	case "compact":

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -18,13 +18,6 @@ type Formatter struct {
 
 // Print outputs the given issues and errors according to configured format
 func (f *Formatter) Print(issues tflint.Issues, tferr *tflint.Error, sources map[string][]byte) {
-
-	if tferr != nil {
-		if diags, ok := tferr.Cause.(hcl.Diagnostics); ok {
-			tferr.Cause = tflint.TerraformConfigParseError{Diags: diags}
-		}
-	}
-
 	switch f.Format {
 	case "default":
 		f.prettyPrint(issues, tferr, sources)

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -21,7 +21,7 @@ func (f *Formatter) Print(issues tflint.Issues, tferr *tflint.Error, sources map
 
 	if tferr != nil {
 		if diags, ok := tferr.Cause.(hcl.Diagnostics); ok {
-			tferr.Cause = tflint.ConfigParseError{&diags}
+			tferr.Cause = tflint.ConfigParseError{Detail: &diags}
 		}
 	}
 

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -16,22 +17,29 @@ type Formatter struct {
 }
 
 // Print outputs the given issues and errors according to configured format
-func (f *Formatter) Print(issues tflint.Issues, err *tflint.Error, sources map[string][]byte) {
+func (f *Formatter) Print(issues tflint.Issues, tferr *tflint.Error, sources map[string][]byte) {
+
+	if tferr != nil {
+		if diags, ok := tferr.Cause.(hcl.Diagnostics); ok {
+			tferr.Cause = tflint.ConfigParseError{&diags}
+		}
+	}
+
 	switch f.Format {
 	case "default":
-		f.prettyPrint(issues, err, sources)
+		f.prettyPrint(issues, tferr, sources)
 	case "json":
-		f.jsonPrint(issues, err)
+		f.jsonPrint(issues, tferr)
 	case "checkstyle":
-		f.checkstylePrint(issues, err, sources)
+		f.checkstylePrint(issues, tferr)
 	case "junit":
-		f.junitPrint(issues, err, sources)
+		f.junitPrint(issues, tferr, sources)
 	case "compact":
-		f.compactPrint(issues, err, sources)
+		f.compactPrint(issues, tferr, sources)
 	case "sarif":
-		f.sarifPrint(issues, err, sources)
+		f.sarifPrint(issues, tferr)
 	default:
-		f.prettyPrint(issues, err, sources)
+		f.prettyPrint(issues, tferr, sources)
 	}
 }
 
@@ -45,5 +53,16 @@ func toSeverity(lintType string) string {
 		return "info"
 	default:
 		panic(fmt.Errorf("Unexpected lint type: %s", lintType))
+	}
+}
+
+func fromHclSeverity(severity hcl.DiagnosticSeverity) string {
+	switch severity {
+	case hcl.DiagError:
+		return "error"
+	case hcl.DiagWarning:
+		return "warning"
+	default:
+		panic(fmt.Errorf("Unexpected HCL severity: %v", severity))
 	}
 }

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -21,7 +21,7 @@ func (f *Formatter) Print(issues tflint.Issues, tferr *tflint.Error, sources map
 
 	if tferr != nil {
 		if diags, ok := tferr.Cause.(hcl.Diagnostics); ok {
-			tferr.Cause = tflint.ConfigParseError{Detail: &diags}
+			tferr.Cause = tflint.ConfigParseError{Detail: diags}
 		}
 	}
 

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -38,10 +38,10 @@ type JSONPos struct {
 
 // JSONError is a temporary structure for converting errors to JSON.
 type JSONError struct {
-	Summary  string    `json:"summary,omitempty"`
-	Detail   string    `json:"detail"`
-	Severity string    `json:"severity"`
-	Range    JSONRange `json:"range,omitempty"`
+	Summary  string     `json:"summary,omitempty"`
+	Detail   string     `json:"detail"`
+	Severity string     `json:"severity"`
+	Range    *JSONRange `json:"range,omitempty"` // pointer so omitempty works
 }
 
 // JSONOutput is a temporary structure for converting to JSON.
@@ -97,7 +97,7 @@ func (f *Formatter) jsonPrint(issues tflint.Issues, tferr *tflint.Error) {
 					Severity: severity,
 					Summary:  diag.Summary,
 					Detail:   diag.Detail,
-					Range: JSONRange{
+					Range: &JSONRange{
 						Filename: diag.Subject.Filename,
 						Start:    JSONPos{Line: diag.Subject.Start.Line, Column: diag.Subject.Start.Column},
 						End:      JSONPos{Line: diag.Subject.End.Line, Column: diag.Subject.End.Column},

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -79,22 +78,10 @@ func (f *Formatter) jsonPrint(issues tflint.Issues, tferr *tflint.Error) {
 
 	if tferr != nil {
 		if parseError, ok := tferr.Cause.(tflint.ConfigParseError); ok {
-			diags := *parseError.Detail
-
-			ret.Errors = make([]JSONError, len(diags))
-			for idx, diag := range diags {
-				var severity string
-				switch diag.Severity {
-				case hcl.DiagError:
-					severity = "error"
-				case hcl.DiagWarning:
-					severity = "warning"
-				default:
-					panic(fmt.Errorf("Unexpected tflint error severity: %v", diag.Severity))
-				}
-
+			ret.Errors = make([]JSONError, len(parseError.Detail))
+			for idx, diag := range parseError.Detail {
 				ret.Errors[idx] = JSONError{
-					Severity: severity,
+					Severity: fromHclSeverity(diag.Severity),
 					Summary:  diag.Summary,
 					Message:  diag.Detail,
 					Range: &JSONRange{

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -77,9 +77,9 @@ func (f *Formatter) jsonPrint(issues tflint.Issues, tferr *tflint.Error) {
 	}
 
 	if tferr != nil {
-		if parseError, ok := tferr.Cause.(tflint.ConfigParseError); ok {
-			ret.Errors = make([]JSONError, len(parseError.Detail))
-			for idx, diag := range parseError.Detail {
+		if parseError, ok := tferr.Cause.(tflint.TerraformConfigParseError); ok {
+			ret.Errors = make([]JSONError, len(parseError.Diags))
+			for idx, diag := range parseError.Diags {
 				ret.Errors[idx] = JSONError{
 					Severity: fromHclSeverity(diag.Severity),
 					Summary:  diag.Summary,

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -39,7 +39,7 @@ type JSONPos struct {
 // JSONError is a temporary structure for converting errors to JSON.
 type JSONError struct {
 	Summary  string     `json:"summary,omitempty"`
-	Detail   string     `json:"detail"`
+	Message  string     `json:"message"`
 	Severity string     `json:"severity"`
 	Range    *JSONRange `json:"range,omitempty"` // pointer so omitempty works
 }
@@ -96,7 +96,7 @@ func (f *Formatter) jsonPrint(issues tflint.Issues, tferr *tflint.Error) {
 				ret.Errors[idx] = JSONError{
 					Severity: severity,
 					Summary:  diag.Summary,
-					Detail:   diag.Detail,
+					Message:  diag.Detail,
 					Range: &JSONRange{
 						Filename: diag.Subject.Filename,
 						Start:    JSONPos{Line: diag.Subject.Start.Line, Column: diag.Subject.Start.Column},
@@ -107,7 +107,7 @@ func (f *Formatter) jsonPrint(issues tflint.Issues, tferr *tflint.Error) {
 		} else {
 			ret.Errors = []JSONError{JSONError{
 				Severity: toSeverity(tflint.ERROR),
-				Detail:   tferr.Error(),
+				Message:  tferr.Error(),
 			}}
 		}
 	}

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -2,6 +2,7 @@ package formatter
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
@@ -78,7 +79,8 @@ func (f *Formatter) jsonPrint(issues tflint.Issues, tferr *tflint.Error) {
 	}
 
 	if tferr != nil {
-		if diags, ok := tferr.Cause.(hcl.Diagnostics); ok {
+		var diags hcl.Diagnostics
+		if errors.As(tferr, &diags) {
 			ret.Errors = make([]JSONError, len(diags))
 			for idx, diag := range diags {
 				ret.Errors[idx] = JSONError{

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -38,10 +38,10 @@ type JSONPos struct {
 
 // JSONError is a temporary structure for converting errors to JSON.
 type JSONError struct {
-	Summary string `json:"summary,omitempty"`
-	Detail string `json:"detail"`
-	Severity string `json:"severity"`
-	Range JSONRange `json:"range,omitempty"`
+	Summary  string    `json:"summary,omitempty"`
+	Detail   string    `json:"detail"`
+	Severity string    `json:"severity"`
+	Range    JSONRange `json:"range,omitempty"`
 }
 
 // JSONOutput is a temporary structure for converting to JSON.
@@ -95,20 +95,20 @@ func (f *Formatter) jsonPrint(issues tflint.Issues, tferr *tflint.Error) {
 
 				ret.Errors[idx] = JSONError{
 					Severity: severity,
-					Summary: diag.Summary,
-					Detail: diag.Detail,
+					Summary:  diag.Summary,
+					Detail:   diag.Detail,
 					Range: JSONRange{
 						Filename: diag.Subject.Filename,
-						Start: JSONPos{Line: diag.Subject.Start.Line, Column: diag.Subject.Start.Column},
-						End: JSONPos{Line: diag.Subject.End.Line, Column: diag.Subject.End.Column},
+						Start:    JSONPos{Line: diag.Subject.Start.Line, Column: diag.Subject.Start.Column},
+						End:      JSONPos{Line: diag.Subject.End.Line, Column: diag.Subject.End.Column},
 					},
 				}
 			}
 		} else {
-			ret.Errors = []JSONError{ JSONError { 
+			ret.Errors = []JSONError{JSONError{
 				Severity: toSeverity(tflint.ERROR),
-				Detail: tferr.Error(),
-			} }
+				Detail:   tferr.Error(),
+			}}
 		}
 	}
 

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -105,7 +105,7 @@ func (f *Formatter) jsonPrint(issues tflint.Issues, tferr *tflint.Error) {
 				}
 			}
 		} else {
-			ret.Errors = []JSONError{JSONError{
+			ret.Errors = []JSONError{{
 				Severity: toSeverity(tflint.ERROR),
 				Message:  tferr.Error(),
 			}}

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -77,9 +78,9 @@ func (f *Formatter) jsonPrint(issues tflint.Issues, tferr *tflint.Error) {
 	}
 
 	if tferr != nil {
-		if parseError, ok := tferr.Cause.(tflint.TerraformConfigParseError); ok {
-			ret.Errors = make([]JSONError, len(parseError.Diags))
-			for idx, diag := range parseError.Diags {
+		if diags, ok := tferr.Cause.(hcl.Diagnostics); ok {
+			ret.Errors = make([]JSONError, len(diags))
+			for idx, diag := range diags {
 				ret.Errors[idx] = JSONError{
 					Severity: fromHclSeverity(diag.Severity),
 					Summary:  diag.Summary,

--- a/formatter/json_test.go
+++ b/formatter/json_test.go
@@ -24,7 +24,7 @@ func Test_jsonPrint(t *testing.T) {
 		{
 			Name:   "error",
 			Error:  tflint.NewContextError("Failed to work", errors.New("I don't feel like working")),
-			Stdout: `{"issues":[],"errors":[{"detail":"Failed to work; I don't feel like working","severity":"error"}]}`,
+			Stdout: `{"issues":[],"errors":[{"message":"Failed to work; I don't feel like working","severity":"error"}]}`,
 		},
 		{
 			Name: "error",
@@ -39,7 +39,7 @@ func Test_jsonPrint(t *testing.T) {
 					},
 				},
 			),
-			Stdout: `{"issues":[],"errors":[{"summary":"summary","detail":"detail","severity":"warning","range":{"filename":"filename","start":{"line":0,"column":0},"end":{"line":5,"column":5}}}]}`,
+			Stdout: `{"issues":[],"errors":[{"summary":"summary","message":"detail","severity":"warning","range":{"filename":"filename","start":{"line":0,"column":0},"end":{"line":5,"column":5}}}]}`,
 		},
 	}
 

--- a/formatter/json_test.go
+++ b/formatter/json_test.go
@@ -35,11 +35,15 @@ func Test_jsonPrint(t *testing.T) {
 						Severity: hcl.DiagWarning,
 						Summary:  "summary",
 						Detail:   "detail",
-						Subject:  &hcl.Range{Filename: "filename", Start: hcl.Pos{0, 0, 0}, End: hcl.Pos{5, 5, 5}},
+						Subject: &hcl.Range{
+							Filename: "filename",
+							Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:      hcl.Pos{Line: 5, Column: 1, Byte: 4},
+						},
 					},
 				},
 			),
-			Stdout: `{"issues":[],"errors":[{"summary":"summary","message":"detail","severity":"warning","range":{"filename":"filename","start":{"line":0,"column":0},"end":{"line":5,"column":5}}}]}`,
+			Stdout: `{"issues":[],"errors":[{"summary":"summary","message":"detail","severity":"warning","range":{"filename":"filename","start":{"line":1,"column":1},"end":{"line":5,"column":5}}}]}`,
 		},
 	}
 

--- a/formatter/json_test.go
+++ b/formatter/json_test.go
@@ -43,7 +43,7 @@ func Test_jsonPrint(t *testing.T) {
 					},
 				},
 			),
-			Stdout: `{"issues":[],"errors":[{"summary":"summary","message":"detail","severity":"warning","range":{"filename":"filename","start":{"line":1,"column":1},"end":{"line":5,"column":5}}}]}`,
+			Stdout: `{"issues":[],"errors":[{"summary":"summary","message":"detail","severity":"warning","range":{"filename":"filename","start":{"line":1,"column":1},"end":{"line":5,"column":1}}}]}`,
 		},
 	}
 

--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -49,6 +49,6 @@ func (f *Formatter) junitPrint(issues tflint.Issues, tferr *tflint.Error, source
 	fmt.Fprint(f.Stdout, string(out))
 
 	if tferr != nil {
-		f.printErrors(tferr, sources)
+		f.prettyPrintErrors(tferr, sources)
 	}
 }

--- a/formatter/pretty.go
+++ b/formatter/pretty.go
@@ -88,11 +88,10 @@ func (f *Formatter) prettyPrintIssueWithSource(issue *tflint.Issue, sources map[
 
 func (f *Formatter) prettyPrintErrors(err *tflint.Error, sources map[string][]byte) {
 	if parseError, ok := err.Cause.(tflint.ConfigParseError); ok {
-		diags := *parseError.Detail
-		fmt.Fprintf(f.Stderr, "%s. %d error(s) occurred:\n\n", err.Message, len(diags.Errs()))
+		fmt.Fprintf(f.Stderr, "%s. %d error(s) occurred:\n\n", err.Message, len(parseError.Detail.Errs()))
 
 		writer := hcl.NewDiagnosticTextWriter(f.Stderr, parseSources(sources), 0, !f.NoColor)
-		_ = writer.WriteDiagnostics(diags)
+		_ = writer.WriteDiagnostics(parseError.Detail)
 	} else {
 		fmt.Fprintf(f.Stderr, "%s. An error occurred:\n\n", err.Message)
 		fmt.Fprintf(f.Stderr, "%s: %s\n\n", colorError("Error"), err.Cause.Error())

--- a/formatter/pretty.go
+++ b/formatter/pretty.go
@@ -2,6 +2,7 @@ package formatter
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -87,7 +88,8 @@ func (f *Formatter) prettyPrintIssueWithSource(issue *tflint.Issue, sources map[
 }
 
 func (f *Formatter) prettyPrintErrors(err *tflint.Error, sources map[string][]byte) {
-	if diags, ok := err.Cause.(hcl.Diagnostics); ok {
+	var diags hcl.Diagnostics
+	if errors.As(err, &diags) {
 		fmt.Fprintf(f.Stderr, "%s. %d error(s) occurred:\n\n", err.Message, len(diags.Errs()))
 
 		writer := hcl.NewDiagnosticTextWriter(f.Stderr, parseSources(sources), 0, !f.NoColor)

--- a/formatter/pretty.go
+++ b/formatter/pretty.go
@@ -87,11 +87,11 @@ func (f *Formatter) prettyPrintIssueWithSource(issue *tflint.Issue, sources map[
 }
 
 func (f *Formatter) prettyPrintErrors(err *tflint.Error, sources map[string][]byte) {
-	if parseError, ok := err.Cause.(tflint.ConfigParseError); ok {
-		fmt.Fprintf(f.Stderr, "%s. %d error(s) occurred:\n\n", err.Message, len(parseError.Detail.Errs()))
+	if parseError, ok := err.Cause.(tflint.TerraformConfigParseError); ok {
+		fmt.Fprintf(f.Stderr, "%s. %d error(s) occurred:\n\n", err.Message, len(parseError.Diags.Errs()))
 
 		writer := hcl.NewDiagnosticTextWriter(f.Stderr, parseSources(sources), 0, !f.NoColor)
-		_ = writer.WriteDiagnostics(parseError.Detail)
+		_ = writer.WriteDiagnostics(parseError.Diags)
 	} else {
 		fmt.Fprintf(f.Stderr, "%s. An error occurred:\n\n", err.Message)
 		fmt.Fprintf(f.Stderr, "%s: %s\n\n", colorError("Error"), err.Cause.Error())

--- a/formatter/pretty.go
+++ b/formatter/pretty.go
@@ -87,11 +87,11 @@ func (f *Formatter) prettyPrintIssueWithSource(issue *tflint.Issue, sources map[
 }
 
 func (f *Formatter) prettyPrintErrors(err *tflint.Error, sources map[string][]byte) {
-	if parseError, ok := err.Cause.(tflint.TerraformConfigParseError); ok {
-		fmt.Fprintf(f.Stderr, "%s. %d error(s) occurred:\n\n", err.Message, len(parseError.Diags.Errs()))
+	if diags, ok := err.Cause.(hcl.Diagnostics); ok {
+		fmt.Fprintf(f.Stderr, "%s. %d error(s) occurred:\n\n", err.Message, len(diags.Errs()))
 
 		writer := hcl.NewDiagnosticTextWriter(f.Stderr, parseSources(sources), 0, !f.NoColor)
-		_ = writer.WriteDiagnostics(parseError.Diags)
+		_ = writer.WriteDiagnostics(diags)
 	} else {
 		fmt.Fprintf(f.Stderr, "%s. An error occurred:\n\n", err.Message)
 		fmt.Fprintf(f.Stderr, "%s: %s\n\n", colorError("Error"), err.Cause.Error())

--- a/formatter/pretty.go
+++ b/formatter/pretty.go
@@ -23,16 +23,16 @@ func (f *Formatter) prettyPrint(issues tflint.Issues, err *tflint.Error, sources
 		fmt.Fprintf(f.Stdout, "%d issue(s) found:\n\n", len(issues))
 
 		for _, issue := range issues.Sort() {
-			f.printIssueWithSource(issue, sources)
+			f.prettyPrintIssueWithSource(issue, sources)
 		}
 	}
 
 	if err != nil {
-		f.printErrors(err, sources)
+		f.prettyPrintErrors(err, sources)
 	}
 }
 
-func (f *Formatter) printIssueWithSource(issue *tflint.Issue, sources map[string][]byte) {
+func (f *Formatter) prettyPrintIssueWithSource(issue *tflint.Issue, sources map[string][]byte) {
 	fmt.Fprintf(
 		f.Stdout,
 		"%s: %s (%s)\n\n",
@@ -86,8 +86,9 @@ func (f *Formatter) printIssueWithSource(issue *tflint.Issue, sources map[string
 	fmt.Fprint(f.Stdout, "\n")
 }
 
-func (f *Formatter) printErrors(err *tflint.Error, sources map[string][]byte) {
-	if diags, ok := err.Cause.(hcl.Diagnostics); ok {
+func (f *Formatter) prettyPrintErrors(err *tflint.Error, sources map[string][]byte) {
+	if parseError, ok := err.Cause.(tflint.ConfigParseError); ok {
+		diags := *parseError.Detail
 		fmt.Fprintf(f.Stderr, "%s. %d error(s) occurred:\n\n", err.Message, len(diags.Errs()))
 
 		writer := hcl.NewDiagnosticTextWriter(f.Stderr, parseSources(sources), 0, !f.NoColor)

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -60,9 +60,7 @@ func (f *Formatter) sarifPrint(issues tflint.Issues, tferr *tflint.Error) {
 	report.AddRun(errRun)
 	if tferr != nil {
 		if parseError, ok := tferr.Cause.(tflint.ConfigParseError); ok {
-			diags := *parseError.Detail
-
-			for _, diag := range diags {
+			for _, diag := range parseError.Detail {
 				location := sarif.NewPhysicalLocation().
 					WithArtifactLocation(sarif.NewSimpleArtifactLocation(diag.Subject.Filename)).
 					WithRegion(

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -3,6 +3,7 @@ package formatter
 import (
 	"fmt"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/owenrumney/go-sarif/sarif"
 	"github.com/terraform-linters/tflint/tflint"
 )
@@ -59,8 +60,8 @@ func (f *Formatter) sarifPrint(issues tflint.Issues, tferr *tflint.Error) {
 	errRun := sarif.NewRun("tflint-errors", "https://github.com/terraform-linters/tflint")
 	report.AddRun(errRun)
 	if tferr != nil {
-		if parseError, ok := tferr.Cause.(tflint.TerraformConfigParseError); ok {
-			for _, diag := range parseError.Diags {
+		if diags, ok := tferr.Cause.(hcl.Diagnostics); ok {
+			for _, diag := range diags {
 				location := sarif.NewPhysicalLocation().
 					WithArtifactLocation(sarif.NewSimpleArtifactLocation(diag.Subject.Filename)).
 					WithRegion(

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -1,6 +1,7 @@
 package formatter
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
@@ -60,7 +61,8 @@ func (f *Formatter) sarifPrint(issues tflint.Issues, tferr *tflint.Error) {
 	errRun := sarif.NewRun("tflint-errors", "https://github.com/terraform-linters/tflint")
 	report.AddRun(errRun)
 	if tferr != nil {
-		if diags, ok := tferr.Cause.(hcl.Diagnostics); ok {
+		var diags hcl.Diagnostics
+		if errors.As(tferr, &diags) {
 			for _, diag := range diags {
 				location := sarif.NewPhysicalLocation().
 					WithArtifactLocation(sarif.NewSimpleArtifactLocation(diag.Subject.Filename)).

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -59,8 +59,8 @@ func (f *Formatter) sarifPrint(issues tflint.Issues, tferr *tflint.Error) {
 	errRun := sarif.NewRun("tflint-errors", "https://github.com/terraform-linters/tflint")
 	report.AddRun(errRun)
 	if tferr != nil {
-		if parseError, ok := tferr.Cause.(tflint.ConfigParseError); ok {
-			for _, diag := range parseError.Detail {
+		if parseError, ok := tferr.Cause.(tflint.TerraformConfigParseError); ok {
+			for _, diag := range parseError.Diags {
 				location := sarif.NewPhysicalLocation().
 					WithArtifactLocation(sarif.NewSimpleArtifactLocation(diag.Subject.Filename)).
 					WithRegion(

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -83,7 +83,7 @@ func (f *Formatter) sarifPrint(issues tflint.Issues, tferr *tflint.Error) {
 		} else {
 			errRun.AddResult("application_error").
 				WithLevel("error").
-				WithMessage(sarif.NewTextMessage(tferr.Message))
+				WithMessage(sarif.NewTextMessage(tferr.Error()))
 		}
 	}
 

--- a/formatter/sarif_test.go
+++ b/formatter/sarif_test.go
@@ -204,7 +204,11 @@ func Test_sarifPrint(t *testing.T) {
 						Severity: hcl.DiagWarning,
 						Summary:  "summary",
 						Detail:   "detail",
-						Subject:  &hcl.Range{Filename: "filename", Start: hcl.Pos{1, 1, 0}, End: hcl.Pos{5, 1, 4}},
+						Subject: &hcl.Range{
+							Filename: "filename",
+							Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:      hcl.Pos{Line: 5, Column: 1, Byte: 4},
+						},
 					},
 				},
 			),

--- a/formatter/sarif_test.go
+++ b/formatter/sarif_test.go
@@ -2,6 +2,7 @@ package formatter
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	hcl "github.com/hashicorp/hcl/v2"
@@ -28,6 +29,15 @@ func Test_sarifPrint(t *testing.T) {
       "tool": {
         "driver": {
           "name": "tflint",
+          "informationUri": "https://github.com/terraform-linters/tflint"
+        }
+      },
+      "results": []
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": "tflint-errors",
           "informationUri": "https://github.com/terraform-linters/tflint"
         }
       },
@@ -93,6 +103,15 @@ func Test_sarifPrint(t *testing.T) {
           ]
         }
       ]
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": "tflint-errors",
+          "informationUri": "https://github.com/terraform-linters/tflint"
+        }
+      },
+      "results": []
     }
   ]
 }`,
@@ -110,7 +129,7 @@ func Test_sarifPrint(t *testing.T) {
 					},
 				},
 			},
-			Error: &tflint.Error{},
+			Error: tflint.NewContextError("Failed to work", errors.New("I don't feel like working")),
 			Stdout: `{
   "version": "2.1.0",
   "$schema": "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
@@ -155,6 +174,86 @@ func Test_sarifPrint(t *testing.T) {
           ]
         }
       ]
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": "tflint-errors",
+          "informationUri": "https://github.com/terraform-linters/tflint"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "application_error",
+          "level": "error",
+          "message": {
+            "text": "Failed to work; I don't feel like working"
+          }
+        }
+      ]
+    }
+  ]
+}`,
+		},
+		{
+			Name: "HCL diagnostics are surfaced as tflint-errors",
+			Error: tflint.NewContextError(
+				"babel fish confused",
+				hcl.Diagnostics{
+					&hcl.Diagnostic{
+						Severity: hcl.DiagWarning,
+						Summary:  "summary",
+						Detail:   "detail",
+						Subject:  &hcl.Range{Filename: "filename", Start: hcl.Pos{1, 1, 0}, End: hcl.Pos{5, 1, 4}},
+					},
+				},
+			),
+			Stdout: `{
+  "version": "2.1.0",
+  "$schema": "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "tflint",
+          "informationUri": "https://github.com/terraform-linters/tflint"
+        }
+      },
+      "results": []
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": "tflint-errors",
+          "informationUri": "https://github.com/terraform-linters/tflint"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "summary",
+          "level": "warning",
+          "message": {
+            "text": "detail"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "filename"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 5,
+                  "endColumn": 1,
+                  "byteOffset": 0,
+                  "byteLength": 4
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }`,
@@ -164,9 +263,9 @@ func Test_sarifPrint(t *testing.T) {
 	for _, tc := range cases {
 		stdout := &bytes.Buffer{}
 		stderr := &bytes.Buffer{}
-		formatter := &Formatter{Stdout: stdout, Stderr: stderr}
+		formatter := &Formatter{Stdout: stdout, Stderr: stderr, Format: "sarif"}
 
-		formatter.sarifPrint(tc.Issues, tc.Error, map[string][]byte{})
+		formatter.Print(tc.Issues, tc.Error, map[string][]byte{})
 
 		if stdout.String() != tc.Stdout {
 			t.Fatalf("Failed %s test: expected=%s, stdout=%s", tc.Name, tc.Stdout, stdout.String())

--- a/integrationtest/inspection/bad-config/.tflint.hcl
+++ b/integrationtest/inspection/bad-config/.tflint.hcl
@@ -1,0 +1,7 @@
+plugin "testing" {
+  enabled = true
+}
+
+plugin "aws" {
+  enabled = false
+}

--- a/integrationtest/inspection/bad-config/result.json
+++ b/integrationtest/inspection/bad-config/result.json
@@ -1,0 +1,15 @@
+{
+  "issues": [],
+  "errors": [
+    {
+      "summary": "Invalid quoted type constraints",
+      "message": "Terraform 0.11 and earlier required type constraints to be given in quotes, but that form is now deprecated and will be removed in a future version of Terraform. Remove the quotes around \"map\" and write map(string) instead to explicitly indicate that the map elements are strings.",
+      "severity": "error",
+      "range": {
+        "filename": "template.tf",
+        "start": { "line": 2, "column": 10 },
+        "end": { "line": 2, "column": 15 }
+      }
+    }
+  ]
+}

--- a/integrationtest/inspection/bad-config/template.tf
+++ b/integrationtest/inspection/bad-config/template.tf
@@ -1,0 +1,9 @@
+variable "ssl_certificates" {
+  type = "map"
+  default = {
+    lorem-elb-us-west-1 = "lorem"
+    ipsum-elb-us-east-1 = "ipsum"
+    dolor-elb-us-east-4 = "dolor"
+  }
+}
+

--- a/integrationtest/inspection/enable-required-config-rule-by-cli/result.json
+++ b/integrationtest/inspection/enable-required-config-rule-by-cli/result.json
@@ -2,7 +2,8 @@
   "issues": [],
   "errors": [
     {
-      "message": "Failed to check `required_config` rule: This rule cannot be enabled with the `--enable-rule` option because it lacks the required configuration"
+      "message": "Failed to check ruleset; Failed to check `required_config` rule: This rule cannot be enabled with the `--enable-rule` option because it lacks the required configuration",
+      "severity": "error"
     }
   ]
 }

--- a/integrationtest/inspection/inspection_test.go
+++ b/integrationtest/inspection/inspection_test.go
@@ -97,6 +97,11 @@ func TestIntegration(t *testing.T) {
 			Command: "./tflint --format json",
 			Dir:     "heredoc",
 		},
+		{
+			Name:    "config parse error with HCL metadata",
+			Command: "./tflint --format json",
+			Dir:     "bad-config",
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/tflint/errors.go
+++ b/tflint/errors.go
@@ -1,6 +1,7 @@
 package tflint
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -52,6 +53,11 @@ func (e *Error) Error() string {
 	}
 
 	return e.Message
+}
+
+// As allows the error to be used with errors.As, detecting whether the underlying Cause has an error of the given type in its chain.
+func (e *Error) As(target interface{}) bool {
+	return errors.As(e.Cause, target)
 }
 
 // NewContextError makes a new context error

--- a/tflint/errors.go
+++ b/tflint/errors.go
@@ -2,6 +2,7 @@ package tflint
 
 import (
 	"fmt"
+
 	hcl "github.com/hashicorp/hcl/v2"
 )
 

--- a/tflint/errors.go
+++ b/tflint/errors.go
@@ -1,6 +1,9 @@
 package tflint
 
-import "fmt"
+import (
+	"fmt"
+	hcl "github.com/hashicorp/hcl/v2"
+)
 
 const (
 	// EvaluationError is an error when interpolation failed (unexpected)
@@ -22,7 +25,7 @@ const (
 	// ContextError is pseudo error code for propagating runtime context.
 	ContextError string = "I:Context"
 
-	// FatalLevel is a recorverable error, it cause panic
+	// FatalLevel is an unrecoverable error, it causes a panic
 	FatalLevel string = "Fatal"
 	// ErrorLevel is a user-level error, it display and feedback error information
 	ErrorLevel string = "Error"
@@ -50,6 +53,14 @@ func (e *Error) Error() string {
 	}
 
 	return e.Message
+}
+
+type ConfigParseError struct {
+	Detail *hcl.Diagnostics
+}
+
+func (e ConfigParseError) Error() string {
+	return (*e.Detail).Error()
 }
 
 // NewContextError makes a new context error

--- a/tflint/errors.go
+++ b/tflint/errors.go
@@ -2,8 +2,6 @@ package tflint
 
 import (
 	"fmt"
-
-	hcl "github.com/hashicorp/hcl/v2"
 )
 
 const (
@@ -54,15 +52,6 @@ func (e *Error) Error() string {
 	}
 
 	return e.Message
-}
-
-// TerraformConfigParseError is an error encountered by TFLint when parsing the user's Terraform configuration.
-type TerraformConfigParseError struct {
-	Diags hcl.Diagnostics
-}
-
-func (e TerraformConfigParseError) Error() string {
-	return e.Diags.Error()
 }
 
 // NewContextError makes a new context error

--- a/tflint/errors.go
+++ b/tflint/errors.go
@@ -56,12 +56,13 @@ func (e *Error) Error() string {
 	return e.Message
 }
 
-type ConfigParseError struct {
-	Detail hcl.Diagnostics
+// TerraformConfigParseError is an error encountered by TFLint when parsing the user's Terraform configuration.
+type TerraformConfigParseError struct {
+	Diags hcl.Diagnostics
 }
 
-func (e ConfigParseError) Error() string {
-	return e.Detail.Error()
+func (e TerraformConfigParseError) Error() string {
+	return e.Diags.Error()
 }
 
 // NewContextError makes a new context error

--- a/tflint/errors.go
+++ b/tflint/errors.go
@@ -57,11 +57,11 @@ func (e *Error) Error() string {
 }
 
 type ConfigParseError struct {
-	Detail *hcl.Diagnostics
+	Detail hcl.Diagnostics
 }
 
 func (e ConfigParseError) Error() string {
-	return (*e.Detail).Error()
+	return e.Detail.Error()
 }
 
 // NewContextError makes a new context error


### PR DESCRIPTION
Teach `--format json` and `--format sarif` to print structured error data. The former currently discards errors with severity warning, and the latter completely ignores `tferr`.

This PR is still in a draft stage (code complete, but missing unit/e2e tests) and is meant to solicit feedback on whether y'all think this makes sense or if you'd prefer to go in a different direction on this.

----

The context behind this PR is that I work on [`trunk`](https://trunk.io/products/check), a universal linter which makes it easy to set up and run linters for all the different types of tooling that developers use, and while looking into setting up `tflint` I was surprised that `--format default`, `--format json`, and `--format sarif` were returning wildly different things on an example repo (I was using [mozilla/partinfra-terraform](https://github.com/mozilla/partinfra-terraform) to experiment).

A bit of yak shaving later, and here we are!

Closes #1163