### PR TITLE
tflint: Add `format` option to the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Application Options:
   -v, --version                                                 Print TFLint version
       --init                                                    Install plugins
       --langserver                                              Start language server
-  -f, --format=[default|json|checkstyle|junit|compact|sarif]    Output format (default: default)
+  -f, --format=[default|json|checkstyle|junit|compact|sarif]    Output format
   -c, --config=FILE                                             Config file name (default: .tflint.hcl)
       --ignore-module=SOURCE                                    Ignore module sources
       --enable-rule=RULE_NAME                                   Enable rules from the command line

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -24,6 +24,7 @@ func (cli *CLI) inspect(opts Options, dir string, filterFiles []string) int {
 		}
 	}
 	cfg.Merge(opts.toConfig())
+	cli.formatter.Format = cfg.Format
 
 	// Setup loader
 	if !cli.testMode {

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -12,7 +12,7 @@ type Options struct {
 	Version       bool     `short:"v" long:"version" description:"Print TFLint version"`
 	Init          bool     `long:"init" description:"Install plugins"`
 	Langserver    bool     `long:"langserver" description:"Start language server"`
-	Format        string   `short:"f" long:"format" description:"Output format" choice:"default" choice:"json" choice:"checkstyle" choice:"junit" choice:"compact" choice:"sarif" default:"default"`
+	Format        string   `short:"f" long:"format" description:"Output format" choice:"default" choice:"json" choice:"checkstyle" choice:"junit" choice:"compact" choice:"sarif"`
 	Config        string   `short:"c" long:"config" description:"Config file name" value-name:"FILE" default:".tflint.hcl"`
 	IgnoreModules []string `long:"ignore-module" description:"Ignore module sources" value-name:"SOURCE"`
 	EnableRules   []string `long:"enable-rule" description:"Enable rules from the command line" value-name:"RULE_NAME"`
@@ -58,6 +58,7 @@ func (opts *Options) toConfig() *tflint.Config {
 	log.Printf("[DEBUG]   EnablePlugins: %s", strings.Join(opts.EnablePlugins, ", "))
 	log.Printf("[DEBUG]   Varfiles: %s", strings.Join(opts.Varfiles, ", "))
 	log.Printf("[DEBUG]   Variables: %s", strings.Join(opts.Variables, ", "))
+	log.Printf("[DEBUG]   Format: %s", opts.Format)
 
 	rules := map[string]*tflint.RuleConfig{}
 	if len(opts.Only) > 0 {
@@ -105,6 +106,7 @@ func (opts *Options) toConfig() *tflint.Config {
 		Varfiles:          varfiles,
 		Variables:         opts.Variables,
 		DisabledByDefault: len(opts.Only) > 0,
+		Format:            opts.Format,
 		Rules:             rules,
 		Plugins:           plugins,
 	}

--- a/cmd/option_test.go
+++ b/cmd/option_test.go
@@ -214,6 +214,21 @@ func Test_toConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:    "--format",
+			Command: "./tflint --format compact",
+			Expected: &tflint.Config{
+				Module:            false,
+				Force:             false,
+				IgnoreModules:     map[string]bool{},
+				Varfiles:          []string{},
+				Variables:         []string{},
+				DisabledByDefault: false,
+				Format:            "compact",
+				Rules:             map[string]*tflint.RuleConfig{},
+				Plugins:           map[string]*tflint.PluginConfig{},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/docs/user-guide/config.md
+++ b/docs/user-guide/config.md
@@ -9,6 +9,7 @@ The config file is written in [HCL](https://github.com/hashicorp/hcl). An exampl
 
 ```hcl
 config {
+  format = "compact"
   plugin_dir = "~/.tflint.d/plugins"
 
   module = true
@@ -40,6 +41,12 @@ You can also use another file as a config file with the `--config` option:
 ```
 $ tflint --config other_config.hcl
 ```
+
+### `format`
+
+CLI flag: `--format`
+
+Change the output format.
 
 ### `plugin_dir`
 

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -31,6 +31,7 @@ func TestLoadConfig(t *testing.T) {
 			files: map[string]string{
 				"config.hcl": `
 config {
+	format = "compact"
 	plugin_dir = "~/.tflint.d/plugins"
 
 	module = true
@@ -80,6 +81,7 @@ plugin "baz" {
 				Variables:         []string{"foo=bar", "bar=['foo']"},
 				DisabledByDefault: false,
 				PluginDir:         "~/.tflint.d/plugins",
+				Format:            "compact",
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
@@ -175,6 +177,19 @@ rule "aws_instance_invalid_type" "myrule" {
 			},
 			errCheck: func(err error) bool {
 				return err == nil || err.Error() != "invalid.hcl:2,34-42: Extraneous label for rule; Only 1 labels (name) are expected for rule blocks."
+			},
+		},
+		{
+			name: "invalid format",
+			file: "invalid_format.hcl",
+			files: map[string]string{
+				"invalid_format.hcl": `
+config {
+	format = "invalid"
+}`,
+			},
+			errCheck: func(err error) bool {
+				return err == nil || err.Error() != "invalid is invalid format. Allowed formats are: default, json, checkstyle, junit, compact, sarif"
 			},
 		},
 		{
@@ -289,6 +304,7 @@ func TestMerge(t *testing.T) {
 		Variables:         []string{"foo=bar"},
 		DisabledByDefault: false,
 		PluginDir:         "./.tflint.d/plugins",
+		Format:            "compact",
 		Rules: map[string]*RuleConfig{
 			"aws_instance_invalid_type": {
 				Name:    "aws_instance_invalid_type",
@@ -341,6 +357,7 @@ func TestMerge(t *testing.T) {
 				Variables:         []string{"foo=bar"},
 				DisabledByDefault: false,
 				PluginDir:         "./.tflint.d/plugins",
+				Format:            "compact",
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
@@ -375,6 +392,7 @@ func TestMerge(t *testing.T) {
 				Variables:         []string{"bar=baz"},
 				DisabledByDefault: false,
 				PluginDir:         "~/.tflint.d/plugins",
+				Format:            "json",
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_ami": {
 						Name:    "aws_instance_invalid_ami",
@@ -410,6 +428,7 @@ func TestMerge(t *testing.T) {
 				Variables:         []string{"foo=bar", "bar=baz"},
 				DisabledByDefault: false,
 				PluginDir:         "~/.tflint.d/plugins",
+				Format:            "json",
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1343

This PR adds the `format` option to the config file. This option allows you to specify the format from the config file, similar to the CLI flags. The following is an example to configure the format as `compact`:

```hcl
config {
  format = "compact"
}
```