### PR TITLE
build: CI only checks docker build for linux/amd64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,8 @@ jobs:
     env:
       # Comma-delimited list of platforms to build for.
       # See https://github.com/docker-library/official-images#multiple-architectures
-      DOCKER_PLATFORMS: linux/amd64,linux/arm64/v8
+      # Only linux/amd64 is supported except for releases as it will take longer in CI
+      DOCKER_PLATFORMS: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64/v8' || 'linux/amd64' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -50,6 +51,7 @@ jobs:
       # necessary to "re-run" the build (everything's already cached) to load
       # each individual platform. When "docker manifest" is production-ready
       # this will no longer be necessary.
+      # https://github.com/docker/build-push-action/issues/321
       run: |
         platforms=(${DOCKER_PLATFORMS//,/ })
         for p in "${platforms[@]}"; do


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/1206

Building for multi-platform on ubuntu will take longer than just building it for linux/amd64. The following build took 20 minutes:
https://github.com/terraform-linters/tflint/runs/5800029463?check_suite_focus=true

What we want to check in this test step is whether the Dockerfile is not broken. It is the responsibility of docker/build-push-action to ensure that multi-platform can be done correctly, and there is no need to check here.

This PR changes the build target to only linux/amd64 except for release. Also, for the above reasons, the linux/aarch64 test will be removed.