### PR TITLE
Add missing E2E test cases

### DIFF
--- a/integrationtest/inspection/conditional/.tflint.hcl
+++ b/integrationtest/inspection/conditional/.tflint.hcl
@@ -1,0 +1,7 @@
+plugin "testing" {
+  enabled = true
+}
+
+plugin "aws" {
+  enabled = false
+}

--- a/integrationtest/inspection/conditional/result.json
+++ b/integrationtest/inspection/conditional/result.json
@@ -1,0 +1,65 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is t2.micro",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 36,
+          "column": 19
+        },
+        "end": {
+          "line": 36,
+          "column": 29
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is t2.micro",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 51,
+          "column": 19
+        },
+        "end": {
+          "line": 51,
+          "column": 29
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is t2.micro",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 61,
+          "column": 19
+        },
+        "end": {
+          "line": 61,
+          "column": 29
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/inspection/conditional/template.tf
+++ b/integrationtest/inspection/conditional/template.tf
@@ -1,0 +1,67 @@
+variable "zero" {
+  default = 0
+}
+
+variable "one" {
+  default = 1
+}
+
+variable "empty_object" {
+  default = {}
+}
+
+variable "object" {
+  default = {
+    foo = "bar"
+  }
+}
+
+variable "empty_set" {
+  default = []
+}
+
+variable "set" {
+  default = ["foo", "bar"]
+}
+
+variable "unknown" {}
+
+resource "aws_instance" "zero" {
+  count = var.zero
+  instance_type = "t2.micro"
+}
+
+resource "aws_instance" "one" {
+  count = var.one
+  instance_type = "t2.micro"
+}
+
+resource "aws_instance" "unknown_count" {
+  count = var.unknown
+  instance_type = "t2.micro"
+}
+
+resource "aws_instance" "empty_object" {
+  for_each = var.empty_object
+  instance_type = "t2.micro"
+}
+
+resource "aws_instance" "object" {
+  for_each = var.object
+  instance_type = "t2.micro"
+}
+
+resource "aws_instance" "empty_set" {
+  for_each = var.empty_set
+  instance_type = "t2.micro"
+}
+
+resource "aws_instance" "set" {
+  for_each = var.set
+  instance_type = "t2.micro"
+}
+
+resource "aws_instance" "unknown_for_each" {
+  for_each = var.unknown
+  instance_type = "t2.micro"
+}

--- a/integrationtest/inspection/dynblock/.tflint.hcl
+++ b/integrationtest/inspection/dynblock/.tflint.hcl
@@ -1,0 +1,7 @@
+plugin "testing" {
+  enabled = true
+}
+
+plugin "aws" {
+  enabled = false
+}

--- a/integrationtest/inspection/dynblock/result.json
+++ b/integrationtest/inspection/dynblock/result.json
@@ -1,0 +1,105 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_s3_bucket_example_lifecycle_rule",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "`lifecycle_rule` block found",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 2,
+          "column": 3
+        },
+        "end": {
+          "line": 2,
+          "column": 17
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_s3_bucket_example_lifecycle_rule",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "`enabled` attribute found",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 3,
+          "column": 15
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_s3_bucket_example_lifecycle_rule",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "`transition` block found",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 4,
+          "column": 5
+        },
+        "end": {
+          "line": 4,
+          "column": 15
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_s3_bucket_example_lifecycle_rule",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "`lifecycle_rule` block found",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 15,
+          "column": 5
+        },
+        "end": {
+          "line": 15,
+          "column": 12
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_s3_bucket_example_lifecycle_rule",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "`enabled` attribute found",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 16,
+          "column": 17
+        },
+        "end": {
+          "line": 16,
+          "column": 37
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/inspection/dynblock/template.tf
+++ b/integrationtest/inspection/dynblock/template.tf
@@ -1,0 +1,29 @@
+resource "aws_s3_bucket" "bucket" {
+  lifecycle_rule {
+    enabled = false
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+  }
+}
+
+resource "aws_s3_bucket" "dynamic" {
+  dynamic "lifecycle_rule" {
+    for_each = toset([true])
+
+    content {
+      enabled = lifecycle_rule.value
+
+      // nested dynamic block does not work because the caller iterates only `transition` blocks
+      dynamic "transition" {
+        for_each = toset([30])
+
+        content {
+          days          = transition.value
+          storage_class = "STANDARD_IA"
+        }
+      }
+    }
+  }
+}

--- a/integrationtest/inspection/inspection_test.go
+++ b/integrationtest/inspection/inspection_test.go
@@ -102,6 +102,21 @@ func TestIntegration(t *testing.T) {
 			Command: "./tflint --format json",
 			Dir:     "bad-config",
 		},
+		{
+			Name:    "conditional resources",
+			Command: "./tflint --format json",
+			Dir:     "conditional",
+		},
+		{
+			Name:    "dynamic blocks",
+			Command: "./tflint --format json",
+			Dir:     "dynblock",
+		},
+		{
+			Name:    "provider config",
+			Command: "./tflint --format json",
+			Dir:     "provider-config",
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/integrationtest/inspection/provider-config/.tflint.hcl
+++ b/integrationtest/inspection/provider-config/.tflint.hcl
@@ -1,0 +1,12 @@
+plugin "customrulesettesting" {
+  enabled = true
+  deep_check = true
+
+  auth {
+    token = "SECRET_TOKEN"
+  }
+}
+
+plugin "aws" {
+  enabled = false
+}

--- a/integrationtest/inspection/provider-config/result.json
+++ b/integrationtest/inspection/provider-config/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "deep_check=true, token=SECRET_TOKEN, zone=asia, annotation=activate/beta1",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 13,
+          "column": 19
+        },
+        "end": {
+          "line": 13,
+          "column": 29
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/inspection/provider-config/template.tf
+++ b/integrationtest/inspection/provider-config/template.tf
@@ -1,0 +1,14 @@
+variable "annotation" {
+  default = "activate/beta1"
+}
+
+provider "custom" {
+  zone = "asia"
+  annotation {
+    value = var.annotation
+  }
+}
+
+resource "aws_instance" "foo" {
+  instance_type = "t2.micro"
+}

--- a/plugin/stub-generator/main.go
+++ b/plugin/stub-generator/main.go
@@ -35,6 +35,7 @@ func main() {
 	// E2E testing
 	execCommand("mkdir", "-p", pluginDir)
 	execCommand("go", "build", "-o", pluginDir+"/tflint-ruleset-testing"+fileExt(), "./sources/testing/main.go")
+	execCommand("go", "build", "-o", pluginDir+"/tflint-ruleset-customrulesettesting"+fileExt(), "./sources/customrulesettesting/main.go")
 	execCommand("go", "build", "-o", "../../integrationtest/inspection/plugin/.tflint.d/plugins/tflint-ruleset-example"+fileExt(), "./sources/example/main.go")
 }
 

--- a/plugin/stub-generator/sources/customrulesettesting/custom/config.go
+++ b/plugin/stub-generator/sources/customrulesettesting/custom/config.go
@@ -1,0 +1,19 @@
+package custom
+
+import "github.com/hashicorp/hcl/v2"
+
+type Config struct {
+	// From .tflint.hcl
+	DeepCheck bool  `hcl:"deep_check,optional"`
+	Auth      *Auth `hcl:"auth,block"`
+
+	// From provider config
+	Zone       string
+	Annotation string
+
+	Remain hcl.Body `hcl:",remain"`
+}
+
+type Auth struct {
+	Token string `hcl:"token"`
+}

--- a/plugin/stub-generator/sources/customrulesettesting/custom/ruleset.go
+++ b/plugin/stub-generator/sources/customrulesettesting/custom/ruleset.go
@@ -1,0 +1,40 @@
+package custom
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+type RuleSet struct {
+	tflint.BuiltinRuleSet
+	config *Config
+}
+
+func (r *RuleSet) ApplyConfig(config *tflint.Config) error {
+	r.ApplyCommonConfig(config)
+
+	cfg := Config{}
+	diags := gohcl.DecodeBody(config.Body, nil, &cfg)
+	if diags.HasErrors() {
+		return diags
+	}
+	r.config = &cfg
+
+	return nil
+}
+
+func (r *RuleSet) Check(rr tflint.Runner) error {
+	runner, err := NewRunner(rr, r.config)
+	if err != nil {
+		return err
+	}
+
+	for _, rule := range r.EnabledRules {
+		if err := rule.Check(runner); err != nil {
+			return fmt.Errorf("Failed to check `%s` rule: %s", rule.Name(), err)
+		}
+	}
+	return nil
+}

--- a/plugin/stub-generator/sources/customrulesettesting/custom/runner.go
+++ b/plugin/stub-generator/sources/customrulesettesting/custom/runner.go
@@ -1,0 +1,72 @@
+package custom
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+type Runner struct {
+	tflint.Runner
+	CustomConfig *Config
+}
+
+func NewRunner(runner tflint.Runner, config *Config) (*Runner, error) {
+	provider, err := runner.RootProvider("custom")
+	if err != nil {
+		return nil, err
+	}
+
+	if provider != nil {
+		content, _, diags := provider.Config.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{Name: "zone"},
+			},
+			Blocks: []hcl.BlockHeaderSchema{
+				{Type: "annotation"},
+			},
+		})
+		if diags.HasErrors() {
+			return nil, diags
+		}
+
+		if attr, exists := content.Attributes["zone"]; exists {
+			var zone string
+			err := runner.EvaluateExprOnRootCtx(attr.Expr, &zone, nil)
+			err = runner.EnsureNoError(err, func() error {
+				config.Zone = zone
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		for _, block := range content.Blocks {
+			content, _, diags := block.Body.PartialContent(&hcl.BodySchema{
+				Attributes: []hcl.AttributeSchema{
+					{Name: "value"},
+				},
+			})
+			if diags.HasErrors() {
+				return nil, diags
+			}
+
+			if attr, exists := content.Attributes["value"]; exists {
+				var val string
+				err := runner.EvaluateExprOnRootCtx(attr.Expr, &val, nil)
+				err = runner.EnsureNoError(err, func() error {
+					config.Annotation = val
+					return nil
+				})
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	return &Runner{
+		Runner:       runner,
+		CustomConfig: config,
+	}, nil
+}

--- a/plugin/stub-generator/sources/customrulesettesting/main.go
+++ b/plugin/stub-generator/sources/customrulesettesting/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/terraform-linters/tflint-plugin-sdk/plugin"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint/plugin/stub-generator/sources/customrulesettesting/custom"
+	"github.com/terraform-linters/tflint/plugin/stub-generator/sources/customrulesettesting/rules"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		RuleSet: &custom.RuleSet{
+			BuiltinRuleSet: tflint.BuiltinRuleSet{
+				Name:    "customrulesettesting",
+				Version: "0.1.0",
+				Rules: []tflint.Rule{
+					rules.NewAwsInstanceExampleTypeRule(),
+				},
+			},
+		},
+	})
+}

--- a/plugin/stub-generator/sources/customrulesettesting/rules/aws_instance_example_type.go
+++ b/plugin/stub-generator/sources/customrulesettesting/rules/aws_instance_example_type.go
@@ -1,0 +1,56 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint/plugin/stub-generator/sources/customrulesettesting/custom"
+)
+
+// AwsInstanceExampleTypeRule checks whether ...
+type AwsInstanceExampleTypeRule struct{}
+
+// NewAwsInstanceExampleTypeRule returns a new rule
+func NewAwsInstanceExampleTypeRule() *AwsInstanceExampleTypeRule {
+	return &AwsInstanceExampleTypeRule{}
+}
+
+// Name returns the rule name
+func (r *AwsInstanceExampleTypeRule) Name() string {
+	return "aws_instance_example_type"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsInstanceExampleTypeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsInstanceExampleTypeRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsInstanceExampleTypeRule) Link() string {
+	return ""
+}
+
+// Check checks whether ...
+func (r *AwsInstanceExampleTypeRule) Check(raw tflint.Runner) error {
+	runner := raw.(*custom.Runner)
+
+	return runner.WalkResourceAttributes("aws_instance", "instance_type", func(attribute *hcl.Attribute) error {
+		return runner.EmitIssueOnExpr(
+			r,
+			fmt.Sprintf(
+				"deep_check=%t, token=%s, zone=%s, annotation=%s",
+				runner.CustomConfig.DeepCheck,
+				runner.CustomConfig.Auth.Token,
+				runner.CustomConfig.Zone,
+				runner.CustomConfig.Annotation,
+			),
+			attribute.Expr,
+		)
+	})
+}

--- a/plugin/stub-generator/sources/testing/main.go
+++ b/plugin/stub-generator/sources/testing/main.go
@@ -14,6 +14,7 @@ func main() {
 			Rules: []tflint.Rule{
 				rules.NewAwsInstanceExampleTypeRule(),
 				rules.NewRequredConfigRule(),
+				rules.NewAwsS3BucketExampleLifecycleRuleRule(),
 			},
 		},
 	})

