### PR TITLE
tflint: Skip evaluation of module arguments if the module call is not evaluated

### DIFF
--- a/tflint/runner_eval_test.go
+++ b/tflint/runner_eval_test.go
@@ -796,7 +796,7 @@ resource "null_resource" "test" {
 	}
 }
 
-func Test_willEvaluateResource(t *testing.T) {
+func Test_isEvaluableResource(t *testing.T) {
 	cases := []struct {
 		Name     string
 		Content  string

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -140,6 +140,31 @@ func Test_NewModuleRunners_nestedModules(t *testing.T) {
 	})
 }
 
+func Test_NewModuleRunners_withZeroCount(t *testing.T) {
+	withinFixtureDir(t, "module_with_count_for_each", func() {
+		runner := testRunnerWithOsFs(t, moduleConfig())
+
+		runners, err := NewModuleRunners(runner)
+		if err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		if len(runners) != 2 {
+			t.Fatalf("This function must return 2 runners, but returned %d", len(runners))
+		}
+
+		moduleNames := make([]string, 2)
+		for idx, r := range runners {
+			moduleNames[idx] = r.TFConfig.Path.String()
+		}
+		expected := []string{"module.count_is_one", "module.for_each_is_not_empty"}
+		less := func(a, b string) bool { return a < b }
+		if diff := cmp.Diff(moduleNames, expected, cmpopts.SortSlices(less)); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}
+
 func Test_NewModuleRunners_modVars(t *testing.T) {
 	withinFixtureDir(t, "nested_module_vars", func() {
 		runner := testRunnerWithOsFs(t, moduleConfig())

--- a/tflint/test-fixtures/module_with_count_for_each/.terraform/modules/modules.json
+++ b/tflint/test-fixtures/module_with_count_for_each/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"count_is_zero","Source":"./module","Dir":"module"},{"Key":"for_each_is_empty","Source":"./module","Dir":"module"},{"Key":"count_is_one","Source":"./module","Dir":"module"},{"Key":"for_each_is_not_empty","Source":"./module","Dir":"module"}]}

--- a/tflint/test-fixtures/module_with_count_for_each/module.tf
+++ b/tflint/test-fixtures/module_with_count_for_each/module.tf
@@ -1,0 +1,42 @@
+variable "config" {
+  type = object({ instance_type = string })
+  default = null
+}
+
+module "count_is_zero" {
+  source = "./module"
+  count = var.config != null ? 1 : 0
+
+  instance_type = var.config.instance_type
+}
+
+module "count_is_one" {
+  source = "./module"
+  count = var.config != null ? 0 : 1
+
+  instance_type = "t2.micro"
+}
+
+variable "instance_types" {
+  type = list(string)
+  default = []
+}
+
+module "for_each_is_empty" {
+  source = "./module"
+  for_each = var.instance_types
+
+  instance_type = each.value
+}
+
+variable "instance_types_with_default" {
+  type = list(string)
+  default = ["t2.micro"]
+}
+
+module "for_each_is_not_empty" {
+  source = "./module"
+  for_each = var.instance_types_with_default
+
+  instance_type = each.value
+}

--- a/tflint/test-fixtures/module_with_count_for_each/module/main.tf
+++ b/tflint/test-fixtures/module_with_count_for_each/module/main.tf
@@ -1,0 +1,6 @@
+variable "instance_type" {}
+
+resource "aws_instance" "foo" {
+  ami = "ami-12345678"
+  instance_type = var.instance_type
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1395

In Terraform, if `count = 0` or `for_each = []`, the module is not evaluated and the module arguments are also not evaluated. So, the following configuration is valid:

```hcl
variable "foo" {
  type = object({ attr = string })
  default = null
}

module "bar" {
  source = "./baz"
  count = 0

  argument = var.foo.attr
}
```

However, TFLint ignores the module's meta-arguments, so in this case `var.foo.attr` was evaluated and an error occurred.

```
Failed to prepare rule checking; failed to eval an expression in module.tf:10; Attempt to get attribute from null value: This value is null, so it does not have any attributes.
```

This PR makes the evaluation of modules aware of the meta-arguments. In the above example, `var.foo.attr` is not evaluated.