### PR TITLE
Add option --enable-all to enable all rules

### DIFF
--- a/cmd/option.go
+++ b/cmd/option.go
@@ -18,6 +18,7 @@ type Options struct {
 	IgnoreModules  []string `long:"ignore-module" description:"Ignore module sources" value-name:"SOURCE"`
 	EnableRules    []string `long:"enable-rule" description:"Enable rules from the command line" value-name:"RULE_NAME"`
 	DisableRules   []string `long:"disable-rule" description:"Disable rules from the command line" value-name:"RULE_NAME"`
+	EnableAllRules bool     `long:"enable-all" description:"Enable all rules" value-name:"ENABLE_ALL"`
 	Only           []string `long:"only" description:"Enable only this rule, disabling all other defaults. Can be specified multiple times" value-name:"RULE_NAME"`
 	EnablePlugins  []string `long:"enable-plugin" description:"Enable plugins from the command line" value-name:"PLUGIN_NAME"`
 	Varfiles       []string `long:"var-file" description:"Terraform variable file name" value-name:"FILE"`
@@ -104,6 +105,7 @@ func (opts *Options) toConfig() *tflint.Config {
 		Varfiles:          varfiles,
 		Variables:         opts.Variables,
 		DisabledByDefault: len(opts.Only) > 0,
+		EnableAllRules:    opts.EnableAllRules,
 		Rules:             rules,
 		Plugins:           plugins,
 	}

--- a/rules/provider.go
+++ b/rules/provider.go
@@ -70,6 +70,9 @@ func NewRules(c *tflint.Config) []Rule {
 
 	for _, rule := range DefaultRules {
 		enabled := rule.Enabled()
+		if c.EnableAllRules {
+			enabled = true
+		}
 		if r := c.Rules[rule.Name()]; r != nil {
 			if r.Enabled {
 				log.Printf("[DEBUG] `%s` is enabled", rule.Name())

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	Varfiles          []string
 	Variables         []string
 	DisabledByDefault bool
+	EnableAllRules    bool
 	PluginDir         string
 	Rules             map[string]*RuleConfig
 	Plugins           map[string]*PluginConfig
@@ -152,6 +153,9 @@ func (c *Config) Merge(other *Config) *Config {
 	}
 	if other.DisabledByDefault {
 		ret.DisabledByDefault = true
+	}
+	if other.EnableAllRules {
+		ret.EnableAllRules = true
 	}
 	if other.PluginDir != "" {
 		ret.PluginDir = other.PluginDir


### PR DESCRIPTION
It would be nice to have a way to enable all available rules.
It seems that there are also other people requesting this feature #1056 