--- a/plugin/stub-generator/sources/testing/rules/aws_s3_bucket_example_lifecycle_rule.go
+++ b/plugin/stub-generator/sources/testing/rules/aws_s3_bucket_example_lifecycle_rule.go
@@ -1,0 +1,69 @@
+package rules
+
+import (
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// AwsS3BucketExampleLifecycleRuleRule checks whether ...
+type AwsS3BucketExampleLifecycleRuleRule struct{}
+
+// NewAwsS3BucketExampleLifecycleRuleRule returns a new rule
+func NewAwsS3BucketExampleLifecycleRuleRule() *AwsS3BucketExampleLifecycleRuleRule {
+	return &AwsS3BucketExampleLifecycleRuleRule{}
+}
+
+// Name returns the rule name
+func (r *AwsS3BucketExampleLifecycleRuleRule) Name() string {
+	return "aws_s3_bucket_example_lifecycle_rule"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsS3BucketExampleLifecycleRuleRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsS3BucketExampleLifecycleRuleRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsS3BucketExampleLifecycleRuleRule) Link() string {
+	return ""
+}
+
+// Check checks whether ...
+func (r *AwsS3BucketExampleLifecycleRuleRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceBlocks("aws_s3_bucket", "lifecycle_rule", func(block *hcl.Block) error {
+		if err := runner.EmitIssue(r, "`lifecycle_rule` block found", block.DefRange); err != nil {
+			return err
+		}
+
+		content, _, diags := block.Body.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{Name: "enabled"},
+			},
+			Blocks: []hcl.BlockHeaderSchema{
+				{Type: "transition"},
+			},
+		})
+		if diags.HasErrors() {
+			return diags
+		}
+
+		if attr, exists := content.Attributes["enabled"]; exists {
+			if err := runner.EmitIssueOnExpr(r, "`enabled` attribute found", attr.Expr); err != nil {
+				return err
+			}
+		}
+
+		for _, block := range content.Blocks {
+			if err := runner.EmitIssue(r, "`transition` block found", block.DefRange); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}


### PR DESCRIPTION
This PR adds E2E test cases to help us migrate to the new plugin system. As far as I've noticed, the following three cases were not followed in the E2E test.

- Conditional resources
  - https://github.com/terraform-linters/tflint/pull/785
- Dynamic blocks
  - https://github.com/terraform-linters/tflint/pull/293
- Provider attributes evaluation
  - https://github.com/terraform-linters/tflint/pull/393