### PR TITLE
Refactor tflint.LoadConfig

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -5,12 +5,13 @@ import (
 	"os"
 
 	"github.com/fatih/color"
+	"github.com/spf13/afero"
 	"github.com/terraform-linters/tflint/plugin"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
 func (cli *CLI) init(opts Options) int {
-	cfg, err := tflint.LoadConfig(opts.Config)
+	cfg, err := tflint.LoadConfig(afero.Afero{Fs: afero.NewOsFs()}, opts.Config)
 	if err != nil {
 		cli.formatter.Print(tflint.Issues{}, fmt.Errorf("Failed to load TFLint config; %w", err), map[string][]byte{})
 		return ExitCodeError

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"strings"
 
-	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -49,13 +48,16 @@ func (opts *Options) toConfig() *tflint.Config {
 	log.Printf("[DEBUG] CLI Options")
 	log.Printf("[DEBUG]   Module: %t", opts.Module)
 	log.Printf("[DEBUG]   Force: %t", opts.Force)
-	log.Printf("[DEBUG]   IgnoreModules: %#v", ignoreModules)
-	log.Printf("[DEBUG]   EnableRules: %#v", opts.EnableRules)
-	log.Printf("[DEBUG]   DisableRules: %#v", opts.DisableRules)
-	log.Printf("[DEBUG]   Only: %#v", opts.Only)
-	log.Printf("[DEBUG]   EnablePlugins: %#v", opts.EnablePlugins)
-	log.Printf("[DEBUG]   Varfiles: %#v", varfiles)
-	log.Printf("[DEBUG]   Variables: %#v", opts.Variables)
+	log.Printf("[DEBUG]   IgnoreModules:")
+	for name, ignore := range ignoreModules {
+		log.Printf("[DEBUG]     %s: %t", name, ignore)
+	}
+	log.Printf("[DEBUG]   EnableRules: %s", strings.Join(opts.EnableRules, ", "))
+	log.Printf("[DEBUG]   DisableRules: %s", strings.Join(opts.DisableRules, ", "))
+	log.Printf("[DEBUG]   Only: %s", strings.Join(opts.Only, ", "))
+	log.Printf("[DEBUG]   EnablePlugins: %s", strings.Join(opts.EnablePlugins, ", "))
+	log.Printf("[DEBUG]   Varfiles: %s", strings.Join(opts.Varfiles, ", "))
+	log.Printf("[DEBUG]   Variables: %s", strings.Join(opts.Variables, ", "))
 
 	rules := map[string]*tflint.RuleConfig{}
 	if len(opts.Only) > 0 {
@@ -63,7 +65,7 @@ func (opts *Options) toConfig() *tflint.Config {
 			rules[rule] = &tflint.RuleConfig{
 				Name:    rule,
 				Enabled: true,
-				Body:    hcl.EmptyBody(),
+				Body:    nil,
 			}
 		}
 	} else {
@@ -71,14 +73,14 @@ func (opts *Options) toConfig() *tflint.Config {
 			rules[rule] = &tflint.RuleConfig{
 				Name:    rule,
 				Enabled: true,
-				Body:    hcl.EmptyBody(),
+				Body:    nil,
 			}
 		}
 		for _, rule := range opts.DisableRules {
 			rules[rule] = &tflint.RuleConfig{
 				Name:    rule,
 				Enabled: false,
-				Body:    hcl.EmptyBody(),
+				Body:    nil,
 			}
 		}
 	}

--- a/cmd/option_test.go
+++ b/cmd/option_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	hcl "github.com/hashicorp/hcl/v2"
 	flags "github.com/jessevdk/go-flags"
 	"github.com/terraform-linters/tflint/tflint"
 )
@@ -134,12 +133,12 @@ func Test_toConfig(t *testing.T) {
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
 						Enabled: true,
-						Body:    hcl.EmptyBody(),
+						Body:    nil,
 					},
 					"aws_instance_previous_type": {
 						Name:    "aws_instance_previous_type",
 						Enabled: true,
-						Body:    hcl.EmptyBody(),
+						Body:    nil,
 					},
 				},
 				Plugins: map[string]*tflint.PluginConfig{},
@@ -159,12 +158,12 @@ func Test_toConfig(t *testing.T) {
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
 						Enabled: false,
-						Body:    hcl.EmptyBody(),
+						Body:    nil,
 					},
 					"aws_instance_previous_type": {
 						Name:    "aws_instance_previous_type",
 						Enabled: false,
-						Body:    hcl.EmptyBody(),
+						Body:    nil,
 					},
 				},
 				Plugins: map[string]*tflint.PluginConfig{},
@@ -184,7 +183,7 @@ func Test_toConfig(t *testing.T) {
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
 						Enabled: true,
-						Body:    hcl.EmptyBody(),
+						Body:    nil,
 					},
 				},
 				Plugins: map[string]*tflint.PluginConfig{},
@@ -218,22 +217,24 @@ func Test_toConfig(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		var opts Options
-		parser := flags.NewParser(&opts, flags.HelpFlag)
+		t.Run(tc.Name, func(t *testing.T) {
+			var opts Options
+			parser := flags.NewParser(&opts, flags.HelpFlag)
 
-		_, err := parser.ParseArgs(strings.Split(tc.Command, " "))
-		if err != nil {
-			t.Fatalf("Failed `%s` test: %s", tc.Name, err)
-		}
+			_, err := parser.ParseArgs(strings.Split(tc.Command, " "))
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		ret := opts.toConfig()
-		eqlopts := []cmp.Option{
-			cmpopts.IgnoreUnexported(tflint.RuleConfig{}),
-			cmpopts.IgnoreUnexported(tflint.PluginConfig{}),
-			cmpopts.IgnoreUnexported(tflint.Config{}),
-		}
-		if !cmp.Equal(tc.Expected, ret, eqlopts...) {
-			t.Fatalf("Failed `%s` test: diff=%s", tc.Name, cmp.Diff(tc.Expected, ret, eqlopts...))
-		}
+			ret := opts.toConfig()
+			eqlopts := []cmp.Option{
+				cmpopts.IgnoreUnexported(tflint.RuleConfig{}),
+				cmpopts.IgnoreUnexported(tflint.PluginConfig{}),
+				cmpopts.IgnoreUnexported(tflint.Config{}),
+			}
+			if diff := cmp.Diff(tc.Expected, ret, eqlopts...); diff != "" {
+				t.Fatal(diff)
+			}
+		})
 	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/spf13/afero"
 	"github.com/terraform-linters/tflint/plugin"
 	"github.com/terraform-linters/tflint/tflint"
 )
