### PR TITLE
terraform: Add support for Terraform v1.2 syntax

### DIFF
--- a/terraform/configs/check.go
+++ b/terraform/configs/check.go
@@ -1,0 +1,132 @@
+package configs
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/terraform/addrs"
+	"github.com/terraform-linters/tflint/terraform/lang"
+)
+
+// CheckRule represents a configuration-defined validation rule, precondition,
+// or postcondition. Blocks of this sort can appear in a few different places
+// in configuration, including "validation" blocks for variables,
+// and "precondition" and "postcondition" blocks for resources.
+type CheckRule struct {
+	// Condition is an expression that must evaluate to true if the condition
+	// holds or false if it does not. If the expression produces an error then
+	// that's considered to be a bug in the module defining the check.
+	//
+	// The available variables in a condition expression vary depending on what
+	// a check is attached to. For example, validation rules attached to
+	// input variables can only refer to the variable that is being validated.
+	Condition hcl.Expression
+
+	// ErrorMessage should be one or more full sentences, which should be in
+	// English for consistency with the rest of the error message output but
+	// can in practice be in any language. The message should describe what is
+	// required for the condition to return true in a way that would make sense
+	// to a caller of the module.
+	//
+	// The error message expression has the same variables available for
+	// interpolation as the corresponding condition.
+	ErrorMessage hcl.Expression
+
+	DeclRange hcl.Range
+}
+
+// validateSelfReferences looks for references in the check rule matching the
+// specified resource address, returning error diagnostics if such a reference
+// is found.
+func (cr *CheckRule) validateSelfReferences(checkType string, addr addrs.Resource) hcl.Diagnostics {
+	var diags hcl.Diagnostics
+	refs, _ := lang.References(cr.Condition.Variables())
+	for _, ref := range refs {
+		var refAddr addrs.Resource
+
+		switch rs := ref.Subject.(type) {
+		case addrs.Resource:
+			refAddr = rs
+		case addrs.ResourceInstance:
+			refAddr = rs.Resource
+		default:
+			continue
+		}
+
+		if refAddr.Equal(addr) {
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Invalid reference in %s", checkType),
+				Detail:   fmt.Sprintf("Configuration for %s may not refer to itself.", addr.String()),
+				Subject:  cr.Condition.Range().Ptr(),
+			})
+			break
+		}
+	}
+	return diags
+}
+
+// decodeCheckRuleBlock decodes the contents of the given block as a check rule.
+//
+// Unlike most of our "decode..." functions, this one can be applied to blocks
+// of various types as long as their body structures are "check-shaped". The
+// function takes the containing block only because some error messages will
+// refer to its location, and the returned object's DeclRange will be the
+// block's header.
+func decodeCheckRuleBlock(block *hcl.Block, override bool) (*CheckRule, hcl.Diagnostics) {
+	var diags hcl.Diagnostics
+	cr := &CheckRule{
+		DeclRange: block.DefRange,
+	}
+
+	if override {
+		// For now we'll just forbid overriding check blocks, to simplify
+		// the initial design. If we can find a clear use-case for overriding
+		// checks in override files and there's a way to define it that
+		// isn't confusing then we could relax this.
+		diags = diags.Append(&hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Can't override %s blocks", block.Type),
+			Detail:   fmt.Sprintf("Override files cannot override %q blocks.", block.Type),
+			Subject:  cr.DeclRange.Ptr(),
+		})
+		return cr, diags
+	}
+
+	content, moreDiags := block.Body.Content(checkRuleBlockSchema)
+	diags = append(diags, moreDiags...)
+
+	if attr, exists := content.Attributes["condition"]; exists {
+		cr.Condition = attr.Expr
+
+		if len(cr.Condition.Variables()) == 0 {
+			// A condition expression that doesn't refer to any variable is
+			// pointless, because its result would always be a constant.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  fmt.Sprintf("Invalid %s expression", block.Type),
+				Detail:   "The condition expression must refer to at least one object from elsewhere in the configuration, or else its result would not be checking anything.",
+				Subject:  cr.Condition.Range().Ptr(),
+			})
+		}
+	}
+
+	if attr, exists := content.Attributes["error_message"]; exists {
+		cr.ErrorMessage = attr.Expr
+	}
+
+	return cr, diags
+}
+
+var checkRuleBlockSchema = &hcl.BodySchema{
+	Attributes: []hcl.AttributeSchema{
+		{
+			Name:     "condition",
+			Required: true,
+		},
+		{
+			Name:     "error_message",
+			Required: true,
+		},
+	},
+}

--- a/terraform/configs/config_build.go
+++ b/terraform/configs/config_build.go
@@ -23,11 +23,15 @@ func BuildConfig(root *Module, walker ModuleWalker) (*Config, hcl.Diagnostics) {
 	cfg.Root = cfg // Root module is self-referential.
 	cfg.Children, diags = buildChildModules(cfg, walker)
 
-	// Now that the config is built, we can connect the provider names to all
-	// the known types for validation.
-	cfg.resolveProviderTypes()
+	// Skip provider resolution if there are any errors, since the provider
+	// configurations themselves may not be valid.
+	if !diags.HasErrors() {
+		// Now that the config is built, we can connect the provider names to all
+		// the known types for validation.
+		cfg.resolveProviderTypes()
+	}
 
-	diags = append(diags, validateProviderConfigs(nil, cfg, false)...)
+	diags = append(diags, validateProviderConfigs(nil, cfg, nil)...)
 
 	return cfg, diags
 }

