### PR TITLE
Add change to readme to map tflint.d directory so we can init

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Instead of installing directly, you can use the Docker images:
 Example:
 
 ```console
-docker run --rm -v $(pwd):/data -t ghcr.io/terraform-linters/tflint
+docker run --rm  -v $HOME/.tflint.d:/root/.tflint.d -v $(pwd):/data -t ghcr.io/terraform-linters/tflint
 ```
 
 ### GitHub Actions


### PR DESCRIPTION
If we don't do this, then it is more difficult to run init and then run tflint. This maps that so that it gets added to your home directory so all projects can use the initialized tflint