### PR TITLE
formatter(junit): use standard range string in failure message

### DIFF
--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -8,6 +8,8 @@ import (
 	"github.com/terraform-linters/tflint/tflint"
 )
 
+// https://www.ibm.com/docs/en/developer-for-zos/14.1.0?topic=formats-junit-xml-format
+
 func (f *Formatter) junitPrint(issues tflint.Issues, appErr error, sources map[string][]byte) {
 	cases := make([]formatter.JUnitTestCase, len(issues))
 

--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -17,14 +17,14 @@ func (f *Formatter) junitPrint(issues tflint.Issues, appErr error, sources map[s
 			Classname: issue.Range.Filename,
 			Time:      "0",
 			Failure: &formatter.JUnitFailure{
-				Message: issue.Message,
+				Message: fmt.Sprintf("%s: %s", issue.Range, issue.Message),
+				Type:    issue.Rule.Severity().String(),
 				Contents: fmt.Sprintf(
-					"line %d, col %d, %s - %s (%s)",
-					issue.Range.Start.Line,
-					issue.Range.Start.Column,
+					"%s: %s\nRule: %s\nRange: %s",
 					issue.Rule.Severity(),
 					issue.Message,
 					issue.Rule.Name(),
+					issue.Range,
 				),
 			},
 		}

--- a/formatter/junit_test.go
+++ b/formatter/junit_test.go
@@ -31,7 +31,7 @@ func Test_junitPrint(t *testing.T) {
 			Issues: tflint.Issues{
 				{
 					Rule:    &testRule{},
-					Message: "test",
+					Message: "issue message",
 					Range: hcl.Range{
 						Filename: "test.tf",
 						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
@@ -44,7 +44,7 @@ func Test_junitPrint(t *testing.T) {
   <testsuite tests="1" failures="1" time="0" name="">
     <properties></properties>
     <testcase classname="test.tf" name="test_rule" time="0">
-      <failure message="test" type="">line 1, col 1, Error - test (test_rule)</failure>
+      <failure message="test.tf:1,1-4: issue message" type="Error">Error: issue message&#xA;Rule: test_rule&#xA;Range: test.tf:1,1-4</failure>
     </testcase>
   </testsuite>
 </testsuites>`,


### PR DESCRIPTION
https://www.ibm.com/docs/en/developer-for-zos/14.1.0?topic=formats-junit-xml-format

A JUnit `<failure>`'s text should contain:

- The text of the rule and the severity.
- The analysis provider and the analysis category.
- The source code file.
- The line number

The filename is currently missing. Additionally, `type` should also be set to the severity.