--- a/terraform/configs/configschema/implied_type.go
+++ b/terraform/configs/configschema/implied_type.go
@@ -47,6 +47,9 @@ func (b *Block) ContainsSensitive() bool {
 		if attrS.NestedType != nil && attrS.NestedType.ContainsSensitive() {
 			return true
 		}
+		if attrS.NestedType != nil && attrS.NestedType.ContainsSensitive() {
+			return true
+		}
 	}
 	for _, blockS := range b.BlockTypes {
 		if blockS.ContainsSensitive() {

--- a/terraform/configs/named_values.go
+++ b/terraform/configs/named_values.go
@@ -2,7 +2,6 @@ package configs
 
 import (
 	"fmt"
-	"unicode"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -30,7 +29,7 @@ type Variable struct {
 	ConstraintType cty.Type
 
 	ParsingMode VariableParsingMode
-	Validations []*VariableValidation
+	Validations []*CheckRule
 	Sensitive   bool
 
 	DescriptionSet bool
@@ -308,53 +307,12 @@ func (m VariableParsingMode) Parse(name, value string) (cty.Value, hcl.Diagnosti
 	}
 }
 
-// VariableValidation represents a configuration-defined validation rule
-// for a particular input variable, given as a "validation" block inside
-// a "variable" block.
-type VariableValidation struct {
-	// Condition is an expression that refers to the variable being tested
-	// and contains no other references. The expression must return true
-	// to indicate that the value is valid or false to indicate that it is
-	// invalid. If the expression produces an error, that's considered a bug
-	// in the module defining the validation rule, not an error in the caller.
-	Condition hcl.Expression
-
-	// ErrorMessage is one or more full sentences, which would need to be in
-	// English for consistency with the rest of the error message output but
-	// can in practice be in any language as long as it ends with a period.
-	// The message should describe what is required for the condition to return
-	// true in a way that would make sense to a caller of the module.
-	ErrorMessage string
-
-	DeclRange hcl.Range
-}
-
-func decodeVariableValidationBlock(varName string, block *hcl.Block, override bool) (*VariableValidation, hcl.Diagnostics) {
-	var diags hcl.Diagnostics
-	vv := &VariableValidation{
-		DeclRange: block.DefRange,
-	}
-
-	if override {
-		// For now we'll just forbid overriding validation blocks, to simplify
-		// the initial design. If we can find a clear use-case for overriding
-		// validations in override files and there's a way to define it that
-		// isn't confusing then we could relax this.
-		diags = diags.Append(&hcl.Diagnostic{
-			Severity: hcl.DiagError,
-			Summary:  "Can't override variable validation rules",
-			Detail:   "Variable \"validation\" blocks cannot be used in override files.",
-			Subject:  vv.DeclRange.Ptr(),
-		})
-		return vv, diags
-	}
-
-	content, moreDiags := block.Body.Content(variableValidationBlockSchema)
-	diags = append(diags, moreDiags...)
-
-	if attr, exists := content.Attributes["condition"]; exists {
-		vv.Condition = attr.Expr
-
+// decodeVariableValidationBlock is a wrapper around decodeCheckRuleBlock
+// that imposes the additional rule that the condition expression can refer
+// only to an input variable of the given name.
+func decodeVariableValidationBlock(varName string, block *hcl.Block, override bool) (*CheckRule, hcl.Diagnostics) {
+	vv, diags := decodeCheckRuleBlock(block, override)
+	if vv.Condition != nil {
 		// The validation condition can only refer to the variable itself,
 		// to ensure that the variable declaration can't create additional
 		// edges in the dependency graph.
@@ -382,81 +340,37 @@ func decodeVariableValidationBlock(varName string, block *hcl.Block, override bo
 				Severity: hcl.DiagError,
 				Summary:  "Invalid variable validation condition",
 				Detail:   fmt.Sprintf("The condition for variable %q must refer to var.%s in order to test incoming values.", varName, varName),
-				Subject:  attr.Expr.Range().Ptr(),
+				Subject:  vv.Condition.Range().Ptr(),
 			})
 		}
 	}
 
-	if attr, exists := content.Attributes["error_message"]; exists {
-		moreDiags := gohcl.DecodeExpression(attr.Expr, nil, &vv.ErrorMessage)
-		diags = append(diags, moreDiags...)
-		if !moreDiags.HasErrors() {
-			const errSummary = "Invalid validation error message"
-			switch {
-			case vv.ErrorMessage == "":
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  errSummary,
-					Detail:   "An empty string is not a valid nor useful error message.",
-					Subject:  attr.Expr.Range().Ptr(),
-				})
-			case !looksLikeSentences(vv.ErrorMessage):
-				// Because we're going to include this string verbatim as part
-				// of a bigger error message written in our usual style in
-				// English, we'll require the given error message to conform
-				// to that. We might relax this in future if e.g. we start
-				// presenting these error messages in a different way, or if
-				// Terraform starts supporting producing error messages in
-				// other human languages, etc.
-				// For pragmatism we also allow sentences ending with
-				// exclamation points, but we don't mention it explicitly here
-				// because that's not really consistent with the Terraform UI
-				// writing style.
-				diags = diags.Append(&hcl.Diagnostic{
-					Severity: hcl.DiagError,
-					Summary:  errSummary,
-					Detail:   "The validation error message must be at least one full sentence starting with an uppercase letter and ending with a period or question mark.\n\nYour given message will be included as part of a larger Terraform error message, written as English prose. For broadly-shared modules we suggest using a similar writing style so that the overall result will be consistent.",
-					Subject:  attr.Expr.Range().Ptr(),
-				})
+	if vv.ErrorMessage != nil {
+		// The same applies to the validation error message, except that
+		// references are not required. A string literal is a valid error
+		// message.
+		goodRefs := 0
+		for _, traversal := range vv.ErrorMessage.Variables() {
+			ref, moreDiags := addrs.ParseRef(traversal)
+			if !moreDiags.HasErrors() {
+				if addr, ok := ref.Subject.(addrs.InputVariable); ok {
+					if addr.Name == varName {
+						goodRefs++
+						continue // Reference is valid
+					}
+				}
 			}
+			// If we fall out here then the reference is invalid.
+			diags = diags.Append(&hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid reference in variable validation",
+				Detail:   fmt.Sprintf("The error message for variable %q can only refer to the variable itself, using var.%s.", varName, varName),
+				Subject:  traversal.SourceRange().Ptr(),
+			})
 		}
 	}
 
 	return vv, diags
-}
-
-// looksLikeSentence is a simple heuristic that encourages writing error
-// messages that will be presentable when included as part of a larger
-// Terraform error diagnostic whose other text is written in the Terraform
-// UI writing style.
-//
-// This is intentionally not a very strong validation since we're assuming
-// that module authors want to write good messages and might just need a nudge
-// about Terraform's specific style, rather than that they are going to try
-// to work around these rules to write a lower-quality message.
-func looksLikeSentences(s string) bool {
-	if len(s) < 1 {
-		return false
-	}
-	runes := []rune(s) // HCL guarantees that all strings are valid UTF-8
-	first := runes[0]
-	last := runes[len(runes)-1]
-
-	// If the first rune is a letter then it must be an uppercase letter.
-	// (This will only see the first rune in a multi-rune combining sequence,
-	// but the first rune is generally the letter if any are, and if not then
-	// we'll just ignore it because we're primarily expecting English messages
-	// right now anyway, for consistency with all of Terraform's other output.)
-	if unicode.IsLetter(first) && !unicode.IsUpper(first) {
-		return false
-	}
-
-	// The string must be at least one full sentence, which implies having
-	// sentence-ending punctuation.
-	// (This assumes that if a sentence ends with quotes then the period
-	// will be outside the quotes, which is consistent with Terraform's UI
-	// writing style.)
-	return last == '.' || last == '?' || last == '!'
 }
 
 // Output represents an "output" block in a module or file.
@@ -466,6 +380,8 @@ type Output struct {
 	Expr        hcl.Expression
 	DependsOn   []hcl.Traversal
 	Sensitive   bool
+
+	Preconditions []*CheckRule
 
 	DescriptionSet bool
 	SensitiveSet   bool
@@ -518,6 +434,26 @@ func decodeOutputBlock(block *hcl.Block, override bool) (*Output, hcl.Diagnostic
 		deps, depsDiags := decodeDependsOn(attr)
 		diags = append(diags, depsDiags...)
 		o.DependsOn = append(o.DependsOn, deps...)
+	}
+
+	for _, block := range content.Blocks {
+		switch block.Type {
+		case "precondition":
+			cr, moreDiags := decodeCheckRuleBlock(block, override)
+			diags = append(diags, moreDiags...)
+			o.Preconditions = append(o.Preconditions, cr)
+		case "postcondition":
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Postconditions are not allowed",
+				Detail:   "Output values can only have preconditions, not postconditions.",
+				Subject:  block.TypeRange.Ptr(),
+			})
+		default:
+			// The cases above should be exhaustive for all block types
+			// defined in the block type schema, so this shouldn't happen.
+			panic(fmt.Sprintf("unexpected lifecycle sub-block type %q", block.Type))
+		}
 	}
 
 	return o, diags
@@ -592,19 +528,6 @@ var variableBlockSchema = &hcl.BodySchema{
 	},
 }
 
-var variableValidationBlockSchema = &hcl.BodySchema{
-	Attributes: []hcl.AttributeSchema{
-		{
-			Name:     "condition",
-			Required: true,
-		},
-		{
-			Name:     "error_message",
-			Required: true,
-		},
-	},
-}
-
 var outputBlockSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{
@@ -620,5 +543,9 @@ var outputBlockSchema = &hcl.BodySchema{
 		{
 			Name: "sensitive",
 		},
+	},
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "precondition"},
+		{Type: "postcondition"},
 	},
 }

