### PR TITLE
Fix panic when enabling plugins by CLI

### DIFF
--- a/integrationtest/inspection/enable-plugin-by-cli/result.json
+++ b/integrationtest/inspection/enable-plugin-by-cli/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is t2.micro",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 2,
+          "column": 19
+        },
+        "end": {
+          "line": 2,
+          "column": 29
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/inspection/enable-plugin-by-cli/template.tf
+++ b/integrationtest/inspection/enable-plugin-by-cli/template.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+  instance_type = "t2.micro"
+}

--- a/integrationtest/inspection/inspection_test.go
+++ b/integrationtest/inspection/inspection_test.go
@@ -147,6 +147,11 @@ func TestIntegration(t *testing.T) {
 			Command: "tflint --only aws_s3_bucket_with_config_example --format json",
 			Dir:     "rule-config",
 		},
+		{
+			Name:    "enable plugin by CLI",
+			Command: "tflint --enable-plugin testing --format json",
+			Dir:     "enable-plugin-by-cli",
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -335,6 +335,9 @@ func (c *PluginConfig) Content(schema *hclext.BodySchema) (*hclext.BodyContent, 
 	if schema == nil {
 		schema = &hclext.BodySchema{}
 	}
+	if c.Body == nil {
+		return &hclext.BodyContent{}, hcl.Diagnostics{}
+	}
 	return hclext.Content(c.Body, schema)
 }
 

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -764,6 +764,7 @@ func TestPluginContent(t *testing.T) {
 	tests := []struct {
 		Name      string
 		Config    string
+		CLI       bool
 		Arg       *hclext.BodySchema
 		Want      *hclext.BodyContent
 		DiagCount int
@@ -823,6 +824,15 @@ plugin "test" {
 			DiagCount: 0,
 		},
 		{
+			Name: "enabled by CLI",
+			CLI:  true,
+			Arg: &hclext.BodySchema{
+				Attributes: []hclext.AttributeSchema{{Name: "foo"}},
+			},
+			Want:      &hclext.BodyContent{},
+			DiagCount: 0,
+		},
+		{
 			Name: "required attribute is not found",
 			Config: `
 plugin "test" {
@@ -857,9 +867,15 @@ plugin "test" {
 			if err != nil {
 				t.Fatal(err)
 			}
-			plugin, exists := config.Plugins["test"]
-			if !exists {
-				t.Fatal("plugin `test` should be declared")
+			var plugin *PluginConfig
+			if test.CLI {
+				plugin = &PluginConfig{Name: "test", Body: nil}
+			} else {
+				var exists bool
+				plugin, exists = config.Plugins["test"]
+				if !exists {
+					t.Fatal("plugin `test` should be declared")
+				}
 			}
 
 			content, diags := plugin.Content(test.Arg)


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1375

In https://github.com/terraform-linters/tflint/pull/1365, the plugin's body enabled by CLI was changed from `hcl.EmptyBody` to nil. `hclext.Content` works fine for typed nil, but causes a panic on zero values. This PR makes that `Content` returns an empty body content without passing it to `hclext.Content`.