### PR TITLE
Avoid too many RuleSetName() rpc call

### DIFF
--- a/tflint/config.go
+++ b/tflint/config.go
@@ -205,17 +205,16 @@ type RuleSet interface {
 func (c *Config) ValidateRules(rulesets ...RuleSet) error {
 	rulesMap := map[string]string{}
 	for _, ruleset := range rulesets {
+		rulesetName, err := ruleset.RuleSetName()
+		if err != nil {
+			return err
+		}
 		ruleNames, err := ruleset.RuleNames()
 		if err != nil {
 			return err
 		}
 
 		for _, rule := range ruleNames {
-			rulesetName, err := ruleset.RuleSetName()
-			if err != nil {
-				return err
-			}
-
 			if existsName, exists := rulesMap[rule]; exists {
 				return fmt.Errorf("`%s` is duplicated in %s and %s", rule, existsName, rulesetName)
 			}


### PR DESCRIPTION
In the process of investigating the new plugin system, I noticed too many RPC calls were issued.
Retrieving the ruleset name does not have to be called for each rule, which can be a huge overhead for rulesets with a large number of rules, such as the AWS ruleset.

This pull request changes to retrieve the name once per ruleset.