--- a/terraform/configs/parser_config.go
+++ b/terraform/configs/parser_config.go
@@ -142,14 +142,14 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 			}
 
 		case "resource":
-			cfg, cfgDiags := decodeResourceBlock(block)
+			cfg, cfgDiags := decodeResourceBlock(block, override)
 			diags = append(diags, cfgDiags...)
 			if cfg != nil {
 				file.ManagedResources = append(file.ManagedResources, cfg)
 			}
 
 		case "data":
-			cfg, cfgDiags := decodeDataBlock(block)
+			cfg, cfgDiags := decodeDataBlock(block, override)
 			diags = append(diags, cfgDiags...)
 			if cfg != nil {
 				file.DataResources = append(file.DataResources, cfg)

--- a/terraform/configs/provider.go
+++ b/terraform/configs/provider.go
@@ -46,6 +46,11 @@ func decodeProviderBlock(block *hcl.Block) (*Provider, hcl.Diagnostics) {
 	name := block.Labels[0]
 	nameDiags := checkProviderNameNormalized(name, block.DefRange)
 	diags = append(diags, nameDiags...)
+	if nameDiags.HasErrors() {
+		// If the name is invalid then we mustn't produce a result because
+		// downstreams could try to use it as a provider type and then crash.
+		return nil, diags
+	}
 
 	provider := &Provider{
 		Name:      name,

--- a/terraform/configs/provider_validation.go
+++ b/terraform/configs/provider_validation.go
@@ -2,6 +2,7 @@ package configs
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -20,20 +21,33 @@ import (
 // passed in through the module call.
 //
 // The call argument is the ModuleCall for the provided Config cfg. The
-// noProviderConfig argument is passed down the call stack, indicating that the
-// module call, or a parent module call, has used a feature that precludes
-// providers from being configured at all within the module.
-func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConfig bool) (diags hcl.Diagnostics) {
+// noProviderConfigRange argument is passed down the call stack, indicating
+// that the module call, or a parent module call, has used a feature (at the
+// specified source location) that precludes providers from being configured at
+// all within the module.
+func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConfigRange *hcl.Range) (diags hcl.Diagnostics) {
 	mod := cfg.Module
 
 	for name, child := range cfg.Children {
 		mc := mod.ModuleCalls[name]
-
+		childNoProviderConfigRange := noProviderConfigRange
 		// if the module call has any of count, for_each or depends_on,
 		// providers are prohibited from being configured in this module, or
 		// any module beneath this module.
-		nope := noProviderConfig || mc.Count != nil || mc.ForEach != nil || mc.DependsOn != nil
-		diags = append(diags, validateProviderConfigs(mc, child, nope)...)
+		switch {
+		case mc.Count != nil:
+			childNoProviderConfigRange = mc.Count.Range().Ptr()
+		case mc.ForEach != nil:
+			childNoProviderConfigRange = mc.ForEach.Range().Ptr()
+		case mc.DependsOn != nil:
+			if len(mc.DependsOn) > 0 {
+				childNoProviderConfigRange = mc.DependsOn[0].SourceRange().Ptr()
+			} else {
+				// Weird! We'll just use the call itself, then.
+				childNoProviderConfigRange = mc.DeclRange.Ptr()
+			}
+		}
+		diags = append(diags, validateProviderConfigs(mc, child, childNoProviderConfigRange)...)
 	}
 
 	// the set of provider configuration names passed into the module, with the
@@ -42,11 +56,11 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 
 	// the set of empty configurations that could be proxy configurations, with
 	// the source range of the empty configuration block.
-	emptyConfigs := map[string]*hcl.Range{}
+	emptyConfigs := map[string]hcl.Range{}
 
 	// the set of provider with a defined configuration, with the source range
 	// of the configuration block declaration.
-	configured := map[string]*hcl.Range{}
+	configured := map[string]hcl.Range{}
 
 	// the set of configuration_aliases defined in the required_providers
 	// block, with the fully qualified provider type.
@@ -54,26 +68,22 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 
 	// the set of provider names defined in the required_providers block, and
 	// their provider types.
-	localNames := map[string]addrs.AbsProviderConfig{}
+	localNames := map[string]addrs.Provider{}
 
 	for _, pc := range mod.ProviderConfigs {
 		name := providerName(pc.Name, pc.Alias)
 		// Validate the config against an empty schema to see if it's empty.
 		_, pcConfigDiags := pc.Config.Content(&hcl.BodySchema{})
 		if pcConfigDiags.HasErrors() || pc.Version.Required != nil {
-			configured[name] = &pc.DeclRange
+			configured[name] = pc.DeclRange
 		} else {
-			emptyConfigs[name] = &pc.DeclRange
+			emptyConfigs[name] = pc.DeclRange
 		}
 	}
 
 	if mod.ProviderRequirements != nil {
 		for _, req := range mod.ProviderRequirements.RequiredProviders {
-			addr := addrs.AbsProviderConfig{
-				Module:   cfg.Path,
-				Provider: req.Type,
-			}
-			localNames[req.Name] = addr
+			localNames[req.Name] = req.Type
 			for _, alias := range req.Aliases {
 				addr := addrs.AbsProviderConfig{
 					Module:   cfg.Path,
@@ -125,11 +135,15 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 			// configuration. We ignore empty configs, because they will
 			// already produce a warning.
 			if !(confOK || localOK) {
+				defAddr := addrs.NewDefaultProvider(name)
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagWarning,
-					Summary:  fmt.Sprintf("Provider %s is undefined", name),
-					Detail: fmt.Sprintf("No provider named %s has been declared in %s.\n", name, moduleText) +
-						fmt.Sprintf("If you wish to refer to the %s provider within the module, add a provider configuration, or an entry in the required_providers block.", name),
+					Summary:  "Reference to undefined provider",
+					Detail: fmt.Sprintf(
+						"There is no explicit declaration for local provider name %q in %s, so Terraform is assuming you mean to pass a configuration for provider %q.\n\nTo clarify your intent and silence this warning, add to %s a required_providers entry named %q with source = %q, or a different source address if appropriate.",
+						name, moduleText, defAddr.ForDisplay(),
+						parentModuleText, name, defAddr.ForDisplay(),
+					),
 					Subject: &passed.InParent.NameRange,
 				})
 				continue
@@ -139,12 +153,16 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 			// there won't be a configuration available at runtime if the
 			// parent module did not pass one in.
 			if !cfg.Path.IsRoot() && !(confOK || passedOK) {
+				defAddr := addrs.NewDefaultProvider(name)
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagWarning,
-					Summary:  fmt.Sprintf("No configuration passed in for provider %s in %s", name, cfg.Path),
-					Detail: fmt.Sprintf("Provider %s is referenced within %s, but no configuration has been supplied.\n", name, moduleText) +
-						fmt.Sprintf("Add a provider named %s to the providers map for %s in %s.", name, cfg.Path, parentModuleText),
-					Subject: &passed.InParent.NameRange,
+					Summary:  "Missing required provider configuration",
+					Detail: fmt.Sprintf(
+						"The configuration for %s expects to inherit a configuration for provider %s with local name %q, but %s doesn't pass a configuration under that name.\n\nTo satisfy this requirement, add an entry for %q to the \"providers\" argument in the module %q block.",
+						moduleText, defAddr.ForDisplay(), name, parentModuleText,
+						name, parentCall.Name,
+					),
+					Subject: parentCall.DeclRange.Ptr(),
 				})
 			}
 		}
@@ -156,11 +174,20 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 	}
 
 	// there cannot be any configurations if no provider config is allowed
-	if len(configured) > 0 && noProviderConfig {
+	if len(configured) > 0 && noProviderConfigRange != nil {
+		// We report this from the perspective of the use of count, for_each,
+		// or depends_on rather than from inside the module, because the
+		// recipient of this message is more likely to be the author of the
+		// calling module (trying to use an older module that hasn't been
+		// updated yet) than of the called module.
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  fmt.Sprintf("Module %s contains provider configuration", cfg.Path),
-			Detail:   "Providers cannot be configured within modules using count, for_each or depends_on.",
+			Summary:  "Module is incompatible with count, for_each, and depends_on",
+			Detail: fmt.Sprintf(
+				"The module at %s is a legacy module which contains its own local provider configurations, and so calls to it may not use the count, for_each, or depends_on arguments.\n\nIf you also control the module %q, consider updating this module to instead expect provider configurations to be passed by its caller.",
+				cfg.Path, cfg.SourceAddr,
+			),
+			Subject: noProviderConfigRange,
 		})
 	}
 
@@ -170,8 +197,11 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Cannot override provider configuration",
-				Detail:   fmt.Sprintf("Provider %s is configured within the module %s and cannot be overridden.", name, cfg.Path),
-				Subject:  &passed.InChild.NameRange,
+				Detail: fmt.Sprintf(
+					"The configuration of %s has its own local configuration for %s, and so it cannot accept an overridden configuration provided by %s.",
+					moduleText, name, parentModuleText,
+				),
+				Subject: &passed.InChild.NameRange,
 			})
 		}
 	}
