### PR TITLE
discovery: reword message on protocol version err

### DIFF
--- a/plugin/discovery.go
+++ b/plugin/discovery.go
@@ -138,16 +138,17 @@ func pluginClientError(err error, config *tflint.PluginConfig) error {
 	if err == nil {
 		return nil
 	}
+	
+	message := err.Error()
+	search := "Incompatible API version with plugin."
 
-	if strings.Contains(err.Error(), "Incompatible API version") {
-		message := err.Error()
+	if strings.Contains(message, "Incompatible API version") {
 		message = strings.Replace(
 			message,
-			"Incompatible API version with plugin.",
-			fmt.Sprintf(`Incompatible API version with plugin "%s".`, config.Name),
+			search,
+			fmt.Sprintf(`TFLint is not compatible with this version of the %q plugin. A newer TFLint or plugin version may be required.`, config.Name),
 			-1,
 		)
-		message = strings.Replace(message, "Client versions:", "TFLint versions:", -1)
 
 		return errors.New(message)
 	}

--- a/plugin/discovery.go
+++ b/plugin/discovery.go
@@ -138,7 +138,7 @@ func pluginClientError(err error, config *tflint.PluginConfig) error {
 	if err == nil {
 		return nil
 	}
-	
+
 	message := err.Error()
 	search := "Incompatible API version with plugin."
 

--- a/plugin/discovery.go
+++ b/plugin/discovery.go
@@ -142,7 +142,7 @@ func pluginClientError(err error, config *tflint.PluginConfig) error {
 	message := err.Error()
 	search := "Incompatible API version with plugin."
 
-	if strings.Contains(message, "Incompatible API version") {
+	if strings.Contains(message, search) {
 		message = strings.Replace(
 			message,
 			search,


### PR DESCRIPTION
* Remove references to "API"
* Remove replacement of "client version" with "TFLint version"
* Mention potential resolutions (different core/plugin versions)

Closes #1341

If https://github.com/hashicorp/go-plugin/pull/191 is accepted this function can be re-written to not use string matching and could determine whether the supported client version(s) are "newer" or "older" than the server (plugin). 