### PR TITLE
feat: get architecture for install

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,14 +1,18 @@
 #!/bin/bash -e
 
-processor=$(uname -m)
+get_machine_arch () {
+    machine_arch=""
+    case $(uname -m) in
+        i386)     machine_arch="386" ;;
+        i686)     machine_arch="386" ;;
+        x86_64)   machine_arch="amd64" ;;
+        aarch64)  dpkg --print-architecture | grep -q "arm64" && machine_arch="arm64" || machine_arch="arm" ;;
+    esac
+    echo $machine_arch
+}
+arch=$(get_machine_arch)
 
-if [ "$processor" == "x86_64" ]; then
-  arch="amd64"
-elif [ "$processor" == "arm64" ]; then
-  arch="arm64"
-else
-  arch="386"
-fi
+echo "arch=$arch"
 
 case "$(uname -s)" in
   Darwin*)


### PR DESCRIPTION
    * add bash function to get architecture
    * match arch to available download assets

I noted that `uname -m` will return aarch64 or aarch,
for arm based machines these changes will allow `os` var to match
multiple architectures and existing download assets.

Tested on darwin x86_64 (amd64), and linux amd64 and arm64.