@@ -188,9 +218,12 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  fmt.Sprintf("No configuration for provider %s", name),
-			Detail: fmt.Sprintf("Configuration required for %s.\n", providerAddr) +
-				fmt.Sprintf("Add a provider named %s to the providers map for %s in %s.", name, cfg.Path, parentModuleText),
+			Summary:  "Missing required provider configuration",
+			Detail: fmt.Sprintf(
+				"The child module requires an additional configuration for provider %s, with the local name %q.\n\nRefer to the module's documentation to understand the intended purpose of this additional provider configuration, and then add an entry for %s in the \"providers\" meta-argument in the module block to choose which provider configuration the module should use for that purpose.",
+				providerAddr.Provider.ForDisplay(), name,
+				name,
+			),
 			Subject: &parentCall.DeclRange,
 		})
 	}
@@ -214,7 +247,7 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 
 		localAddr, localName := localNames[name]
 		if localName {
-			providerAddr = localAddr
+			providerAddr.Provider = localAddr
 		}
 
 		aliasAddr, configAlias := configAliases[name]
@@ -225,20 +258,30 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 		_, emptyConfig := emptyConfigs[name]
 
 		if !(localName || configAlias || emptyConfig) {
-			severity := hcl.DiagError
 
 			// we still allow default configs, so switch to a warning if the incoming provider is a default
 			if providerAddr.Provider.IsDefault() {
-				severity = hcl.DiagWarning
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  "Reference to undefined provider",
+					Detail: fmt.Sprintf(
+						"There is no explicit declaration for local provider name %q in %s, so Terraform is assuming you mean to pass a configuration for %q.\n\nIf you also control the child module, add a required_providers entry named %q with the source address %q.",
+						name, moduleText, providerAddr.Provider.ForDisplay(),
+						name, providerAddr.Provider.ForDisplay(),
+					),
+					Subject: &passed.InChild.NameRange,
+				})
+			} else {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Reference to undefined provider",
+					Detail: fmt.Sprintf(
+						"The child module does not declare any provider requirement with the local name %q.\n\nIf you also control the child module, you can add a required_providers entry named %q with the source address %q to accept this provider configuration.",
+						name, name, providerAddr.Provider.ForDisplay(),
+					),
+					Subject: &passed.InChild.NameRange,
+				})
 			}
-
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: severity,
-				Summary:  fmt.Sprintf("Provider %s is undefined", name),
-				Detail: fmt.Sprintf("Module %s does not declare a provider named %s.\n", cfg.Path, name) +
-					fmt.Sprintf("If you wish to specify a provider configuration for the module, add an entry for %s in the required_providers block within the module.", name),
-				Subject: &passed.InChild.NameRange,
-			})
 		}
 
 		// The provider being passed in must also be of the correct type.
@@ -264,40 +307,126 @@ func validateProviderConfigs(parentCall *ModuleCall, cfg *Config, noProviderConf
 		}
 
 		if !providerAddr.Provider.Equals(parentAddr.Provider) {
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  fmt.Sprintf("Invalid type for provider %s", providerAddr),
-				Detail: fmt.Sprintf("Cannot use configuration from %s for %s. ", parentAddr, providerAddr) +
-					"The given provider configuration is for a different provider type.",
-				Subject: &passed.InChild.NameRange,
-			})
+			// If this module declares the same source address for a different
+			// local name then we'll prefer to suggest changing to match
+			// the child module's chosen name, assuming that it was the local
+			// name that was wrong rather than the source address.
+			var otherLocalName string
+			for localName, sourceAddr := range localNames {
+				if sourceAddr.Equals(parentAddr.Provider) {
+					otherLocalName = localName
+					break
+				}
+			}
+
+			const errSummary = "Provider type mismatch"
+			if otherLocalName != "" {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  errSummary,
+					Detail: fmt.Sprintf(
+						"The assigned configuration is for provider %q, but local name %q in %s represents %q.\n\nTo pass this configuration to the child module, use the local name %q instead.",
+						parentAddr.Provider.ForDisplay(), passed.InChild.Name,
+						parentModuleText, providerAddr.Provider.ForDisplay(),
+						otherLocalName,
+					),
+					Subject: &passed.InChild.NameRange,
+				})
+			} else {
+				// If there is no declared requirement for the provider the
+				// caller is trying to pass under any name then we'll instead
+				// report it as an unsuitable configuration to pass into the
+				// child module's provider configuration slot.
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  errSummary,
+					Detail: fmt.Sprintf(
+						"The local name %q in %s represents provider %q, but %q in %s represents %q.\n\nEach provider has its own distinct configuration schema and provider types, so this module's %q can be assigned only a configuration for %s, which is not required by %s.",
+						passed.InParent, parentModuleText, parentAddr.Provider.ForDisplay(),
+						passed.InChild, moduleText, providerAddr.Provider.ForDisplay(),
+						passed.InChild, providerAddr.Provider.ForDisplay(),
+						moduleText,
+					),
+					Subject: passed.InParent.NameRange.Ptr(),
+				})
+			}
 		}
 	}
 
