### PR TITLE
feat: added support for codeclimate output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,26 +115,26 @@ Usage:
   tflint [OPTIONS] [FILE or DIR...]
 
 Application Options:
-  -v, --version                                                 Print TFLint version
-      --init                                                    Install plugins
-      --langserver                                              Start language server
-  -f, --format=[default|json|checkstyle|junit|compact|sarif]    Output format
-  -c, --config=FILE                                             Config file name (default: .tflint.hcl)
-      --ignore-module=SOURCE                                    Ignore module sources
-      --enable-rule=RULE_NAME                                   Enable rules from the command line
-      --disable-rule=RULE_NAME                                  Disable rules from the command line
-      --only=RULE_NAME                                          Enable only this rule, disabling all other defaults. Can be specified multiple times
-      --enable-plugin=PLUGIN_NAME                               Enable plugins from the command line
-      --var-file=FILE                                           Terraform variable file name
-      --var='foo=bar'                                           Set a Terraform variable
-      --module                                                  Inspect modules
-      --force                                                   Return zero exit status even if issues found
-      --color                                                   Enable colorized output
-      --no-color                                                Disable colorized output
-      --loglevel=[trace|debug|info|warn|error]                  Change the loglevel
+  -v, --version                                                             Print TFLint version
+      --init                                                                Install plugins
+      --langserver                                                          Start language server
+  -f, --format=[default|json|checkstyle|junit|compact|sarif|codeclimate]    Output format
+  -c, --config=FILE                                                         Config file name (default: .tflint.hcl)
+      --ignore-module=SOURCE                                                Ignore module sources
+      --enable-rule=RULE_NAME                                               Enable rules from the command line
+      --disable-rule=RULE_NAME                                              Disable rules from the command line
+      --only=RULE_NAME                                                      Enable only this rule, disabling all other defaults. Can be specified multiple times
+      --enable-plugin=PLUGIN_NAME                                           Enable plugins from the command line
+      --var-file=FILE                                                       Terraform variable file name
+      --var='foo=bar'                                                       Set a Terraform variable
+      --module                                                              Inspect modules
+      --force                                                               Return zero exit status even if issues found
+      --color                                                               Enable colorized output
+      --no-color                                                            Disable colorized output
+      --loglevel=[trace|debug|info|warn|error]                              Change the loglevel
 
 Help Options:
