### PR TITLE
plugin: Allow accepting IncludeNotCreated option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/sourcegraph/jsonrpc2 v0.1.0
 	github.com/spf13/afero v1.8.2
 	github.com/stretchr/testify v1.7.1
-	github.com/terraform-linters/tflint-plugin-sdk v0.10.2-0.20220501165639-4304281d4b8d
+	github.com/terraform-linters/tflint-plugin-sdk v0.10.2-0.20220502173159-77d30f16c48e
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.10.0
 	github.com/zclconf/go-cty-yaml v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -288,8 +288,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/terraform-linters/tflint-plugin-sdk v0.10.2-0.20220501165639-4304281d4b8d h1:ccaBalVL/cYNvuhr/oM+26nDrL1GfCQwULB6dAmvFbw=
-github.com/terraform-linters/tflint-plugin-sdk v0.10.2-0.20220501165639-4304281d4b8d/go.mod h1:buSG6YRD4H7GzQpPerADmNBFaYOx31B8o8u9l+7SegY=
+github.com/terraform-linters/tflint-plugin-sdk v0.10.2-0.20220502173159-77d30f16c48e h1:FGTOPyAaxf+mrHiqElkcLCG6BUhZoVFZudUXE3FgzU8=
+github.com/terraform-linters/tflint-plugin-sdk v0.10.2-0.20220502173159-77d30f16c48e/go.mod h1:buSG6YRD4H7GzQpPerADmNBFaYOx31B8o8u9l+7SegY=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/integrationtest/inspection/conditional/result.json
+++ b/integrationtest/inspection/conditional/result.json
@@ -59,6 +59,66 @@
         }
       },
       "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_iam_policy_example",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "name is zero",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 71,
+          "column": 10
+        },
+        "end": {
+          "line": 71,
+          "column": 16
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_iam_policy_example",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "name is one",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 76,
+          "column": 10
+        },
+        "end": {
+          "line": 76,
+          "column": 15
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_iam_policy_example",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "name is unknown_count",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 81,
+          "column": 10
+        },
+        "end": {
+          "line": 81,
+          "column": 25
+        }
+      },
+      "callers": []
     }
   ],
   "errors": []

--- a/integrationtest/inspection/conditional/template.tf
+++ b/integrationtest/inspection/conditional/template.tf
@@ -65,3 +65,18 @@ resource "aws_instance" "unknown_for_each" {
   for_each = var.unknown
   instance_type = "t2.micro"
 }
+
+resource "aws_iam_policy" "zero" {
+  count = var.zero
+  name = "zero"
+}
+
+resource "aws_iam_policy" "one" {
+  count = var.one
+  name = "one"
+}
+
+resource "aws_iam_policy" "unknown_count" {
+  count = var.unknown
+  name = "unknown_count"
+}

--- a/plugin/stub-generator/sources/testing/main.go
+++ b/plugin/stub-generator/sources/testing/main.go
@@ -13,6 +13,7 @@ func main() {
 			Version: "0.1.0",
 			Rules: []tflint.Rule{
 				rules.NewAwsAutoscalingGroupCtyEvalExampleRule(),
+				rules.NewAwsIAMPolicyExampleRule(),
 				rules.NewAwsInstanceExampleTypeRule(),
 				rules.NewAwsS3BucketExampleLifecycleRuleRule(),
 				rules.NewAwsInstanceMapEvalExampleRule(),

--- a/plugin/stub-generator/sources/testing/rules/aws_iam_policy_example.go
+++ b/plugin/stub-generator/sources/testing/rules/aws_iam_policy_example.go
@@ -1,0 +1,74 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// AwsIAMPolicyExampleRule checks whether ...
+type AwsIAMPolicyExampleRule struct {
+	tflint.DefaultRule
+}
+
+// NewAwsIAMPolicyExampleRule returns a new rule
+func NewAwsIAMPolicyExampleRule() *AwsIAMPolicyExampleRule {
+	return &AwsIAMPolicyExampleRule{}
+}
+
+// Name returns the rule name
+func (r *AwsIAMPolicyExampleRule) Name() string {
+	return "aws_iam_policy_example"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsIAMPolicyExampleRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsIAMPolicyExampleRule) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsIAMPolicyExampleRule) Link() string {
+	return ""
+}
+
+// Check checks whether ...
+func (r *AwsIAMPolicyExampleRule) Check(runner tflint.Runner) error {
+	resources, err := runner.GetResourceContent("aws_iam_policy", &hclext.BodySchema{
+		Attributes: []hclext.AttributeSchema{{Name: "name"}},
+	}, &tflint.GetModuleContentOption{
+		ModuleCtx:         tflint.SelfModuleCtxType,
+		IncludeNotCreated: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		attribute, exists := resource.Body.Attributes["name"]
+		if !exists {
+			continue
+		}
+
+		var name string
+		err := runner.EvaluateExpr(attribute.Expr, &name, nil)
+
+		err = runner.EnsureNoError(err, func() error {
+			return runner.EmitIssue(
+				r,
+				fmt.Sprintf("name is %s", name),
+				attribute.Expr.Range(),
+			)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -272,6 +272,7 @@ func NewModuleRunners(parent *Runner) ([]*Runner, error) {
 //      https://www.terraform.io/language/meta-arguments/count
 //      https://www.terraform.io/language/meta-arguments/for_each
 //
+// However, this behavior is controlled by options. The above is the default.
 func (r *Runner) GetModuleContent(bodyS *hclext.BodySchema, opts sdk.GetModuleContentOption) (*hclext.BodyContent, hcl.Diagnostics) {
 	// For performance, determine in advance whether the target resource exists.
 	if opts.Hint.ResourceType != "" {
@@ -302,6 +303,10 @@ func (r *Runner) GetModuleContent(bodyS *hclext.BodySchema, opts sdk.GetModuleCo
 	}
 
 	content = resolveDynamicBlocks(content)
+
+	if opts.IncludeNotCreated {
+		return content, diags
+	}
 
 	out := &hclext.BodyContent{Attributes: content.Attributes}
 	for _, block := range content.Blocks {


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint-plugin-sdk/pull/160

This PR allows you to accept the options added in https://github.com/terraform-linters/tflint-plugin-sdk/pull/160. In versions that do not include this fix, this option will be ignored, but otherwise it will work fine.