-	// Empty configurations are no longer needed
+	// Empty configurations are no longer needed. Since the replacement for
+	// this calls for one entry per provider rather than one entry per
+	// provider _configuration_, we'll first gather them up by provider
+	// and then report a single warning for each, whereby we can show a direct
+	// example of what the replacement should look like.
+	type ProviderReqSuggestion struct {
+		SourceAddr      addrs.Provider
+		SourceRanges    []hcl.Range
+		RequiredConfigs []string
+		AliasCount      int
+	}
+	providerReqSuggestions := make(map[string]*ProviderReqSuggestion)
 	for name, src := range emptyConfigs {
-		detail := fmt.Sprintf("Remove the %s provider block from %s.", name, cfg.Path)
-
-		isAlias := strings.Contains(name, ".")
-		_, isConfigAlias := configAliases[name]
-		_, isLocalName := localNames[name]
-
-		if isAlias && !isConfigAlias {
-			localName := strings.Split(name, ".")[0]
-			detail = fmt.Sprintf("Remove the %s provider block from %s. Add %s to the list of configuration_aliases for %s in required_providers to define the provider configuration name.", name, cfg.Path, name, localName)
+		providerLocalName := name
+		if idx := strings.IndexByte(providerLocalName, '.'); idx >= 0 {
+			providerLocalName = providerLocalName[:idx]
 		}
 
-		if !isAlias && !isLocalName {
-			// if there is no local name, add a note to include it in the
-			// required_provider block
-			detail += fmt.Sprintf("\nTo ensure the correct provider configuration is used, add %s to the required_providers configuration", name)
+		sourceAddr, ok := localNames[name]
+		if !ok {
+			sourceAddr = addrs.NewDefaultProvider(providerLocalName)
 		}
 
+		suggestion := providerReqSuggestions[providerLocalName]
+		if suggestion == nil {
+			providerReqSuggestions[providerLocalName] = &ProviderReqSuggestion{
+				SourceAddr: sourceAddr,
+			}
+			suggestion = providerReqSuggestions[providerLocalName]
+		}
+
+		if providerLocalName != name {
+			// It's an aliased provider config, then.
+			suggestion.AliasCount++
+		}
+
+		suggestion.RequiredConfigs = append(suggestion.RequiredConfigs, name)
+		suggestion.SourceRanges = append(suggestion.SourceRanges, src)
+	}
+	for name, suggestion := range providerReqSuggestions {
+		var buf strings.Builder
+
+		fmt.Fprintf(
+			&buf,
+			"Earlier versions of Terraform used empty provider blocks (\"proxy provider configurations\") for child modules to declare their need to be passed a provider configuration by their callers. That approach was ambiguous and is now deprecated.\n\nIf you control this module, you can migrate to the new declaration syntax by removing all of the empty provider %q blocks and then adding or updating an entry like the following to the required_providers block of %s:\n",
+			name, moduleText,
+		)
+		fmt.Fprintf(&buf, "    %s = {\n", name)
+		fmt.Fprintf(&buf, "      source = %q\n", suggestion.SourceAddr.ForDisplay())
+		if suggestion.AliasCount > 0 {
+			// A lexical sort is fine because all of these strings are
+			// guaranteed to start with the same provider local name, and
+			// so we're only really sorting by the alias part.
+			sort.Strings(suggestion.RequiredConfigs)
+			fmt.Fprintln(&buf, "      configuration_aliases = [")
+			for _, addrStr := range suggestion.RequiredConfigs {
+				fmt.Fprintf(&buf, "        %s,\n", addrStr)
+			}
+			fmt.Fprintln(&buf, "      ]")
+
+		}
+		fmt.Fprint(&buf, "    }")
+
+		// We're arbitrarily going to just take the one source range that
+		// sorts earliest here. Multiple should be rare, so this is only to
+		// ensure that we produce a deterministic result in the edge case.
+		sort.Slice(suggestion.SourceRanges, func(i, j int) bool {
+			return suggestion.SourceRanges[i].String() < suggestion.SourceRanges[j].String()
+		})
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagWarning,
-			Summary:  "Empty provider configuration blocks are not required",
-			Detail:   detail,
-			Subject:  src,
+			Summary:  "Redundant empty provider block",
+			Detail:   buf.String(),
+			Subject:  suggestion.SourceRanges[0].Ptr(),
 		})
 	}
 

--- a/terraform/configs/resource.go
+++ b/terraform/configs/resource.go
@@ -6,8 +6,11 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	hcljson "github.com/hashicorp/hcl/v2/json"
 
 	"github.com/terraform-linters/tflint/terraform/addrs"
+	"github.com/terraform-linters/tflint/terraform/lang"
+	"github.com/terraform-linters/tflint/terraform/tfdiags"
 )
 
 // Resource represents a "resource" or "data" block in a module or file.
@@ -22,7 +25,12 @@ type Resource struct {
 	ProviderConfigRef *ProviderConfigRef
 	Provider          addrs.Provider
 
+	Preconditions  []*CheckRule
+	Postconditions []*CheckRule
+
 	DependsOn []hcl.Traversal
+
+	TriggersReplacement []hcl.Expression
 
 	// Managed is populated only for Mode = addrs.ManagedResourceMode,
 	// containing the additional fields that apply to managed resources.
@@ -42,7 +50,6 @@ type ManagedResource struct {
 	PreventDestroy      bool
 	IgnoreChanges       []hcl.Traversal
 	IgnoreAllChanges    bool
-	ReplaceTriggeredBy  []hcl.Traversal
 
 	CreateBeforeDestroySet bool
 	PreventDestroySet      bool
@@ -82,7 +89,13 @@ func (r *Resource) ProviderConfigAddr() addrs.LocalProviderConfig {
 	}
 }
 
-func decodeResourceBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
+// HasCustomConditions returns true if and only if the resource has at least
+// one author-specified custom condition.
+func (r *Resource) HasCustomConditions() bool {
+	return len(r.Postconditions) != 0 || len(r.Preconditions) != 0
+}
+
+func decodeResourceBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	r := &Resource{
 		Mode:      addrs.ManagedResourceMode,
@@ -175,6 +188,13 @@ func decodeResourceBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
 				r.Managed.PreventDestroySet = true
 			}
 
+			if attr, exists := lcContent.Attributes["replace_triggered_by"]; exists {
+				exprs, hclDiags := decodeReplaceTriggeredBy(attr.Expr)
+				diags = diags.Extend(hclDiags)
+
+				r.TriggersReplacement = append(r.TriggersReplacement, exprs...)
+			}
+
 			if attr, exists := lcContent.Attributes["ignore_changes"]; exists {
 
 				// ignore_changes can either be a list of relative traversals
@@ -235,32 +255,27 @@ func decodeResourceBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
 					}
 
 				}
-
 			}
