### PR TITLE
cmd: Add `--color` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Application Options:
       --var='foo=bar'                                           Set a Terraform variable
       --module                                                  Inspect modules
       --force                                                   Return zero exit status even if issues found
+      --color                                                   Enable colorized output
       --no-color                                                Disable colorized output
       --loglevel=[trace|debug|info|warn|error]                  Change the loglevel
 

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -55,6 +55,10 @@ func (cli *CLI) Run(args []string) int {
 		Stderr: cli.errStream,
 		Format: opts.Format,
 	}
+	if opts.Color {
+		color.NoColor = false
+		cli.formatter.NoColor = false
+	}
 	if opts.NoColor {
 		color.NoColor = true
 		cli.formatter.NoColor = true

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -23,6 +23,7 @@ type Options struct {
 	Variables     []string `long:"var" description:"Set a Terraform variable" value-name:"'foo=bar'"`
 	Module        bool     `long:"module" description:"Inspect modules"`
 	Force         bool     `long:"force" description:"Return zero exit status even if issues found"`
+	Color         bool     `long:"color" description:"Enable colorized output"`
 	NoColor       bool     `long:"no-color" description:"Disable colorized output"`
 	LogLevel      string   `long:"loglevel" description:"Change the loglevel" choice:"trace" choice:"debug" choice:"info" choice:"warn" choice:"error"`
 }


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1325

This PR adds a new `--color` option. This option forces colorized output to be enabled. Colored output is enabled by default, but is automatically disabled if a tty is not attached. The `--color` option always enables colorized output, even if the tty is not attached. You can see the behavior by output via a pipe.

```bash
$ tflint | less -R
# Disabled color

$ tflint --color | less -R
# Enabled color
```