### PR TITLE
Remove a redundant log message

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -86,8 +86,6 @@ else
   if [ $retVal -ne 0 ]; then
     echo "Failed to install tflint"
     exit $retVal
-  else
-    echo "tflint installed at ${dest} successfully"
   fi
 fi
 


### PR DESCRIPTION
`install -v` will already show the same thing:

Installing /tmp/tflint to /usr/local/bin/...
'/tmp/tflint' -> '/usr/local/bin/tflint'
tflint installed at /usr/local/bin/ successfully