### PR TITLE
Add signatures for keyless signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
     tags:
     - v*.*.*
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -19,6 +23,10 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.18
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@v2.2.1
+      with:
+        cosign-release: 'v1.7.2'
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,19 @@ changelog:
   skip: true
 checksum:
   name_template: 'checksums.txt'
+signs:
+  - cmd: cosign
+    env:
+    - COSIGN_EXPERIMENTAL=1
+    signature: '${artifact}.keyless.sig'
+    certificate: '${artifact}.pem'
+    output: true
+    artifacts: checksum
+    args:
+      - sign-blob
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
 release:
   github:
     owner: terraform-linters

--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ Chocolatey (Windows):
 choco install tflint
 ```
 
+### Verification
+
+GnuPG
+
+```
+gpg --import 8CE69160EB3F2FE9.key
+gpg --verify checksum.txt.sig checksum.txt
+sha256sum --ignore-missing -c checksums.txt
+```
+
+Cosign (experimental)
+
+```
+COSIGN_EXPERIMENTAL=1 cosign verify-blob --signature checksums.txt.keyless.sig checksums.txt
+sha256sum --ignore-missing -c checksums.txt
+```
+
+**IMPORTANT:** Keyless Signing is in development and you should not completely trust this way. For instance, you have not validated the OIDC subject claim, so it is not guaranteed to be the public key issued by the maintainers.
+
 ### Docker
 
 Instead of installing directly, you can use the Docker images:


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint/issues/1351

This PR adds the signatures for keyless signing when releasing a new version. GoReleaser has published an example of signging by [cosign](https://github.com/sigstore/cosign), which is used as a reference.
https://goreleaser.com/customization/sign/#with-cosign

In order to use GitHub Actions as an OIDC provider, the `id-token` permission is given. This will result in signing without manual authentication.

As far as I researched, cosign's keyless signing is an experimental feature, so added a warning to the README. For example, the following problems can be considered:

- The rekor.sigstore.dev and fulcio.sigstore.dev are operated on a best-effort basis and log entries may be reset without notice.
  - https://docs.sigstore.dev/rekor/public-instance
  - https://docs.sigstore.dev/fulcio/overview
- There is no way to verify the OIDC subject claim, so you cannot guarantee that it was signed in the workflow of this repository.
  - https://github.com/sigstore/cosign/issues/1313