### PR TITLE
Fix unintended errors when enabling Terraform rules by CLI

### DIFF
--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -477,11 +477,15 @@ func (r *Runner) DecodeRuleConfig(ruleName string, val interface{}) error {
 	if rule, exists := r.config.Rules[ruleName]; exists {
 		// If you enable the rule through the CLI instead of the file, its hcl.Body will be nil.
 		if rule.Body == nil {
-			return errors.New("This rule cannot be enabled with the `--enable-rule` option because it lacks the required configuration")
-		}
-		diags := gohcl.DecodeBody(rule.Body, nil, val)
-		if diags.HasErrors() {
-			return diags
+			diags := gohcl.DecodeBody(hcl.EmptyBody(), nil, val)
+			if diags.HasErrors() {
+				return errors.New("This rule cannot be enabled with the `--enable-rule` option because it lacks the required configuration")
+			}
+		} else {
+			diags := gohcl.DecodeBody(rule.Body, nil, val)
+			if diags.HasErrors() {
+				return diags
+			}
 		}
 	}
 	return nil

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -1194,6 +1194,30 @@ func Test_DecodeRuleConfig_emptyBody(t *testing.T) {
 	}
 }
 
+func Test_DecodeRuleConfig_emptyBodyWithOptional(t *testing.T) {
+	type ruleSchema struct {
+		Foo string `hcl:"foo,optional"`
+	}
+	options := ruleSchema{}
+
+	cfg := EmptyConfig()
+	cfg.Rules["test"] = &RuleConfig{
+		Name:    "test",
+		Enabled: true,
+		Body:    nil,
+	}
+
+	runner := TestRunnerWithConfig(t, map[string]string{}, cfg)
+	if err := runner.DecodeRuleConfig("test", &options); err != nil {
+		t.Fatalf("Failed to decode rule config: %s", err)
+	}
+
+	expected := ruleSchema{Foo: ""}
+	if diff := cmp.Diff(options, expected); diff != "" {
+		t.Fatalf("Failed to decode rule config: diff=%s", diff)
+	}
+}
+
 func Test_listVarRefs(t *testing.T) {
 	cases := []struct {
 		Name     string


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1374
See https://github.com/terraform-linters/tflint/pull/1373

The fix in #1373 is the same as the [`GetRuleConfigContent`](https://github.com/terraform-linters/tflint/blob/6d02f853c5d945b94855ce94b879818d7eaea1dc/plugin/server.go#L55-L73), but it turns out that the `DecodeRuleConfig`, which is only used in Terraform rules, is not the same behavior.

Rules with a configuration cannot be enabled from the CLI, but Terraform rules can be enabled with the default config. This inconsistency will be fixed by https://github.com/terraform-linters/tflint/issues/1352.