@@ -12,7 +13,7 @@ func (cli *CLI) printVersion(opts Options) int {
 	fmt.Fprintf(cli.outStream, "TFLint version %s\n", tflint.Version)
 
 	// Load configuration files to print plugin versions
-	cfg, err := tflint.LoadConfig(opts.Config)
+	cfg, err := tflint.LoadConfig(afero.Afero{Fs: afero.NewOsFs()}, opts.Config)
 	if err != nil {
 		log.Printf("[ERROR] Failed to load TFLint config: %s", err)
 		return ExitCodeOK
@@ -22,7 +23,7 @@ func (cli *CLI) printVersion(opts Options) int {
 			rule.Enabled = false
 		}
 	}
-	cfg = cfg.Merge(opts.toConfig())
+	cfg.Merge(opts.toConfig())
 
 	rulesetPlugin, err := plugin.Discovery(cfg)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/sourcegraph/jsonrpc2 v0.1.0
 	github.com/spf13/afero v1.8.2
 	github.com/stretchr/testify v1.7.1
-	github.com/terraform-linters/tflint-plugin-sdk v0.10.1
+	github.com/terraform-linters/tflint-plugin-sdk v0.10.2-0.20220501165639-4304281d4b8d
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.10.0
 	github.com/zclconf/go-cty-yaml v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -288,8 +288,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/terraform-linters/tflint-plugin-sdk v0.10.1 h1:NmiTY6BmC8E1GpfPCF5rat/Ukcc3MmeZ9DJtF6a7+Pk=
-github.com/terraform-linters/tflint-plugin-sdk v0.10.1/go.mod h1:buSG6YRD4H7GzQpPerADmNBFaYOx31B8o8u9l+7SegY=
+github.com/terraform-linters/tflint-plugin-sdk v0.10.2-0.20220501165639-4304281d4b8d h1:ccaBalVL/cYNvuhr/oM+26nDrL1GfCQwULB6dAmvFbw=
+github.com/terraform-linters/tflint-plugin-sdk v0.10.2-0.20220501165639-4304281d4b8d/go.mod h1:buSG6YRD4H7GzQpPerADmNBFaYOx31B8o8u9l+7SegY=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/langserver/workspace_did_change_watched_files.go
+++ b/langserver/workspace_did_change_watched_files.go
@@ -17,11 +17,12 @@ func (h *handler) workspaceDidChangeWatchedFiles(ctx context.Context, conn *json
 		return nil, fmt.Errorf("root directory is undefined")
 	}
 
-	newConfig, err := tflint.LoadConfig(h.configPath)
+	newConfig, err := tflint.LoadConfig(afero.Afero{Fs: afero.NewOsFs()}, h.configPath)
 	if err != nil {
 		return nil, err
 	}
-	h.config = newConfig.Merge(h.cliConfig)
+	newConfig.Merge(h.cliConfig)
+	h.config = newConfig
 	h.rules = rules.NewRules(h.config)
 
 	h.fs = afero.NewCopyOnWriteFs(afero.NewOsFs(), afero.NewMemMapFs())

--- a/rules/terraformrules/terraform_module_pinned_source_test.go
+++ b/rules/terraformrules/terraform_module_pinned_source_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/spf13/afero"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -537,7 +538,7 @@ func loadConfigfromTempFile(t *testing.T, content string) *tflint.Config {
 	if _, err := tmpfile.Write([]byte(content)); err != nil {
 		t.Fatal(err)
 	}
-	config, err := tflint.LoadConfig(tmpfile.Name())
+	config, err := tflint.LoadConfig(afero.Afero{Fs: afero.NewOsFs()}, tmpfile.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rules/terraformrules/terraform_module_version_test.go
+++ b/rules/terraformrules/terraform_module_version_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/spf13/afero"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -249,7 +250,7 @@ func loadConfigfromModuleVersionTempFile(t *testing.T, content string) *tflint.C
 	if _, err := tmpfile.Write([]byte(content)); err != nil {
 		t.Fatal(err)
 	}
-	config, err := tflint.LoadConfig(tmpfile.Name())
+	config, err := tflint.LoadConfig(afero.Afero{Fs: afero.NewOsFs()}, tmpfile.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rules/terraformrules/terraform_naming_convention_test.go
+++ b/rules/terraformrules/terraform_naming_convention_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/spf13/afero"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -2907,7 +2908,7 @@ func loadConfigFromNamingConventionTempFile(t *testing.T, content string) *tflin
 	if _, err := tmpfile.Write([]byte(content)); err != nil {
 		t.Fatal(err)
 	}
-	config, err := tflint.LoadConfig(tmpfile.Name())
+	config, err := tflint.LoadConfig(afero.Afero{Fs: afero.NewOsFs()}, tmpfile.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -1,16 +1,15 @@
 package tflint
 
 import (
-	"errors"
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclparse"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/afero"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	sdk "github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
@@ -18,30 +17,32 @@ import (
 var defaultConfigFile = ".tflint.hcl"
 var fallbackConfigFile = "~/.tflint.hcl"
 
-var removedRulesMap = map[string]string{
-	"terraform_dash_in_data_source_name": "`terraform_dash_in_data_source_name` rule was removed in v0.16.0. Please use `terraform_naming_convention` rule instead",
-	"terraform_dash_in_module_name":      "`terraform_dash_in_module_name` rule was removed in v0.16.0. Please use `terraform_naming_convention` rule instead",
-	"terraform_dash_in_output_name":      "`terraform_dash_in_output_name` rule was removed in v0.16.0. Please use `terraform_naming_convention` rule instead",
-	"terraform_dash_in_resource_name":    "`terraform_dash_in_resource_name` rule was removed in v0.16.0. Please use `terraform_naming_convention` rule instead",
+var configSchema = &hcl.BodySchema{
+	Blocks: []hcl.BlockHeaderSchema{
+		{
+			Type: "config",
+		},
+		{
+			Type:       "rule",
+			LabelNames: []string{"name"},
+		},
+		{
+			Type:       "plugin",
+			LabelNames: []string{"name"},
+		},
+	},
 }
 
-type rawConfig struct {
-	Config *struct {
-		Module            *bool            `hcl:"module"`
-		Force             *bool            `hcl:"force"`
-		IgnoreModule      *map[string]bool `hcl:"ignore_module"`
-		Varfile           *[]string        `hcl:"varfile"`
-		Variables         *[]string        `hcl:"variables"`
-		DisabledByDefault *bool            `hcl:"disabled_by_default"`
-		PluginDir         *string          `hcl:"plugin_dir"`
-		// Removed options
-		TerraformVersion *string            `hcl:"terraform_version"`
-		IgnoreRule       *map[string]bool   `hcl:"ignore_rule"`
-		DeepCheck        *bool              `hcl:"deep_check"`
-		AwsCredentials   *map[string]string `hcl:"aws_credentials"`
-	} `hcl:"config,block"`
-	Rules   []RuleConfig   `hcl:"rule,block"`
-	Plugins []PluginConfig `hcl:"plugin,block"`
+var innerConfigSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{Name: "module"},
+		{Name: "force"},
+		{Name: "ignore_module"},
+		{Name: "varfile"},
+		{Name: "variables"},
+		{Name: "disabled_by_default"},
+		{Name: "plugin_dir"},
+	},
 }
 
 // Config describes the behavior of TFLint
@@ -56,7 +57,6 @@ type Config struct {
 	Rules             map[string]*RuleConfig
 	Plugins           map[string]*PluginConfig
 
-	file    *hcl.File
 	sources map[string][]byte
 }
 
@@ -65,9 +65,6 @@ type RuleConfig struct {
 	Name    string   `hcl:"name,label"`
 	Enabled bool     `hcl:"enabled"`
 	Body    hcl.Body `hcl:",remain"`
-
-	// file is the result of parsing the HCL file that declares the rule configuration.
-	file *hcl.File
 }
 
 // PluginConfig is a TFLint's plugin config
@@ -83,9 +80,6 @@ type PluginConfig struct {
 	// Parsed source attributes
 	SourceOwner string
 	SourceRepo  string
-
-	// file is the result of parsing the HCL file that declares the plugin configuration.
-	file *hcl.File
 }
 
 // EmptyConfig returns default config
@@ -103,71 +97,193 @@ func EmptyConfig() *Config {
 	}
 }
 
-// LoadConfig loads TFLint config from file
-// If failed to load the default config file, it tries to load config file under the home directory
-// Therefore, if there is no default config file, it will not return an error
-func LoadConfig(file string) (*Config, error) {
+// LoadConfig reads TFLint config from a file.
+// If ./.tflint.hcl does not exist, load ~/.tflint.hcl.
+// This fallback does not fire when explicitly reading a file other than .tflint.hcl.
+func LoadConfig(fs afero.Afero, file string) (*Config, error) {
 	log.Printf("[INFO] Load config: %s", file)
-	if _, err := os.Stat(file); !os.IsNotExist(err) {
-		cfg, err := loadConfigFromFile(file)
+	if f, err := fs.Open(file); err == nil {
+		cfg, err := loadConfig(f)
 		if err != nil {
-			log.Printf("[ERROR] %s", err)
 			return nil, err
 		}
 		return cfg, nil
 	} else if file != defaultConfigFile {
-		log.Printf("[ERROR] %s", err)
-		return nil, fmt.Errorf("`%s` is not found", file)
+		return nil, fmt.Errorf("failed to load file: %w", err)
 	} else {
-		log.Printf("[INFO] Default config file is not found. Ignored")
+		log.Printf("[INFO] file not found")
 	}
 
 	fallback, err := homedir.Expand(fallbackConfigFile)
 	if err != nil {
-		log.Printf("[ERROR] %s", err)
 		return nil, err
 	}
 
-	log.Printf("[INFO] Load fallback config: %s", fallback)
-	if _, err := os.Stat(fallback); !os.IsNotExist(err) {
-		cfg, err := loadConfigFromFile(fallback)
+	log.Printf("[INFO] Load config: %s", fallback)
+	if f, err := fs.Open(fallback); err == nil {
+		cfg, err := loadConfig(f)
 		if err != nil {
 			return nil, err
 		}
 		return cfg, nil
 	}
-	log.Printf("[INFO] Fallback config file is not found. Ignored")
+	log.Printf("[INFO] file not found")
 
 	log.Print("[INFO] Use default config")
 	return EmptyConfig(), nil
 }
 
-// Merge returns a merged copy of the two configs
-// Since the argument takes precedence, it can be used as overwriting of the config
-func (c *Config) Merge(other *Config) *Config {
-	ret := c.copy()
+func loadConfig(file afero.File) (*Config, error) {
+	src, err := afero.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
 
+	parser := hclparse.NewParser()
+	f, diags := parser.ParseHCL(src, file.Name())
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	content, diags := f.Body.Content(configSchema)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	config := EmptyConfig()
+	config.sources = parser.Sources()
+	for _, block := range content.Blocks {
+		switch block.Type {
+		case "config":
+			inner, diags := block.Body.Content(innerConfigSchema)
+			if diags.HasErrors() {
+				return config, diags
+			}
+
+			for name, attr := range inner.Attributes {
+				switch name {
+				case "module":
+					if err := gohcl.DecodeExpression(attr.Expr, nil, &config.Module); err != nil {
+						return config, err
+					}
+				case "force":
+					if err := gohcl.DecodeExpression(attr.Expr, nil, &config.Force); err != nil {
+						return config, err
+					}
+				case "ignore_module":
+					if err := gohcl.DecodeExpression(attr.Expr, nil, &config.IgnoreModules); err != nil {
+						return config, err
+					}
+				case "varfile":
+					if err := gohcl.DecodeExpression(attr.Expr, nil, &config.Varfiles); err != nil {
+						return config, err
+					}
+				case "variables":
+					if err := gohcl.DecodeExpression(attr.Expr, nil, &config.Variables); err != nil {
+						return config, err
+					}
+				case "disabled_by_default":
+					if err := gohcl.DecodeExpression(attr.Expr, nil, &config.DisabledByDefault); err != nil {
+						return config, err
+					}
+				case "plugin_dir":
+					if err := gohcl.DecodeExpression(attr.Expr, nil, &config.PluginDir); err != nil {
+						return config, err
+					}
+				default:
+					panic("never happened")
+				}
+			}
+		case "rule":
+			ruleConfig := &RuleConfig{Name: block.Labels[0]}
+			if err := gohcl.DecodeBody(block.Body, nil, ruleConfig); err != nil {
+				return config, err
+			}
+			config.Rules[block.Labels[0]] = ruleConfig
+		case "plugin":
+			pluginConfig := &PluginConfig{Name: block.Labels[0]}
+			if err := gohcl.DecodeBody(block.Body, nil, pluginConfig); err != nil {
+				return config, err
+			}
+			if err := pluginConfig.validate(); err != nil {
+				return config, err
+			}
+			config.Plugins[block.Labels[0]] = pluginConfig
+		default:
+			panic("never happened")
+		}
+	}
+
+	log.Printf("[DEBUG] Config loaded")
+	log.Printf("[DEBUG]   Module: %t", config.Module)
+	log.Printf("[DEBUG]   Force: %t", config.Force)
+	log.Printf("[DEBUG]   IgnoreModules:")
+	for name, ignore := range config.IgnoreModules {
+		log.Printf("[DEBUG]     %s: %t", name, ignore)
+	}
+	log.Printf("[DEBUG]   Varfiles: %s", strings.Join(config.Varfiles, ", "))
+	log.Printf("[DEBUG]   Variables: %s", strings.Join(config.Variables, ", "))
+	log.Printf("[DEBUG]   DisabledByDefault: %t", config.DisabledByDefault)
+	log.Printf("[DEBUG]   PluginDir: %s", config.PluginDir)
+	log.Printf("[DEBUG]   Rules:")
+	for name, rule := range config.Rules {
+		log.Printf("[DEBUG]     %s: %t", name, rule.Enabled)
+	}
+	log.Printf("[DEBUG]   Plugins:")
+	for name, plugin := range config.Plugins {
+		log.Printf("[DEBUG]     %s: enabled=%t, version=%s, source=%s", name, plugin.Enabled, plugin.Version, plugin.Source)
+	}
+
+	return config, nil
+}
+
+// Sources returns parsed config file sources.
+// Normally, there is only one file, but it is represented by map to retain the file name.
+func (c *Config) Sources() map[string][]byte {
+	return c.sources
+}
+
+// Merge merges the two configs and applies to itself.
+// Since the argument takes precedence, it can be used as overwriting of the config.
+func (c *Config) Merge(other *Config) {
 	if other.Module {
-		ret.Module = true
+		c.Module = true
 	}
 	if other.Force {
-		ret.Force = true
+		c.Force = true
 	}
 	if other.DisabledByDefault {
-		ret.DisabledByDefault = true
+		c.DisabledByDefault = true
 	}
 	if other.PluginDir != "" {
-		ret.PluginDir = other.PluginDir
+		c.PluginDir = other.PluginDir
 	}
 
-	ret.IgnoreModules = mergeBoolMap(ret.IgnoreModules, other.IgnoreModules)
-	ret.Varfiles = append(ret.Varfiles, other.Varfiles...)
-	ret.Variables = append(ret.Variables, other.Variables...)
+	for name, ignore := range other.IgnoreModules {
+		c.IgnoreModules[name] = ignore
+	}
+	c.Varfiles = append(c.Varfiles, other.Varfiles...)
+	c.Variables = append(c.Variables, other.Variables...)
 
-	ret.Rules = mergeRuleMap(ret.Rules, other.Rules)
-	ret.Plugins = mergePluginMap(ret.Plugins, other.Plugins)
+	for name, rule := range other.Rules {
+		// HACK: If you enable the rule through the CLI instead of the file, its hcl.Body will be nil.
+		//       In this case, only override Enabled flag
+		if _, exists := c.Rules[name]; exists && rule.Body == nil {
+			c.Rules[name].Enabled = rule.Enabled
+		} else {
+			c.Rules[name] = rule
+		}
+	}
 
-	return ret
+	for name, plugin := range other.Plugins {
+		// HACK: If you enable the plugin through the CLI instead of the file, its hcl.Body will be nil.
+		//       In this case, only override Enabled flag
+		if _, exists := c.Plugins[name]; exists && plugin.Body == nil {
+			c.Plugins[name].Enabled = plugin.Enabled
+		} else {
+			c.Plugins[name] = plugin
+		}
+	}
 }
 
 // ToPluginConfig converts self into the plugin configuration format
@@ -185,43 +301,12 @@ func (c *Config) ToPluginConfig() *sdk.Config {
 	return cfg
 }
 
-// PluginContent returns config content of the passed rule based on the schema.
-func (c *Config) PluginContent(name string, schema *hclext.BodySchema) (*hclext.BodyContent, hcl.Diagnostics) {
+// Content extracts a plugin config based on the passed schema.
+func (c *PluginConfig) Content(schema *hclext.BodySchema) (*hclext.BodyContent, hcl.Diagnostics) {
 	if schema == nil {
 		schema = &hclext.BodySchema{}
 	}
-	if c.file == nil {
-		return &hclext.BodyContent{}, nil
-	}
-
-	plugins, _, diags := c.file.Body.PartialContent(&hcl.BodySchema{
-		Blocks: []hcl.BlockHeaderSchema{
-			{Type: "plugin", LabelNames: []string{"name"}},
-		},
-	})
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	schema.Attributes = append(schema.Attributes,
-		hclext.AttributeSchema{Name: "enabled"},
-		hclext.AttributeSchema{Name: "source"},
-		hclext.AttributeSchema{Name: "version"},
-		hclext.AttributeSchema{Name: "signing_key"},
-	)
-	for _, plugin := range plugins.Blocks {
-		if plugin.Labels[0] == name {
-			return hclext.Content(plugin.Body, schema)
-		}
-	}
-
-	return &hclext.BodyContent{}, nil
-}
-
-// Sources returns parsed config file sources.
-// Normally, there is only one file, but it is represented by map to retain the file name.
-func (c *Config) Sources() map[string][]byte {
-	return c.sources
+	return hclext.Content(c.Body, schema)
 }
 
 // RuleSet is an interface to handle plugin's RuleSet and core RuleSet both
@@ -255,217 +340,11 @@ func (c *Config) ValidateRules(rulesets ...RuleSet) error {
 
 	for _, rule := range c.Rules {
 		if _, exists := rulesMap[rule.Name]; !exists {
-			if message, exists := removedRulesMap[rule.Name]; exists {
-				return errors.New(message)
-			}
 			return fmt.Errorf("Rule not found: %s", rule.Name)
 		}
 	}
 
 	return nil
-}
-
-func (c *Config) copy() *Config {
-	ignoreModules := make(map[string]bool)
-	for k, v := range c.IgnoreModules {
-		ignoreModules[k] = v
-	}
-
-	varfiles := make([]string, len(c.Varfiles))
-	copy(varfiles, c.Varfiles)
-
-	variables := make([]string, len(c.Variables))
-	copy(variables, c.Variables)
-
-	rules := map[string]*RuleConfig{}
-	for k, v := range c.Rules {
-		rules[k] = &RuleConfig{}
-		*rules[k] = *v
-	}
-
-	plugins := map[string]*PluginConfig{}
-	for k, v := range c.Plugins {
-		plugins[k] = &PluginConfig{}
-		*plugins[k] = *v
-	}
-
-	return &Config{
-		Module:            c.Module,
-		Force:             c.Force,
-		IgnoreModules:     ignoreModules,
-		Varfiles:          varfiles,
-		Variables:         variables,
-		DisabledByDefault: c.DisabledByDefault,
-		PluginDir:         c.PluginDir,
-		Rules:             rules,
-		Plugins:           plugins,
-
-		file:    c.file,
-		sources: c.sources,
-	}
-}
-
-func loadConfigFromFile(file string) (*Config, error) {
-	parser := hclparse.NewParser()
-
-	f, diags := parser.ParseHCLFile(file)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	var raw rawConfig
-	diags = gohcl.DecodeBody(f.Body, nil, &raw)
-	if diags.HasErrors() {
-		return nil, diags
-	}
-
-	if raw.Config != nil {
-		if raw.Config.TerraformVersion != nil {
-			return nil, errors.New("`terraform_version` was removed in v0.9.0 because the option is no longer used")
-		}
-
-		if raw.Config.IgnoreRule != nil {
-			return nil, errors.New("`ignore_rule` was removed in v0.12.0. Please define `rule` block with `enabled = false` instead")
-		}
-
-		if raw.Config.DeepCheck != nil {
-			return nil, errors.New(`global "deep_check" option was removed in v0.23.0. Please declare "plugin" block like the following:
-
-plugin "aws" {
-  enabled = true
-  deep_check = true
-}`)
-		}
-
-		if raw.Config.AwsCredentials != nil {
-			return nil, errors.New(`"aws_credentials" was removed in v0.23.0. Please declare "plugin" block like the following:
-
-plugin "aws" {
-  enabled = true
-  deep_check = true
-  access_key = ...
-}`)
-		}
-	}
-
-	cfg := raw.toConfig()
-	cfg.file = f
-	cfg.sources = parser.Sources()
-	for _, rule := range cfg.Rules {
-		rule.file = f
-	}
-	for _, plugin := range cfg.Plugins {
-		plugin.file = f
-
-		if err := plugin.validate(); err != nil {
-			return nil, err
-		}
-	}
-
-	log.Printf("[DEBUG] Config loaded")
-	log.Printf("[DEBUG]   Module: %t", cfg.Module)
-	log.Printf("[DEBUG]   Force: %t", cfg.Force)
-	log.Printf("[DEBUG]   IgnoreModules: %#v", cfg.IgnoreModules)
-	log.Printf("[DEBUG]   Varfiles: %#v", cfg.Varfiles)
-	log.Printf("[DEBUG]   Variables: %#v", cfg.Variables)
-	log.Printf("[DEBUG]   DisabledByDefault: %#v", cfg.DisabledByDefault)
-	log.Printf("[DEBUG]   PluginDir: %s", cfg.PluginDir)
-	log.Printf("[DEBUG]   Rules: %#v", cfg.Rules)
-	log.Printf("[DEBUG]   Plugins: %#v", cfg.Plugins)
-
-	return cfg, nil
-}
-
-func mergeBoolMap(a, b map[string]bool) map[string]bool {
-	ret := map[string]bool{}
-	for k, v := range a {
-		ret[k] = v
-	}
-	for k, v := range b {
-		ret[k] = v
-	}
-	return ret
-}
-
-func mergeRuleMap(a, b map[string]*RuleConfig) map[string]*RuleConfig {
-	ret := map[string]*RuleConfig{}
-	for k, v := range a {
-		ret[k] = v
-	}
-	for k, v := range b {
-		// HACK: If you enable the rule through the CLI instead of the file, its hcl.Body will not contain valid range.
-		// @see https://github.com/hashicorp/hcl/blob/v2.10.1/merged.go#L132-L135
-		// In this case, only override Enabled flag
-		if _, exists := ret[k]; exists && v.Body.MissingItemRange().Filename == "<empty>" {
-			ret[k].Enabled = v.Enabled
-		} else {
-			ret[k] = v
-		}
-	}
-	return ret
-}
-
-func mergePluginMap(a, b map[string]*PluginConfig) map[string]*PluginConfig {
-	ret := map[string]*PluginConfig{}
-	for k, v := range a {
-		ret[k] = v
-	}
-	for k, v := range b {
-		// If you enable the plugin through the CLI instead of the file, its hcl.Body will be nil.
-		// In this case, only override Enabled flag
-		if _, exists := ret[k]; exists && v.Body == nil {
-			ret[k].Enabled = v.Enabled
-		} else {
-			ret[k] = v
-		}
-	}
-	return ret
-}
-
-func (raw *rawConfig) toConfig() *Config {
-	ret := EmptyConfig()
-	rc := raw.Config
-
-	if rc != nil {
-		if rc.Module != nil {
-			ret.Module = *rc.Module
-		}
-		if rc.Force != nil {
-			ret.Force = *rc.Force
-		}
-		if rc.DisabledByDefault != nil {
-			ret.DisabledByDefault = *rc.DisabledByDefault
-		}
-		if rc.IgnoreModule != nil {
-			ret.IgnoreModules = *rc.IgnoreModule
-		}
-		if rc.Varfile != nil {
-			ret.Varfiles = *rc.Varfile
-		}
-		if rc.Variables != nil {
-			ret.Variables = *rc.Variables
-		}
-		if rc.PluginDir != nil {
-			ret.PluginDir = *rc.PluginDir
-		}
-	}
-
-	for _, r := range raw.Rules {
-		var rule = r
-		ret.Rules[rule.Name] = &rule
-	}
-
-	for _, p := range raw.Plugins {
-		var plugin = p
-		ret.Plugins[plugin.Name] = &plugin
-	}
-
-	return ret
-}
-
-// Bytes returns the bytes of the configuration file declared in the rule.
-func (r *RuleConfig) Bytes() []byte {
-	return r.file.Bytes
 }
 
 func (c *PluginConfig) validate() error {

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -2,35 +2,75 @@ package tflint
 
 import (
 	"errors"
-	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/spf13/afero"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	sdk "github.com/terraform-linters/tflint-plugin-sdk/tflint"
 )
 
-func Test_LoadConfig(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
+func TestLoadConfig(t *testing.T) {
+	// default error check helper
+	neverHappend := func(err error) bool { return err != nil }
 
-	cases := []struct {
-		Name     string
-		File     string
-		Fallback string
-		Expected *Config
+	tests := []struct {
+		name     string
+		file     string
+		files    map[string]string
+		want     *Config
+		errCheck func(error) bool
 	}{
 		{
-			Name: "load file",
-			File: filepath.Join(currentDir, "test-fixtures", "config", "config.hcl"),
-			Expected: &Config{
+			name: "load file",
+			file: "config.hcl",
+			files: map[string]string{
+				"config.hcl": `
+config {
+	plugin_dir = "~/.tflint.d/plugins"
+
+	module = true
+	force = true
+
+	ignore_module = {
+		"github.com/terraform-linters/example-module" = true
+	}
+
+	varfile = ["example1.tfvars", "example2.tfvars"]
+
+	variables = ["foo=bar", "bar=['foo']"]
+}
+
+rule "aws_instance_invalid_type" {
+	enabled = false
+}
+
+rule "aws_instance_previous_type" {
+	enabled = false
+	foo = "bar"
+}
+
+plugin "foo" {
+	enabled = true
+}
+
+plugin "bar" {
+	enabled = false
+	version = "0.1.0"
+	source = "github.com/foo/bar"
+	signing_key = "SIGNING_KEY"
+}
+
+plugin "baz" {
+	enabled = true
+	foo = "baz"
+}`,
+			},
+			want: &Config{
 				Module: true,
 				Force:  true,
 				IgnoreModules: map[string]bool{
@@ -64,19 +104,32 @@ func Test_LoadConfig(t *testing.T) {
 						SourceOwner: "foo",
 						SourceRepo:  "bar",
 					},
+					"baz": {
+						Name:    "baz",
+						Enabled: true,
+					},
 				},
 			},
+			errCheck: neverHappend,
 		},
 		{
-			Name:     "empty file",
-			File:     filepath.Join(currentDir, "test-fixtures", "config", "empty.hcl"),
-			Expected: EmptyConfig(),
+			name:     "empty file",
+			file:     "empty.hcl",
+			files:    map[string]string{"empty.hcl": ""},
+			want:     EmptyConfig(),
+			errCheck: neverHappend,
 		},
 		{
-			Name:     "fallback",
-			File:     filepath.Join(currentDir, "test-fixtures", "config", "not_found.hcl"),
-			Fallback: filepath.Join(currentDir, "test-fixtures", "config", "fallback.hcl"),
-			Expected: &Config{
+			name: "default home config",
+			file: ".tflint.hcl",
+			files: map[string]string{
+				"/root/.tflint.hcl": `
+config {
+	force = true
+	disabled_by_default = true
+}`,
+			},
+			want: &Config{
 				Module:            false,
 				Force:             true,
 				IgnoreModules:     map[string]bool{},
@@ -86,143 +139,136 @@ func Test_LoadConfig(t *testing.T) {
 				Rules:             map[string]*RuleConfig{},
 				Plugins:           map[string]*PluginConfig{},
 			},
+			errCheck: neverHappend,
 		},
 		{
-			Name:     "fallback file not found",
-			File:     filepath.Join(currentDir, "test-fixtures", "config", "not_found.hcl"),
-			Fallback: filepath.Join(currentDir, "test-fixtures", "config", "fallback_not_found.hcl"),
-			Expected: EmptyConfig(),
+			name:     "no config",
+			file:     ".tflint.hcl",
+			want:     EmptyConfig(),
+			errCheck: neverHappend,
+		},
+		{
+			name: "file not found",
+			file: "not_found.hcl",
+			errCheck: func(err error) bool {
+				return err == nil || err.Error() != "failed to load file: open not_found.hcl: file does not exist"
+			},
+		},
+		{
+			name: "syntax error",
+			file: "syntax_error.hcl",
+			files: map[string]string{
+				"syntax_error.hcl": `}`,
+			},
+			errCheck: func(err error) bool {
+				return err == nil || err.Error() != "syntax_error.hcl:1,1-2: Argument or block definition required; An argument or block definition is required here."
+			},
+		},
+		{
+			name: "invalid config",
+			file: "invalid.hcl",
+			files: map[string]string{
+				"invalid.hcl": `
+rule "aws_instance_invalid_type" "myrule" {
+	enabled = false
+}`,
+			},
+			errCheck: func(err error) bool {
+				return err == nil || err.Error() != "invalid.hcl:2,34-42: Extraneous label for rule; Only 1 labels (name) are expected for rule blocks."
+			},
+		},
+		{
+			name: "plugin without source",
+			file: "plugin_without_source.hcl",
+			files: map[string]string{
+				"plugin_without_source.hcl": `
+plugin "foo" {
+	enabled = true
+
+	version = "0.1.0"
+}`,
+			},
+			errCheck: func(err error) bool {
+				return err == nil || err.Error() != "plugin `foo`: `source` attribute cannot be omitted when specifying `version`"
+			},
+		},
+		{
+			name: "plugin without version",
+			file: "plugin_without_version.hcl",
+			files: map[string]string{
+				"plugin_without_version.hcl": `
+plugin "foo" {
+	enabled = true
+
+	source = "github.com/foo/bar"
+}`,
+			},
+			errCheck: func(err error) bool {
+				return err == nil || err.Error() != "plugin `foo`: `version` attribute cannot be omitted when specifying `source`"
+			},
+		},
+		{
+			name: "plugin with invalid source",
+			file: "plugin_with_invalid_source.hcl",
+			files: map[string]string{
+				"plugin_with_invalid_source.hcl": `
+plugin "foo" {
+	enabled = true
+
+	version = "0.1.0"
+	source = "github.com/foo/bar/baz"
+}`,
+			},
+			errCheck: func(err error) bool {
+				return err == nil || err.Error() != "plugin `foo`: `source` is invalid. Must be in the format `github.com/owner/repo`"
+			},
+		},
+		{
+			name: "plugin with invalid source host",
+			file: "plugin_with_invalid_source_host.hcl",
+			files: map[string]string{
+				"plugin_with_invalid_source_host.hcl": `
+plugin "foo" {
+	enabled = true
+
+	version = "0.1.0"
+	source = "gitlab.com/foo/bar"
+}`,
+			},
+			errCheck: func(err error) bool {
+				return err == nil || err.Error() != "plugin `foo`: `source` is invalid. Hostname must be `github.com`"
+			},
 		},
 	}
 
-	for _, tc := range cases {
-		originalDefault := defaultConfigFile
-		defaultConfigFile = filepath.Join(currentDir, "test-fixtures", "config", "not_found.hcl")
-		originalFallback := fallbackConfigFile
-		fallbackConfigFile = tc.Fallback
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("HOME", "/root")
+			fs := afero.Afero{Fs: afero.NewMemMapFs()}
+			for name, src := range test.files {
+				if err := fs.WriteFile(name, []byte(src), os.ModePerm); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-		ret, err := LoadConfig(tc.File)
-		if err != nil {
-			t.Fatalf("Failed `%s` test: Unexpected error occurred: %s", tc.Name, err)
-		}
+			got, err := LoadConfig(fs, test.file)
+			if test.errCheck(err) {
+				t.Fatal(err)
+			}
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(RuleConfig{}),
-			cmpopts.IgnoreUnexported(PluginConfig{}),
-			cmpopts.IgnoreUnexported(Config{}),
-			cmpopts.IgnoreFields(PluginConfig{}, "Body"),
-			cmpopts.IgnoreFields(RuleConfig{}, "Body"),
-		}
-		if !cmp.Equal(tc.Expected, ret, opts...) {
-			t.Fatalf("Failed `%s` test: diff=%s", tc.Name, cmp.Diff(tc.Expected, ret, opts...))
-		}
-
-		defaultConfigFile = originalDefault
-		fallbackConfigFile = originalFallback
+			opts := []cmp.Option{
+				cmpopts.IgnoreUnexported(Config{}),
+				cmpopts.IgnoreFields(PluginConfig{}, "Body"),
+				cmpopts.IgnoreFields(RuleConfig{}, "Body"),
+			}
+			if diff := cmp.Diff(test.want, got, opts...); diff != "" {
+				t.Fatal(diff)
+			}
+		})
 	}
 }
 
-func Test_LoadConfig_error(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cases := []struct {
-		Name     string
-		File     string
-		Expected string
-	}{
-		{
-			Name: "file not found",
-			File: filepath.Join(currentDir, "test-fixtures", "config", "not_found.hcl"),
-			Expected: fmt.Sprintf(
-				"`%s` is not found",
-				filepath.Join(currentDir, "test-fixtures", "config", "not_found.hcl"),
-			),
-		},
-		{
-			Name: "syntax error",
-			File: filepath.Join(currentDir, "test-fixtures", "config", "syntax_error.hcl"),
-			Expected: fmt.Sprintf(
-				"%s:1,1-2: Invalid character; The \"`\" character is not valid. To create a multi-line string, use the \"heredoc\" syntax, like \"<<EOT\"., and 1 other diagnostic(s)",
-				filepath.Join(currentDir, "test-fixtures", "config", "syntax_error.hcl"),
-			),
-		},
-		{
-			Name: "invalid config",
-			File: filepath.Join(currentDir, "test-fixtures", "config", "invalid.hcl"),
-			Expected: fmt.Sprintf(
-				"%s:1,34-42: Extraneous label for rule; Only 1 labels (name) are expected for rule blocks.",
-				filepath.Join(currentDir, "test-fixtures", "config", "invalid.hcl"),
-			),
-		},
-		{
-			Name:     "terraform_version",
-			File:     filepath.Join(currentDir, "test-fixtures", "config", "terraform_version.hcl"),
-			Expected: "`terraform_version` was removed in v0.9.0 because the option is no longer used",
-		},
-		{
-			Name:     "ignore_rule",
-			File:     filepath.Join(currentDir, "test-fixtures", "config", "ignore_rule.hcl"),
-			Expected: "`ignore_rule` was removed in v0.12.0. Please define `rule` block with `enabled = false` instead",
-		},
-		{
-			Name: "deep_check",
-			File: filepath.Join(currentDir, "test-fixtures", "config", "deep_check.hcl"),
-			Expected: `global "deep_check" option was removed in v0.23.0. Please declare "plugin" block like the following:
-
-plugin "aws" {
-  enabled = true
-  deep_check = true
-}`,
-		},
-		{
-			Name: "aws_credentials",
-			File: filepath.Join(currentDir, "test-fixtures", "config", "aws_credentials.hcl"),
-			Expected: `"aws_credentials" was removed in v0.23.0. Please declare "plugin" block like the following:
-
-plugin "aws" {
-  enabled = true
-  deep_check = true
-  access_key = ...
-}`,
-		},
-		{
-			Name:     "plugin without source",
-			File:     filepath.Join(currentDir, "test-fixtures", "config", "plugin_without_source.hcl"),
-			Expected: "plugin `foo`: `source` attribute cannot be omitted when specifying `version`",
-		},
-		{
-			Name:     "plugin without version",
-			File:     filepath.Join(currentDir, "test-fixtures", "config", "plugin_without_version.hcl"),
-			Expected: "plugin `foo`: `version` attribute cannot be omitted when specifying `source`",
-		},
-		{
-			Name:     "plugin with invalid source",
-			File:     filepath.Join(currentDir, "test-fixtures", "config", "plugin_with_invalid_source.hcl"),
-			Expected: "plugin `foo`: `source` is invalid. Must be in the format `github.com/owner/repo`",
-		},
-		{
-			Name:     "plugin with invalid source host",
-			File:     filepath.Join(currentDir, "test-fixtures", "config", "plugin_with_invalid_source_host.hcl"),
-			Expected: "plugin `foo`: `source` is invalid. Hostname must be `github.com`",
-		},
-	}
-
-	for _, tc := range cases {
-		_, err := LoadConfig(tc.File)
-		if err == nil {
-			t.Fatalf("Failed `%s` test: Expected error does not occurred", tc.Name)
-		}
-
-		if err.Error() != tc.Expected {
-			t.Fatalf("Failed `%s` test: expected error is `%s`, but get `%s`", tc.Name, tc.Expected, err.Error())
-		}
-	}
-}
-
-func Test_Merge(t *testing.T) {
+func TestMerge(t *testing.T) {
 	file1, diags := hclsyntax.ParseConfig([]byte(`foo = "bar"`), "test.hcl", hcl.Pos{})
 	if diags.HasErrors() {
 		t.Fatalf("Failed to parse test config: %s", diags)
@@ -232,7 +278,7 @@ func Test_Merge(t *testing.T) {
 		t.Fatalf("Failed to parse test config: %s", diags)
 	}
 
-	cfg := &Config{
+	config := &Config{
 		Module: true,
 		Force:  true,
 		IgnoreModules: map[string]bool{
@@ -258,33 +304,33 @@ func Test_Merge(t *testing.T) {
 		Plugins: map[string]*PluginConfig{},
 	}
 
-	cases := []struct {
-		Name     string
-		Base     *Config
-		Other    *Config
-		Expected *Config
+	tests := []struct {
+		name  string
+		base  *Config
+		other *Config
+		want  *Config
 	}{
 		{
-			Name:     "empty",
-			Base:     EmptyConfig(),
-			Other:    EmptyConfig(),
-			Expected: EmptyConfig(),
+			name:  "empty",
+			base:  EmptyConfig(),
+			other: EmptyConfig(),
+			want:  EmptyConfig(),
 		},
 		{
-			Name:     "prefer base",
-			Base:     cfg,
-			Other:    EmptyConfig(),
-			Expected: cfg,
+			name:  "prefer base",
+			base:  config,
+			other: EmptyConfig(),
+			want:  config,
 		},
 		{
-			Name:     "prefer other",
-			Base:     EmptyConfig(),
-			Other:    cfg,
-			Expected: cfg,
+			name:  "prefer other",
+			base:  EmptyConfig(),
+			other: config,
+			want:  config,
 		},
 		{
-			Name: "override and merge",
-			Base: &Config{
+			name: "override and merge",
+			base: &Config{
 				Module: true,
 				Force:  false,
 				IgnoreModules: map[string]bool{
@@ -318,7 +364,7 @@ func Test_Merge(t *testing.T) {
 					},
 				},
 			},
-			Other: &Config{
+			other: &Config{
 				Module: false,
 				Force:  true,
 				IgnoreModules: map[string]bool{
@@ -352,7 +398,7 @@ func Test_Merge(t *testing.T) {
 					},
 				},
 			},
-			Expected: &Config{
+			want: &Config{
 				Module: true,
 				Force:  true,
 				IgnoreModules: map[string]bool{
@@ -398,8 +444,8 @@ func Test_Merge(t *testing.T) {
 			},
 		},
 		{
-			Name: "CLI --only argument and merge",
-			Base: &Config{
+			name: "CLI --only argument and merge",
+			base: &Config{
 				Module: true,
 				Force:  false,
 				IgnoreModules: map[string]bool{
@@ -432,7 +478,7 @@ func Test_Merge(t *testing.T) {
 					},
 				},
 			},
-			Other: &Config{
+			other: &Config{
 				Module: false,
 				Force:  true,
 				IgnoreModules: map[string]bool{
@@ -446,12 +492,12 @@ func Test_Merge(t *testing.T) {
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
 						Enabled: true,
-						Body:    hcl.EmptyBody(),
+						Body:    nil,
 					},
 					"aws_instance_previous_type": {
 						Name:    "aws_instance_previous_type",
 						Enabled: true,
-						Body:    hcl.EmptyBody(), // Will not attach, missing config
+						Body:    nil, // Will not attach, missing config
 					},
 				},
 				Plugins: map[string]*PluginConfig{
@@ -465,7 +511,7 @@ func Test_Merge(t *testing.T) {
 					},
 				},
 			},
-			Expected: &Config{
+			want: &Config{
 				Module: true,
 				Force:  true,
 				IgnoreModules: map[string]bool{
@@ -485,7 +531,7 @@ func Test_Merge(t *testing.T) {
 					"aws_instance_previous_type": {
 						Name:    "aws_instance_previous_type",
 						Enabled: true,
-						Body:    hcl.EmptyBody(),
+						Body:    nil,
 					},
 					"aws_instance_invalid_ami": {
 						Name:    "aws_instance_invalid_ami",
@@ -510,8 +556,8 @@ func Test_Merge(t *testing.T) {
 			},
 		},
 		{
-			Name: "merge rule config with CLI-based config",
-			Base: &Config{
+			name: "merge rule config with CLI-based config",
+			base: &Config{
 				Module:            false,
 				Force:             false,
 				IgnoreModules:     map[string]bool{},
@@ -527,7 +573,7 @@ func Test_Merge(t *testing.T) {
 				},
 				Plugins: map[string]*PluginConfig{},
 			},
-			Other: &Config{
+			other: &Config{
 				Module:            false,
 				Force:             false,
 				IgnoreModules:     map[string]bool{},
@@ -538,12 +584,12 @@ func Test_Merge(t *testing.T) {
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
 						Enabled: true,
-						Body:    hcl.EmptyBody(),
+						Body:    nil,
 					},
 				},
 				Plugins: map[string]*PluginConfig{},
 			},
-			Expected: &Config{
+			want: &Config{
 				Module:            false,
 				Force:             false,
 				IgnoreModules:     map[string]bool{},
@@ -561,8 +607,8 @@ func Test_Merge(t *testing.T) {
 			},
 		},
 		{
-			Name: "merge plugin config with CLI-based config",
-			Base: &Config{
+			name: "merge plugin config with CLI-based config",
+			base: &Config{
 				Module:            false,
 				Force:             false,
 				IgnoreModules:     map[string]bool{},
@@ -583,7 +629,7 @@ func Test_Merge(t *testing.T) {
 					},
 				},
 			},
-			Other: &Config{
+			other: &Config{
 				Module:            false,
 				Force:             false,
 				IgnoreModules:     map[string]bool{},
@@ -598,7 +644,7 @@ func Test_Merge(t *testing.T) {
 					},
 				},
 			},
-			Expected: &Config{
+			want: &Config{
 				Module:            false,
 				Force:             false,
 				IgnoreModules:     map[string]bool{},
@@ -622,35 +668,57 @@ func Test_Merge(t *testing.T) {
 		},
 	}
 
-	for _, tc := range cases {
-		ret := tc.Base.Merge(tc.Other)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.base.Merge(test.other)
 
-		opts := []cmp.Option{
-			cmpopts.IgnoreUnexported(RuleConfig{}),
-			cmpopts.IgnoreUnexported(PluginConfig{}),
-			cmpopts.IgnoreUnexported(Config{}),
-			cmpopts.IgnoreUnexported(hclsyntax.Body{}),
-			cmpopts.IgnoreFields(hclsyntax.Body{}, "Attributes", "Blocks"),
-		}
-		if !cmp.Equal(tc.Expected, ret, opts...) {
-			t.Fatalf("Failed `%s` test: diff=%s", tc.Name, cmp.Diff(tc.Expected, ret, opts...))
-		}
+			opts := []cmp.Option{
+				cmpopts.IgnoreUnexported(Config{}),
+				cmpopts.IgnoreUnexported(hclsyntax.Body{}),
+				cmpopts.IgnoreFields(hclsyntax.Body{}, "Attributes", "Blocks"),
+			}
+			if diff := cmp.Diff(test.want, test.base, opts...); diff != "" {
+				t.Fatal(diff)
+			}
+		})
 	}
 }
 
 func Test_ToPluginConfig(t *testing.T) {
-	currentDir, err := os.Getwd()
+	src := `
+config {
+	disabled_by_default = true
+}
+
+rule "aws_instance_invalid_type" {
+	enabled = false
+}
+
+rule "aws_instance_invalid_ami" {
+	enabled = true
+}
+
+plugin "foo" {
+	enabled = true
+
+	custom = "foo"
+}
+
+plugin "bar" {
+	enabled = false
+}`
+
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	if err := fs.WriteFile("test.hcl", []byte(src), os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	config, err := LoadConfig(fs, "test.hcl")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	config, err := LoadConfig(filepath.Join(currentDir, "test-fixtures", "config", "plugin.hcl"))
-	if err != nil {
-		t.Fatalf("Failed: Unexpected error occurred: %s", err)
-	}
-
-	ret := config.ToPluginConfig()
-	expected := &sdk.Config{
+	got := config.ToPluginConfig()
+	want := &sdk.Config{
 		Rules: map[string]*sdk.RuleConfig{
 			"aws_instance_invalid_type": {
 				Name:    "aws_instance_invalid_type",
@@ -668,69 +736,45 @@ func Test_ToPluginConfig(t *testing.T) {
 		cmpopts.IgnoreFields(hcl.Range{}, "Filename"),
 		cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
 	}
-	if !cmp.Equal(expected, ret, opts...) {
-		t.Fatalf("Failed to match: %s", cmp.Diff(expected, ret, opts...))
+	if diff := cmp.Diff(got, want, opts...); diff != "" {
+		t.Fatal(diff)
 	}
 }
 
 func TestPluginContent(t *testing.T) {
-	var fileIdx int
-	loadConfig := func(src string) *Config {
-		file := filepath.Join(t.TempDir(), fmt.Sprintf(".tflint%d.hcl", fileIdx))
-		fileIdx += 1
-		if err := os.WriteFile(file, []byte(src), 0755); err != nil {
-			t.Fatalf("failed to create config file: %s", err)
-		}
-		config, err := LoadConfig(file)
-		if err != nil {
-			t.Fatalf("failed to load test config: %s", err)
-		}
-		return config
-	}
-
 	tests := []struct {
 		Name      string
-		Config    *Config
-		Args      func() (string, *hclext.BodySchema)
+		Config    string
+		Arg       *hclext.BodySchema
 		Want      *hclext.BodyContent
 		DiagCount int
 	}{
 		{
-			Name:   "schema is nil",
-			Config: EmptyConfig(),
-			Args: func() (string, *hclext.BodySchema) {
-				return "test", nil
+			Name: "schema is nil",
+			Config: `
+plugin "test" {
+	enabled = true
+}`,
+			Arg: nil,
+			Want: &hclext.BodyContent{
+				Attributes: hclext.Attributes{},
+				Blocks:     hclext.Blocks{},
 			},
-			Want:      &hclext.BodyContent{},
-			DiagCount: 0,
-		},
-		{
-			Name:   "config is not loaded from file",
-			Config: EmptyConfig(),
-			Args: func() (string, *hclext.BodySchema) {
-				return "test", &hclext.BodySchema{
-					Attributes: []hclext.AttributeSchema{{Name: "foo"}},
-				}
-			},
-			Want:      &hclext.BodyContent{},
 			DiagCount: 0,
 		},
 		{
 			Name: "manually installed plugin",
-			Config: loadConfig(`
+			Config: `
 plugin "test" {
 	enabled = true
 	foo = "bar"
-}`),
-			Args: func() (string, *hclext.BodySchema) {
-				return "test", &hclext.BodySchema{
-					Attributes: []hclext.AttributeSchema{{Name: "foo"}},
-				}
+}`,
+			Arg: &hclext.BodySchema{
+				Attributes: []hclext.AttributeSchema{{Name: "foo"}},
 			},
 			Want: &hclext.BodyContent{
 				Attributes: hclext.Attributes{
-					"enabled": &hclext.Attribute{Name: "enabled"},
-					"foo":     &hclext.Attribute{Name: "foo"},
+					"foo": &hclext.Attribute{Name: "foo"},
 				},
 				Blocks: hclext.Blocks{},
 			},
@@ -738,7 +782,7 @@ plugin "test" {
 		},
 		{
 			Name: "auto installed plugin",
-			Config: loadConfig(`
+			Config: `
 plugin "test" {
 	enabled = true
 	version = "0.1.0"
@@ -747,94 +791,38 @@ plugin "test" {
 	signing_key = "PUBLIC_KEY"
 
 	foo = "bar"
-}`),
-			Args: func() (string, *hclext.BodySchema) {
-				return "test", &hclext.BodySchema{
-					Attributes: []hclext.AttributeSchema{{Name: "foo"}},
-				}
+}`,
+			Arg: &hclext.BodySchema{
+				Attributes: []hclext.AttributeSchema{{Name: "foo"}},
 			},
 			Want: &hclext.BodyContent{
 				Attributes: hclext.Attributes{
-					"enabled":     &hclext.Attribute{Name: "enabled"},
-					"version":     &hclext.Attribute{Name: "version"},
-					"source":      &hclext.Attribute{Name: "source"},
-					"signing_key": &hclext.Attribute{Name: "signing_key"},
-					"foo":         &hclext.Attribute{Name: "foo"},
+					"foo": &hclext.Attribute{Name: "foo"},
 				},
 				Blocks: hclext.Blocks{},
 			},
-			DiagCount: 0,
-		},
-		{
-			Name: "multiple plugins",
-			Config: loadConfig(`
-plugin "manual_installed" {
-	enabled = true
-	foo = "bar"
-}
-
-plugin "auto_installed" {
-	enabled = true
-	version = "0.1.0"
-	source  = "github.com/example/example"
-
-	signing_key = "PUBLIC_KEY"
-
-	baz = "qux"
-}`),
-			Args: func() (string, *hclext.BodySchema) {
-				return "manual_installed", &hclext.BodySchema{
-					Attributes: []hclext.AttributeSchema{{Name: "foo"}},
-				}
-			},
-			Want: &hclext.BodyContent{
-				Attributes: hclext.Attributes{
-					"enabled": &hclext.Attribute{Name: "enabled"},
-					"foo":     &hclext.Attribute{Name: "foo"},
-				},
-				Blocks: hclext.Blocks{},
-			},
-			DiagCount: 0,
-		},
-		{
-			Name: "plugin not found",
-			Config: loadConfig(`
-plugin "test" {
-	enabled = true
-	foo = "bar"
-}`),
-			Args: func() (string, *hclext.BodySchema) {
-				return "example", &hclext.BodySchema{
-					Attributes: []hclext.AttributeSchema{{Name: "foo"}},
-				}
-			},
-			Want:      &hclext.BodyContent{},
 			DiagCount: 0,
 		},
 		{
 			Name: "required attribute is not found",
-			Config: loadConfig(`
+			Config: `
 plugin "test" {
 	enabled = true
-}`),
-			Args: func() (string, *hclext.BodySchema) {
-				return "test", &hclext.BodySchema{
-					Attributes: []hclext.AttributeSchema{{Name: "foo", Required: true}},
-				}
+}`,
+			Arg: &hclext.BodySchema{
+				Attributes: []hclext.AttributeSchema{{Name: "foo", Required: true}},
 			},
 			DiagCount: 1, // The argument "foo" is required
 		},
 		{
 			Name: "unsupported attribute is found",
-			Config: loadConfig(`
+			Config: `
 plugin "test" {
 	enabled = true
 	bar = "baz"
-}`),
-			Args: func() (string, *hclext.BodySchema) {
-				return "test", &hclext.BodySchema{
-					Attributes: []hclext.AttributeSchema{{Name: "foo"}},
-				}
+}`,
+			Arg: &hclext.BodySchema{
+				Attributes: []hclext.AttributeSchema{{Name: "foo"}},
 			},
 			DiagCount: 1, // An argument named "bar" is not expected here
 		},
@@ -842,7 +830,20 @@ plugin "test" {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			content, diags := test.Config.PluginContent(test.Args())
+			fs := afero.Afero{Fs: afero.NewMemMapFs()}
+			if err := fs.WriteFile("test.hcl", []byte(test.Config), os.ModePerm); err != nil {
+				t.Fatal(err)
+			}
+			config, err := LoadConfig(fs, "test.hcl")
+			if err != nil {
+				t.Fatal(err)
+			}
+			plugin, exists := config.Plugins["test"]
+			if !exists {
+				t.Fatal("plugin `test` should be declared")
+			}
+
+			content, diags := plugin.Content(test.Arg)
 			if len(diags) != test.DiagCount {
 				t.Errorf("wrong number of diagnostics %d; want %d", len(diags), test.DiagCount)
 				for _, diag := range diags {
@@ -925,19 +926,6 @@ func Test_ValidateRules(t *testing.T) {
 			RuleSets: []RuleSet{&ruleSetB{}},
 			Err:      errors.New("Rule not found: aws_instance_invalid_type"),
 		},
-		{
-			Name: "removed rule",
-			Config: &Config{
-				Rules: map[string]*RuleConfig{
-					"terraform_dash_in_resource_name": {
-						Name:    "terraform_dash_in_resource_name",
-						Enabled: true,
-					},
-				},
-			},
-			RuleSets: []RuleSet{&ruleSetA{}, &ruleSetB{}},
-			Err:      errors.New("`terraform_dash_in_resource_name` rule was removed in v0.16.0. Please use `terraform_naming_convention` rule instead"),
-		},
 	}
 
 	for _, tc := range cases {
@@ -954,118 +942,6 @@ func Test_ValidateRules(t *testing.T) {
 			if err.Error() != tc.Err.Error() {
 				t.Fatalf("Failed %s: error message is not matched: want=%s got=%s", tc.Name, tc.Err, err)
 			}
-		}
-	}
-}
-
-func Test_copy(t *testing.T) {
-	cfg := &Config{
-		Module: true,
-		Force:  true,
-		IgnoreModules: map[string]bool{
-			"github.com/terraform-linters/example-1": true,
-			"github.com/terraform-linters/example-2": false,
-		},
-		Varfiles:          []string{"example1.tfvars", "example2.tfvars"},
-		Variables:         []string{},
-		DisabledByDefault: true,
-		PluginDir:         "./.tflint.d/plugins",
-		Rules: map[string]*RuleConfig{
-			"aws_instance_invalid_type": {
-				Name:    "aws_instance_invalid_type",
-				Enabled: false,
-			},
-			"aws_instance_invalid_ami": {
-				Name:    "aws_instance_invalid_ami",
-				Enabled: true,
-			},
-		},
-		Plugins: map[string]*PluginConfig{
-			"foo": {
-				Name:    "foo",
-				Enabled: true,
-			},
-			"bar": {
-				Name:    "bar",
-				Enabled: false,
-			},
-		},
-	}
-
-	cases := []struct {
-		Name       string
-		SideEffect func(*Config)
-	}{
-		{
-			Name: "Module",
-			SideEffect: func(c *Config) {
-				c.Module = false
-			},
-		},
-		{
-			Name: "Force",
-			SideEffect: func(c *Config) {
-				c.Force = false
-			},
-		},
-		{
-			Name: "DisabledByDefault",
-			SideEffect: func(c *Config) {
-				c.DisabledByDefault = false
-			},
-		},
-		{
-			Name: "PluginDir",
-			SideEffect: func(c *Config) {
-				c.PluginDir = "~/.tflint.d/plugins"
-			},
-		},
-		{
-			Name: "IgnoreModules",
-			SideEffect: func(c *Config) {
-				c.IgnoreModules["github.com/terraform-linters/example-1"] = false
-			},
-		},
-		{
-			Name: "Varfiles",
-			SideEffect: func(c *Config) {
-				c.Varfiles = append(c.Varfiles, "new.tfvars")
-			},
-		},
-		{
-			Name: "Variables",
-			SideEffect: func(c *Config) {
-				c.Variables = append(c.Variables, "baz=foo")
-			},
-		},
-		{
-			Name: "Rules",
-			SideEffect: func(c *Config) {
-				c.Rules["aws_instance_invalid_type"].Enabled = true
-			},
-		},
-		{
-			Name: "Plugins",
-			SideEffect: func(c *Config) {
-				c.Plugins["foo"].Enabled = false
-			},
-		},
-	}
-
-	opts := []cmp.Option{
-		cmpopts.IgnoreUnexported(RuleConfig{}),
-		cmpopts.IgnoreUnexported(PluginConfig{}),
-		cmpopts.IgnoreUnexported(Config{}),
-	}
-	for _, tc := range cases {
-		ret := cfg.copy()
-		if !cmp.Equal(cfg, ret, opts...) {
-			t.Fatalf("The copied config doesn't match original: Diff=%s", cmp.Diff(cfg, ret, opts...))
-		}
-
-		tc.SideEffect(ret)
-		if cmp.Equal(cfg, ret, opts...) {
-			t.Fatalf("The original was changed when updating `%s`", tc.Name)
 		}
 	}
 }

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -488,8 +488,9 @@ func (r *Runner) RuleConfig(ruleName string) *RuleConfig {
 	return r.config.Rules[ruleName]
 }
 
-func (r *Runner) ConfigFile() *hcl.File {
-	return r.config.file
+// ConfigSources returns the sources of TFLint config files
+func (r *Runner) ConfigSources() map[string][]byte {
+	return r.config.Sources()
 }
 
 func (r *Runner) emitIssue(issue *Issue) {


### PR DESCRIPTION
This PR refactors the implementation for `tflint.LoadConfig`. The `Config` functions have the following problems:

- Use `rawConfig` where all fields are pointers to check whether a field is set. However, pointers of primitive types may cause dereference errors.
- Config may have an `hcl.File` object for encoding, but It's not intuitive and it's easy to cause panic.
- `Merge` produces a deep copy of itself, but the deep copy implementation is redundant.
- `LoadConfig` always loads files from the file system, which makes it difficult to use for tests that require complex configs.

In this PR, I removed `rawConfig` and parsed it without using `gohcl` so that I could determine if the field was set while using the primitive type as it is. It is inspired by the implementation of the Terraform core.

Unnecessary file objects have been removed as much as possible. Note that in the process, there is an incompatibility with `GetRuleConfigContent`. Previously, reserved attributes (e.g. `enabled`) were always returned, regardless of the passed schema, but new implementations will not always include them.

The `Merge` does not make a deep copy, it simply has side effects. Intuitively, I thought that side effects should be avoided, but this makes the implementation simpler.

Finally, The `LoadConfig` takes afero's FS as an argument. This abstracts the file system and makes it easier to use with memory FS from testing.