-			if attr, exists := lcContent.Attributes["replace_triggered_by"]; exists {
 
-				// ignore_changes can either be a list of relative traversals
-				// or it can be just the keyword "all" to ignore changes to this
-				// resource entirely.
-				//   ignore_changes = [ami, instance_type]
-				//   ignore_changes = all
-				// We also allow two legacy forms for compatibility with earlier
-				// versions:
-				//   ignore_changes = ["ami", "instance_type"]
-				//   ignore_changes = ["*"]
+			for _, block := range lcContent.Blocks {
+				switch block.Type {
+				case "precondition", "postcondition":
+					cr, moreDiags := decodeCheckRuleBlock(block, override)
+					diags = append(diags, moreDiags...)
 
-				exprs, listDiags := hcl.ExprList(attr.Expr)
-				diags = append(diags, listDiags...)
+					moreDiags = cr.validateSelfReferences(block.Type, r.Addr())
+					diags = append(diags, moreDiags...)
 
-				for _, expr := range exprs {
-					expr, shimDiags := shimTraversalInString(expr, false)
-					diags = append(diags, shimDiags...)
-
-					traversal, travDiags := hcl.RelTraversalForExpr(expr)
-					diags = append(diags, travDiags...)
-					if len(traversal) != 0 {
-						r.Managed.ReplaceTriggeredBy = append(r.Managed.ReplaceTriggeredBy, traversal)
+					switch block.Type {
+					case "precondition":
+						r.Preconditions = append(r.Preconditions, cr)
+					case "postcondition":
+						r.Postconditions = append(r.Postconditions, cr)
 					}
+				default:
+					// The cases above should be exhaustive for all block types
+					// defined in the lifecycle schema, so this shouldn't happen.
+					panic(fmt.Sprintf("unexpected lifecycle sub-block type %q", block.Type))
 				}
 			}
 
@@ -334,7 +349,7 @@ func decodeResourceBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
 	return r, diags
 }
 
-func decodeDataBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
+func decodeDataBlock(block *hcl.Block, override bool) (*Resource, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	r := &Resource{
 		Mode:      addrs.DataResourceMode,
@@ -395,6 +410,7 @@ func decodeDataBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
 	}
 
 	var seenEscapeBlock *hcl.Block
+	var seenLifecycle *hcl.Block
 	for _, block := range content.Blocks {
 		switch block.Type {
 
@@ -418,26 +434,177 @@ func decodeDataBlock(block *hcl.Block) (*Resource, hcl.Diagnostics) {
 			// will see a blend of both.
 			r.Config = hcl.MergeBodies([]hcl.Body{r.Config, block.Body})
 
-		// The rest of these are just here to reserve block type names for future use.
 		case "lifecycle":
-			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
-				Summary:  "Unsupported lifecycle block",
-				Detail:   "Data resources do not have lifecycle settings, so a lifecycle block is not allowed.",
-				Subject:  &block.DefRange,
-			})
+			if seenLifecycle != nil {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Duplicate lifecycle block",
+					Detail:   fmt.Sprintf("This resource already has a lifecycle block at %s.", seenLifecycle.DefRange),
+					Subject:  block.DefRange.Ptr(),
+				})
+				continue
+			}
+			seenLifecycle = block
+
+			lcContent, lcDiags := block.Body.Content(resourceLifecycleBlockSchema)
+			diags = append(diags, lcDiags...)
+
+			// All of the attributes defined for resource lifecycle are for
+			// managed resources only, so we can emit a common error message
+			// for any given attributes that HCL accepted.
+			for name, attr := range lcContent.Attributes {
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid data resource lifecycle argument",
+					Detail:   fmt.Sprintf("The lifecycle argument %q is defined only for managed resources (\"resource\" blocks), and is not valid for data resources.", name),
+					Subject:  attr.NameRange.Ptr(),
+				})
+			}
+
+			for _, block := range lcContent.Blocks {
+				switch block.Type {
+				case "precondition", "postcondition":
+					cr, moreDiags := decodeCheckRuleBlock(block, override)
+					diags = append(diags, moreDiags...)
+
+					moreDiags = cr.validateSelfReferences(block.Type, r.Addr())
+					diags = append(diags, moreDiags...)
+
+					switch block.Type {
+					case "precondition":
+						r.Preconditions = append(r.Preconditions, cr)
+					case "postcondition":
+						r.Postconditions = append(r.Postconditions, cr)
+					}
+				default:
+					// The cases above should be exhaustive for all block types
+					// defined in the lifecycle schema, so this shouldn't happen.
+					panic(fmt.Sprintf("unexpected lifecycle sub-block type %q", block.Type))
+				}
+			}
 
 		default:
+			// Any other block types are ones we're reserving for future use,
+			// but don't have any defined meaning today.
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
 				Summary:  "Reserved block type name in data block",
 				Detail:   fmt.Sprintf("The block type name %q is reserved for use by Terraform in a future version.", block.Type),
-				Subject:  &block.TypeRange,
+				Subject:  block.TypeRange.Ptr(),
 			})
 		}
 	}
 
 	return r, diags