-  -h, --help                                                    Show this help message
+  -h, --help                                                                Show this help message
 
 ```
 

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -12,7 +12,7 @@ type Options struct {
 	Version       bool     `short:"v" long:"version" description:"Print TFLint version"`
 	Init          bool     `long:"init" description:"Install plugins"`
 	Langserver    bool     `long:"langserver" description:"Start language server"`
-	Format        string   `short:"f" long:"format" description:"Output format" choice:"default" choice:"json" choice:"checkstyle" choice:"junit" choice:"compact" choice:"sarif"`
+	Format        string   `short:"f" long:"format" description:"Output format" choice:"default" choice:"json" choice:"checkstyle" choice:"junit" choice:"compact" choice:"sarif" choice:"codeclimate"`
 	Config        string   `short:"c" long:"config" description:"Config file name" value-name:"FILE" default:".tflint.hcl"`
 	IgnoreModules []string `long:"ignore-module" description:"Ignore module sources" value-name:"SOURCE"`
 	EnableRules   []string `long:"enable-rule" description:"Enable rules from the command line" value-name:"RULE_NAME"`

--- a/formatter/codeclimate.go
+++ b/formatter/codeclimate.go
@@ -1,0 +1,167 @@
+package formatter
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+// CodeClimateIssue is a temporary structure for converting TFLint issues to CodeClimate report format.
+// See specs here: https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types
+// We're only mapping the types for which we have data and the required ones
+type CodeClimateIssue struct {
+	Type           string                `json:"type"`
+	CheckName      string                `json:"check_name"`
+	Description    string                `json:"description"`
+	Content        string                `json:"content,omitempty"`
+	Categories     []string              `json:"categories"`
+	Location       CodeClimateLocation   `json:"location"`
+	OtherLocations []CodeClimateLocation `json:"other_locations,omitempty"`
+	Fingerprint    string                `json:"fingerprint"`
+	Severity       string                `json:"severity,omitempty"`
+}
+
+type CodeClimateLocation struct {
+	Path      string               `json:"path"`
+	Positions CodeClimatePositions `json:"positions"`
+}
+
+type CodeClimatePositions struct {
+	Begin CodeClimatePosition `json:"begin"`
+	End   CodeClimatePosition `json:"end,omitempty"`
+}
+
+type CodeClimatePosition struct {
+	Line   int `json:"line"`
+	Column int `json:"column,omitempty"`
+}
+
+// Downloads the provided link and returns it as a string
+func downloadLinkContent(link string) string {
+	resp, err := http.Get(link)
+
+	// We don't care about the error as there's no way to recover from it.
+	// In case of errors we just return an empty string
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	// No errors mean that we can go on and extract the text data
+	defer resp.Body.Close()
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, resp.Body)
+
+	// Again, we don't deal with errors
+	if err != nil {
+		return ""
+	}
+
+	// If everything went fine we can return the buffered string's contents
+	return buf.String()
+}
+
+func getMD5Hash(text string) string {
+	hasher := md5.New()
+	hasher.Write([]byte(text))
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+// Map TFLint severities with the ones expected by Code Climate
+func toCodeClimateSeverity(tfSeverity string) string {
+	switch tfSeverity {
+	case "error":
+		return "critical"
+	case "warning":
+		return "minor"
+	case "info":
+		return "info"
+	default:
+		panic(fmt.Errorf("Unexpected severity type: %s", tfSeverity))
+	}
+}
+
+func (f *Formatter) codeClimatePrint(issues tflint.Issues, appErr error) {
+	ret := make([]CodeClimateIssue, len(issues))
+
+	for idx, issue := range issues.Sort() {
+		ret[idx] = CodeClimateIssue{
+			Type:        "issue",
+			CheckName:   issue.Rule.Name(),
+			Description: issue.Message,
+			Content:     downloadLinkContent(issue.Rule.Link()),
+			Categories:  []string{"Style"},
+			Location: CodeClimateLocation{
+				Path: issue.Range.Filename,
+				Positions: CodeClimatePositions{
+					Begin: CodeClimatePosition{Line: issue.Range.Start.Line, Column: issue.Range.Start.Column},
+					End:   CodeClimatePosition{Line: issue.Range.End.Line, Column: issue.Range.End.Column},
+				},
+			},
+			OtherLocations: make([]CodeClimateLocation, len(issue.Callers)),
+			Severity:       toCodeClimateSeverity(toSeverity(issue.Rule.Severity())),
+			Fingerprint:    getMD5Hash(issue.Range.Filename + issue.Rule.Name() + issue.Message),
+		}
+		for i, caller := range issue.Callers {
+			ret[idx].OtherLocations[i] = CodeClimateLocation{
+				Path: caller.Filename,
+				Positions: CodeClimatePositions{
+					Begin: CodeClimatePosition{Line: caller.Start.Line, Column: caller.Start.Column},
+					End:   CodeClimatePosition{Line: caller.End.Line, Column: caller.End.Column},
+				},
+			}
+		}
+	}
+
+	if appErr != nil {
+		var diags hcl.Diagnostics
+		var codeClimateErrors []CodeClimateIssue
+		if errors.As(appErr, &diags) {
+			codeClimateErrors = make([]CodeClimateIssue, len(diags))
+			for idx, diag := range diags {
+				codeClimateErrors[idx] = CodeClimateIssue{
+					Type:        "issue",
+					CheckName:   "TFLint Error",
+					Description: diag.Detail,
+					Content:     diag.Summary,
+					Categories:  []string{"Bug Risk"},
+					Severity:    toCodeClimateSeverity(fromHclSeverity(diag.Severity)),
+					Fingerprint: getMD5Hash(diag.Subject.Filename + diag.Detail),
+					Location: CodeClimateLocation{
+						Path: diag.Subject.Filename,
+						Positions: CodeClimatePositions{
+							Begin: CodeClimatePosition{Line: diag.Subject.Start.Line, Column: diag.Subject.Start.Column},
+							End:   CodeClimatePosition{Line: diag.Subject.End.Line, Column: diag.Subject.End.Column},
+						},
+					},
+				}
+			}
+		} else {
+			codeClimateErrors = []CodeClimateIssue{{
+				Type:        "issue",
+				CheckName:   "TFLint Error",
+				Description: appErr.Error(),
+				Categories:  []string{"Bug Risk"},
+				Severity:    toCodeClimateSeverity(toSeverity(tflint.ERROR)),
+				Fingerprint: getMD5Hash(appErr.Error()),
+				Location:    CodeClimateLocation{},
+			}}
+		}
+
+		// Merge errors and issues
+		ret = append(ret, codeClimateErrors...)
+	}
+
+	out, err := json.Marshal(ret)
+	if err != nil {
+		fmt.Fprint(f.Stderr, err)
+	}
+	fmt.Fprint(f.Stdout, string(out))
+}

--- a/formatter/codeclimate_test.go
+++ b/formatter/codeclimate_test.go
@@ -1,0 +1,62 @@
+package formatter
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_codeClimatePrint(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Issues tflint.Issues
+		Error  error
+		Stdout string
+	}{
+		{
+			Name:   "no issues",
+			Issues: tflint.Issues{},
+			Stdout: `[]`,
+		},
+		{
+			Name:   "error",
+			Error:  fmt.Errorf("Failed to work; %w", errors.New("I don't feel like working")),
+			Stdout: `[{"type":"issue","check_name":"TFLint Error","description":"Failed to work; I don't feel like working","categories":["Bug Risk"],"location":{"path":"","positions":{"begin":{"line":0},"end":{"line":0}}},"fingerprint":"57394bce0549274282f603462359aad7","severity":"critical"}]`,
+		},
+		{
+			Name: "error",
+			Error: fmt.Errorf(
+				"babel fish confused; %w",
+				hcl.Diagnostics{
+					&hcl.Diagnostic{
+						Severity: hcl.DiagWarning,
+						Summary:  "summary",
+						Detail:   "detail",
+						Subject: &hcl.Range{
+							Filename: "filename",
+							Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+							End:      hcl.Pos{Line: 5, Column: 1, Byte: 4},
+						},
+					},
+				},
+			),
+			Stdout: `[{"type":"issue","check_name":"TFLint Error","description":"detail","content":"summary","categories":["Bug Risk"],"location":{"path":"filename","positions":{"begin":{"line":1,"column":1},"end":{"line":5,"column":1}}},"fingerprint":"33c423ea5450bd2d6209c131fad9398d","severity":"minor"}]`,
+		},
+	}
+
+	for _, tc := range cases {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		formatter := &Formatter{Stdout: stdout, Stderr: stderr, Format: "codeclimate"}
+
+		formatter.Print(tc.Issues, tc.Error, map[string][]byte{})
+
+		if stdout.String() != tc.Stdout {
+			t.Fatalf("Failed %s test: expected=%s, stdout=%s", tc.Name, tc.Stdout, stdout.String())
+		}
+	}
+}

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -31,6 +31,8 @@ func (f *Formatter) Print(issues tflint.Issues, err error, sources map[string][]
 		f.compactPrint(issues, err, sources)
 	case "sarif":
 		f.sarifPrint(issues, err)
+	case "codeclimate":
+		f.codeClimatePrint(issues, err)
 	default:
 		f.prettyPrint(issues, err, sources)
 	}

--- a/integrationtest/inspection/codeclimatesyntax/.tflint.hcl
+++ b/integrationtest/inspection/codeclimatesyntax/.tflint.hcl
@@ -1,0 +1,3 @@
+plugin "testing" {
+  enabled = true
+}

--- a/integrationtest/inspection/codeclimatesyntax/result.json
+++ b/integrationtest/inspection/codeclimatesyntax/result.json
@@ -1,0 +1,25 @@
+[
+  {
+    "type": "issue",
+    "check_name": "aws_instance_example_type",
+    "description": "instance type is t1.xmicro",
+    "categories": [
+      "Style"
+    ],
+    "location": {
+      "path": "template.tf.json",
+      "positions": {
+        "begin": {
+          "line": 5,
+          "column": 26
+        },
+        "end": {
+          "line": 5,
+          "column": 37
+        }
+      }
+    },
+    "fingerprint": "7850528045e0ba17c9d68992f3352abd",
+    "severity": "critical"
+  }
+]

--- a/integrationtest/inspection/codeclimatesyntax/template.tf.json
+++ b/integrationtest/inspection/codeclimatesyntax/template.tf.json
@@ -1,0 +1,10 @@
+{
+  "resource": {
+    "aws_instance": {
+      "example": {
+        "instance_type": "t1.xmicro",
+        "ami": "${join(\"\", [\"ami-123456\"])}"
+      }
+    }
+  }
+}

--- a/integrationtest/inspection/inspection_test.go
+++ b/integrationtest/inspection/inspection_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -71,6 +72,11 @@ func TestIntegration(t *testing.T) {
 			Name:    "jsonsyntax",
 			Command: "./tflint --format json",
 			Dir:     "jsonsyntax",
+		},
+		{
+			Name:    "codeclimatesyntax",
+			Command: "./tflint --format codeclimate",
+			Dir:     "codeclimatesyntax",
 		},
 		{
 			Name:    "path",
@@ -191,12 +197,21 @@ func TestIntegration(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			var expected *formatter.JSONOutput
+			// JSON is not the only testable format so we should be able to unmarshal into other formats as well
+			var expected interface{}
+			var got interface{}
+			if tc.Dir == "codeclimatesyntax" {
+				expected = reflect.Zero(reflect.TypeOf(make([]formatter.CodeClimateIssue, 0))).Interface()
+				got = reflect.Zero(reflect.TypeOf(make([]formatter.CodeClimateIssue, 0))).Interface()
+			} else {
+				expected = reflect.Zero(reflect.TypeOf(formatter.JSONOutput{})).Interface()
+				got = reflect.Zero(reflect.TypeOf(formatter.JSONOutput{})).Interface()
+			}
+
 			if err := json.Unmarshal(b, &expected); err != nil {
 				t.Fatal(err)
 			}
 
-			var got *formatter.JSONOutput
 			if err := json.Unmarshal(outStream.Bytes(), &got); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This is mostly meant to be used in GitLab CI as a way to provide a code quality report from TFLint.

As of today, getting a code quality report requires building a Docker image that adds `jq` to `tflint` and to manually manipulate the provided json output to match the expected format.

EDIT: as a side not, I'm not a Go expert so please provide feedback on what can be improved.