### PR TITLE
cmd: Lookup issues by normalized path

### DIFF
--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -414,7 +414,7 @@ func (r *Runner) LookupIssues(files ...string) Issues {
 	issues := Issues{}
 	for _, issue := range r.Issues {
 		for _, file := range files {
-			if file == issue.Range.Filename {
+			if filepath.Clean(file) == filepath.Clean(issue.Range.Filename) {
 				issues = append(issues, issue)
 			}
 		}

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -1025,40 +1025,81 @@ func Test_RunnerFiles(t *testing.T) {
 }
 
 func Test_LookupIssues(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		issues   Issues
+		expected Issues
+	}{
+		{
+			name: "multiple files",
+			in:   "template.tf",
+			issues: Issues{
+				{
+					Rule:    &testRule{},
+					Message: "This is test rule",
+					Range: hcl.Range{
+						Filename: "template.tf",
+						Start:    hcl.Pos{Line: 1},
+					},
+				},
+				{
+					Rule:    &testRule{},
+					Message: "This is test rule",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 1},
+					},
+				},
+			},
+			expected: Issues{
+				{
+					Rule:    &testRule{},
+					Message: "This is test rule",
+					Range: hcl.Range{
+						Filename: "template.tf",
+						Start:    hcl.Pos{Line: 1},
+					},
+				},
+			},
+		},
+		{
+			name: "path normalization",
+			in:   "./template.tf",
+			issues: Issues{
+				{
+					Rule:    &testRule{},
+					Message: "This is test rule",
+					Range: hcl.Range{
+						Filename: "template.tf",
+						Start:    hcl.Pos{Line: 1},
+					},
+				},
+			},
+			expected: Issues{
+				{
+					Rule:    &testRule{},
+					Message: "This is test rule",
+					Range: hcl.Range{
+						Filename: "template.tf",
+						Start:    hcl.Pos{Line: 1},
+					},
+				},
+			},
+		},
+	}
+
 	runner := TestRunner(t, map[string]string{})
-	runner.Issues = Issues{
-		{
-			Rule:    &testRule{},
-			Message: "This is test rule",
-			Range: hcl.Range{
-				Filename: "template.tf",
-				Start:    hcl.Pos{Line: 1},
-			},
-		},
-		{
-			Rule:    &testRule{},
-			Message: "This is test rule",
-			Range: hcl.Range{
-				Filename: "resource.tf",
-				Start:    hcl.Pos{Line: 1},
-			},
-		},
-	}
 
-	ret := runner.LookupIssues("template.tf")
-	expected := Issues{
-		{
-			Rule:    &testRule{},
-			Message: "This is test rule",
-			Range: hcl.Range{
-				Filename: "template.tf",
-				Start:    hcl.Pos{Line: 1},
-			},
-		},
-	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runner.Issues = test.issues
 
-	if !cmp.Equal(expected, ret) {
-		t.Fatalf("Failed test: diff: %s", cmp.Diff(expected, ret))
+			got := runner.LookupIssues(test.in)
+			if diff := cmp.Diff(test.expected, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1412

If you pass a file path, TFLint will only report issues that match the passed file path from the inspection results for that directory. However, the file path is not normalized, so `./main.tf` and `main.tf` are treated as separate files.

```console
$ tflint main.tf
1 issue(s) found:

Warning: Interpolation-only expressions are deprecated in Terraform v0.12.14 (terraform_deprecated_interpolation)

  on main.tf line 4:
   4:   instance_type = "${var.foo}"

Reference: https://github.com/terraform-linters/tflint/blob/v0.37.0/docs/rules/terraform_deprecated_interpolation.md
```

```console
$ tflint ./main.tf
# No issues found
```

This PR fixes this problem by looking up the issues by a normalized path.