+}
+
+// decodeReplaceTriggeredBy decodes and does basic validation of the
+// replace_triggered_by expressions, ensuring they only contains references to
+// a single resource, and the only extra variables are count.index or each.key.
+func decodeReplaceTriggeredBy(expr hcl.Expression) ([]hcl.Expression, hcl.Diagnostics) {
+	// Since we are manually parsing the replace_triggered_by argument, we
+	// need to specially handle json configs, in which case the values will
+	// be json strings rather than hcl. To simplify parsing however we will
+	// decode the individual list elements, rather than the entire expression.
+	isJSON := hcljson.IsJSONExpression(expr)
+
+	exprs, diags := hcl.ExprList(expr)
+
+	for i, expr := range exprs {
+		if isJSON {
+			// We can abuse the hcl json api and rely on the fact that calling
+			// Value on a json expression with no EvalContext will return the
+			// raw string. We can then parse that as normal hcl syntax, and
+			// continue with the decoding.
+			v, ds := expr.Value(nil)
+			diags = diags.Extend(ds)
+			if diags.HasErrors() {
+				continue
+			}
+
+			expr, ds = hclsyntax.ParseExpression([]byte(v.AsString()), "", expr.Range().Start)
+			diags = diags.Extend(ds)
+			if diags.HasErrors() {
+				continue
+			}
+			// make sure to swap out the expression we're returning too
+			exprs[i] = expr
+		}
+
+		refs, refDiags := lang.ReferencesInExpr(expr)
+		for _, diag := range refDiags {
+			severity := hcl.DiagError
+			if diag.Severity() == tfdiags.Warning {
+				severity = hcl.DiagWarning
+			}
+
+			desc := diag.Description()
+
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: severity,
+				Summary:  desc.Summary,
+				Detail:   desc.Detail,
+				Subject:  expr.Range().Ptr(),
+			})
+		}
+
+		if refDiags.HasErrors() {
+			continue
+		}
+
+		resourceCount := 0
+		for _, ref := range refs {
+			switch sub := ref.Subject.(type) {
+			case addrs.Resource, addrs.ResourceInstance:
+				resourceCount++
+
+			case addrs.ForEachAttr:
+				if sub.Name != "key" {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid each reference in replace_triggered_by expression",
+						Detail:   "Only each.key may be used in replace_triggered_by.",
+						Subject:  expr.Range().Ptr(),
+					})
+				}
+			case addrs.CountAttr:
+				if sub.Name != "index" {
+					diags = append(diags, &hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "Invalid count reference in replace_triggered_by expression",
+						Detail:   "Only count.index may be used in replace_triggered_by.",
+						Subject:  expr.Range().Ptr(),
+					})
+				}
+			default:
+				// everything else should be simple traversals
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Invalid reference in replace_triggered_by expression",
+					Detail:   "Only resources, count.index, and each.key may be used in replace_triggered_by.",
+					Subject:  expr.Range().Ptr(),
+				})
+			}
+		}
+
+		switch {
+		case resourceCount == 0:
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid replace_triggered_by expression",
+				Detail:   "Missing resource reference in replace_triggered_by expression.",
+				Subject:  expr.Range().Ptr(),
+			})
+		case resourceCount > 1:
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Invalid replace_triggered_by expression",
+				Detail:   "Multiple resource references in replace_triggered_by expression.",
+				Subject:  expr.Range().Ptr(),
+			})
+		}
+	}
+	return exprs, diags
 }
 
 type ProviderConfigRef struct {
@@ -578,13 +745,17 @@ var resourceBlockSchema = &hcl.BodySchema{
 var dataBlockSchema = &hcl.BodySchema{
 	Attributes: commonResourceAttributes,
 	Blocks: []hcl.BlockHeaderSchema{
-		{Type: "lifecycle"}, // reserved for future use
-		{Type: "locals"},    // reserved for future use
-		{Type: "_"},         // meta-argument escaping block
+		{Type: "lifecycle"},
+		{Type: "locals"}, // reserved for future use
+		{Type: "_"},      // meta-argument escaping block
 	},
 }
 
 var resourceLifecycleBlockSchema = &hcl.BodySchema{
+	// We tell HCL that these elements are all valid for both "resource"
+	// and "data" lifecycle blocks, but the rules are actually more restrictive
+	// than that. We deal with that after decoding so that we can return
+	// more specific error messages than HCL would typically return itself.
 	Attributes: []hcl.AttributeSchema{
 		{
 			Name: "create_before_destroy",
@@ -598,5 +769,9 @@ var resourceLifecycleBlockSchema = &hcl.BodySchema{
 		{
 			Name: "replace_triggered_by",
 		},
+	},
+	Blocks: []hcl.BlockHeaderSchema{
+		{Type: "precondition"},
+		{Type: "postcondition"},
 	},
 }

--- a/terraform/lang/funcs/cidr.go
+++ b/terraform/lang/funcs/cidr.go
@@ -60,6 +60,10 @@ var CidrNetmaskFunc = function.New(&function.Spec{
 			return cty.UnknownVal(cty.String), fmt.Errorf("invalid CIDR expression: %s", err)
 		}
 
+		if network.IP.To4() == nil {
+			return cty.UnknownVal(cty.String), fmt.Errorf("IPv6 addresses cannot have a netmask: %s", args[0].AsString())
+		}
+
 		return cty.StringVal(ipaddr.IP(network.Mask).String()), nil
 	},
 })

--- a/terraform/lang/funcs/collection.go
+++ b/terraform/lang/funcs/collection.go
@@ -311,8 +311,8 @@ var LookupFunc = function.New(&function.Spec{
 			return defaultVal.WithMarks(markses...), nil
 		}
 
-		return cty.UnknownVal(cty.DynamicPseudoType).WithMarks(markses...), fmt.Errorf(
-			"lookup failed to find '%s'", lookupKey)
+		return cty.UnknownVal(cty.DynamicPseudoType), fmt.Errorf(
+			"lookup failed to find key %s", redactIfSensitive(lookupKey, keyMarks))
 	},
 })
 
@@ -525,6 +525,10 @@ var SumFunc = function.New(&function.Spec{
 
 		s := arg[0]
 		if s.IsNull() {
+			return cty.NilVal, function.NewArgErrorf(0, "argument must be list, set, or tuple of number values")
+		}
+		s, err = convert.Convert(s, cty.Number)
+		if err != nil {
 			return cty.NilVal, function.NewArgErrorf(0, "argument must be list, set, or tuple of number values")
 		}
 		for _, v := range arg[1:] {

--- a/terraform/lang/funcs/conversion.go
+++ b/terraform/lang/funcs/conversion.go
@@ -1,12 +1,10 @@
 package funcs
 
 import (
-	"fmt"
-	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/terraform-linters/tflint/terraform/lang/marks"
+	"github.com/terraform-linters/tflint/terraform/lang/types"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 	"github.com/zclconf/go-cty/cty/function"
@@ -32,9 +30,10 @@ func MakeToFunc(wantTy cty.Type) function.Function {
 				// messages to be more appropriate for an explicit type
 				// conversion, whereas the cty function system produces
 				// messages aimed at _implicit_ type conversions.
-				Type:        cty.DynamicPseudoType,
-				AllowNull:   true,
-				AllowMarked: true,
+				Type:             cty.DynamicPseudoType,
+				AllowNull:        true,
+				AllowMarked:      true,
+				AllowDynamicType: true,
 			},
 		},
 		Type: func(args []cty.Value) (cty.Type, error) {
@@ -97,6 +96,9 @@ func MakeToFunc(wantTy cty.Type) function.Function {
 	})
 }
 
+// TypeFunc returns an encapsulated value containing its argument's type. This
+// value is marked to allow us to limit the use of this function at the moment
+// to only a few supported use cases.
 var TypeFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
 		{
@@ -107,116 +109,12 @@ var TypeFunc = function.New(&function.Spec{
 			AllowNull:        true,
 		},
 	},
-	Type: function.StaticReturnType(cty.String),
+	Type: function.StaticReturnType(types.TypeType),
 	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		return cty.StringVal(TypeString(args[0].Type())).Mark(marks.Raw), nil
+		givenType := args[0].Type()
+		return cty.CapsuleVal(types.TypeType, &givenType).Mark(marks.TypeType), nil
 	},
 })
