### PR TITLE
Fix panic when enabling Terraform rules by CLI

### DIFF
--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -1179,7 +1179,7 @@ func Test_DecodeRuleConfig_emptyBody(t *testing.T) {
 	cfg.Rules["test"] = &RuleConfig{
 		Name:    "test",
 		Enabled: true,
-		Body:    hcl.EmptyBody(),
+		Body:    nil,
 	}
 
 	runner := TestRunnerWithConfig(t, map[string]string{}, cfg)


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1372

In https://github.com/terraform-linters/tflint/pull/1365, the rule's body enabled by CLI was changed from `hcl.EmptyBody` to nil, but the runner, which is only used in Terraform rules, did not support it well.