-
-// Modified copy of TypeString from go-cty:
-// https://github.com/zclconf/go-cty-debug/blob/master/ctydebug/type_string.go
-//
-// TypeString returns a string representation of a given type that is
-// reminiscent of Go syntax calling into the cty package but is mainly
-// intended for easy human inspection of values in tests, debug output, etc.
-//
-// The resulting string will include newlines and indentation in order to
-// increase the readability of complex structures. It always ends with a
-// newline, so you can print this result directly to your output.
-func TypeString(ty cty.Type) string {
-	var b strings.Builder
-	writeType(ty, &b, 0)
-	return b.String()
-}
-
-func writeType(ty cty.Type, b *strings.Builder, indent int) {
-	switch {
-	case ty == cty.NilType:
-		b.WriteString("nil")
-		return
-	case ty.IsObjectType():
-		atys := ty.AttributeTypes()
-		if len(atys) == 0 {
-			b.WriteString("object({})")
-			return
-		}
-		attrNames := make([]string, 0, len(atys))
-		for name := range atys {
-			attrNames = append(attrNames, name)
-		}
-		sort.Strings(attrNames)
-		b.WriteString("object({\n")
-		indent++
-		for _, name := range attrNames {
-			aty := atys[name]
-			b.WriteString(indentSpaces(indent))
-			fmt.Fprintf(b, "%s: ", name)
-			writeType(aty, b, indent)
-			b.WriteString(",\n")
-		}
-		indent--
-		b.WriteString(indentSpaces(indent))
-		b.WriteString("})")
-	case ty.IsTupleType():
-		etys := ty.TupleElementTypes()
-		if len(etys) == 0 {
-			b.WriteString("tuple([])")
-			return
-		}
-		b.WriteString("tuple([\n")
-		indent++
-		for _, ety := range etys {
-			b.WriteString(indentSpaces(indent))
-			writeType(ety, b, indent)
-			b.WriteString(",\n")
-		}
-		indent--
-		b.WriteString(indentSpaces(indent))
-		b.WriteString("])")
-	case ty.IsCollectionType():
-		ety := ty.ElementType()
-		switch {
-		case ty.IsListType():
-			b.WriteString("list(")
-		case ty.IsMapType():
-			b.WriteString("map(")
-		case ty.IsSetType():
-			b.WriteString("set(")
-		default:
-			// At the time of writing there are no other collection types,
-			// but we'll be robust here and just pass through the GoString
-			// of anything we don't recognize.
-			b.WriteString(ty.FriendlyName())
-			return
-		}
-		// Because object and tuple types render split over multiple
-		// lines, a collection type container around them can end up
-		// being hard to see when scanning, so we'll generate some extra
-		// indentation to make a collection of structural type more visually
-		// distinct from the structural type alone.
-		complexElem := ety.IsObjectType() || ety.IsTupleType()
-		if complexElem {
-			indent++
-			b.WriteString("\n")
-			b.WriteString(indentSpaces(indent))
-		}
-		writeType(ty.ElementType(), b, indent)
-		if complexElem {
-			indent--
-			b.WriteString(",\n")
-			b.WriteString(indentSpaces(indent))
-		}
-		b.WriteString(")")
-	default:
-		// For any other type we'll just use its GoString and assume it'll
-		// follow the usual GoString conventions.
-		b.WriteString(ty.FriendlyName())
-	}
-}
-
-func indentSpaces(level int) string {
-	return strings.Repeat("    ", level)
-}
 
 func Type(input []cty.Value) (cty.Value, error) {
 	return TypeFunc.Call(input)

--- a/terraform/lang/funcs/redact.go
+++ b/terraform/lang/funcs/redact.go
@@ -1,0 +1,20 @@
+package funcs
+
+import (
+	"fmt"
+
+	"github.com/terraform-linters/tflint/terraform/lang/marks"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func redactIfSensitive(value interface{}, markses ...cty.ValueMarks) string {
+	if marks.Has(cty.DynamicVal.WithMarks(markses...), marks.Sensitive) {
+		return "(sensitive value)"
+	}
+	switch v := value.(type) {
+	case string:
+		return fmt.Sprintf("%q", v)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}

--- a/terraform/lang/marks/marks.go
+++ b/terraform/lang/marks/marks.go
@@ -1,18 +1,16 @@
 package marks
 
 import (
-	"strings"
-
 	"github.com/zclconf/go-cty/cty"
 )
 
 // valueMarks allow creating strictly typed values for use as cty.Value marks.
-// The variable name for new values should be the title-cased format of the
-// value to better match the GoString output for debugging.
+// Each distinct mark value must be a constant in this package whose value
+// is a valueMark whose underlying string matches the name of the variable.
 type valueMark string
 
 func (m valueMark) GoString() string {
-	return "marks." + strings.Title(string(m))
+	return "marks." + string(m)
 }
 
 // Has returns true if and only if the cty.Value has the given mark.
@@ -36,8 +34,9 @@ func Contains(val cty.Value, mark valueMark) bool {
 
 // Sensitive indicates that this value is marked as sensitive in the context of
 // Terraform.
-var Sensitive = valueMark("sensitive")
+const Sensitive = valueMark("Sensitive")
 
-// Raw is used to indicate to the repl that the value should be written without
-// any formatting.
-var Raw = valueMark("raw")
+// TypeType is used to indicate that the value contains a representation of
+// another value's type. This is part of the implementation of the console-only
+// `type` function.
+const TypeType = valueMark("TypeType")

--- a/terraform/lang/types/type_type.go
+++ b/terraform/lang/types/type_type.go
@@ -1,0 +1,12 @@
+package types
+
+import (
+	"reflect"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+// TypeType is a capsule type used to represent a cty.Type as a cty.Value. This
+// is used by the `type()` console function to smuggle cty.Type values to the
+// REPL session, where it can be displayed to the user directly.
+var TypeType = cty.Capsule("type", reflect.TypeOf(cty.Type{}))

--- a/terraform/lang/types/types.go
+++ b/terraform/lang/types/types.go
@@ -1,0 +1,2 @@
+// Package types contains non-standard cty types used only within Terraform.
+package types

--- a/terraform/tfdiags/diagnostic.go
+++ b/terraform/tfdiags/diagnostic.go
@@ -1,6 +1,8 @@
 package tfdiags
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/hcl/v2"
 )
 
@@ -23,6 +25,20 @@ const (
 	Error   Severity = 'E'
 	Warning Severity = 'W'
 )
+
+// ToHCL converts a Severity to the equivalent HCL diagnostic severity.
+func (s Severity) ToHCL() hcl.DiagnosticSeverity {
+	switch s {
+	case Warning:
+		return hcl.DiagWarning
+	case Error:
+		return hcl.DiagError
+	default:
+		// The above should always be exhaustive for all of the valid
+		// Severity values in this package.
+		panic(fmt.Sprintf("unknown diagnostic severity %s", s))
+	}
+}
 
 type Description struct {
 	Address string

--- a/terraform/tfdiags/hcl.go
+++ b/terraform/tfdiags/hcl.go
@@ -1,8 +1,6 @@
 package tfdiags
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/hcl/v2"
 )
 
@@ -110,19 +108,9 @@ func (diags Diagnostics) ToHCL() hcl.Diagnostics {
 		fromExpr := diag.FromExpr()
 
 		hclDiag := &hcl.Diagnostic{
-			Summary: desc.Summary,
-			Detail:  desc.Detail,
-		}
-
-		switch severity {
-		case Warning:
-			hclDiag.Severity = hcl.DiagWarning
-		case Error:
-			hclDiag.Severity = hcl.DiagError
-		default:
-			// The above should always be exhaustive for all of the valid
-			// Severity values in this package.
-			panic(fmt.Sprintf("unknown diagnostic severity %s", severity))
+			Summary:  desc.Summary,
+			Detail:   desc.Detail,
+			Severity: severity.ToHCL(),
 		}
 		if source.Subject != nil {
 			hclDiag.Subject = source.Subject.ToHCL().Ptr()

--- a/terraform/version/version.go
+++ b/terraform/version/version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // The main version number that is being run at the moment.
-var Version = "1.1.0"
+var Version = "1.2.1"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -544,7 +544,7 @@ func prepareVariableValues(config *configs.Config, cliVars ...terraform.InputVal
 		}
 	}
 
-	variables := terraform.DefaultVariableValues(configVars)
+	variables := DefaultVariableValues(configVars)
 	envVars, diags := getTFEnvVariables(configVars)
 	if diags.HasErrors() {
 		return variableValues, diags


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1388
See also https://github.com/hashicorp/terraform/releases/tag/v1.2.0 https://github.com/hashicorp/terraform/releases/tag/v1.2.1

This PR updates the bundled Terraform's internal packages version to v1.2.1 from v1.1.
This will allow you to use the new keywords such as `precondition`, `postcondition`, and `replace_triggered_by` added in v1.2.

Most of these changes were completed by simply copying the Terraform package, but it's worth noting that `terraform.DefaultVariableValues` has been removed in [this commit](https://github.com/hashicorp/terraform/commit/36c4d4c241b3402d7fbf677e4e7850f6ab80e66f).

However, if you look at the history of the change, it looks like it was removed when the Terraform core team removed the redundant variable merge logic, so this function itself is not a problem. So, we have moved this function under the tflint package and referenced it. There are no changes to the implementation.