### PR TITLE
`terraform_empty_list_equality`: improve expression detection

### DIFF
--- a/rules/terraformrules/terraform_empty_list_equality.go
+++ b/rules/terraformrules/terraform_empty_list_equality.go
@@ -58,17 +58,17 @@ func (r *TerraformEmptyListEqualityRule) checkEmptyList(runner *tflint.Runner) e
 	return runner.WalkExpressions(func(expr hcl.Expression) error {
 		if binaryOpExpr, ok := expr.(*hclsyntax.BinaryOpExpr); ok && binaryOpExpr.Op.Type == cty.Bool {
 			if tupleConsExpr, ok := binaryOpExpr.LHS.(*hclsyntax.TupleConsExpr); ok && len(tupleConsExpr.Exprs) == 0 {
-				r.emitEmptyListEqualityIssue(binaryOpExpr.Range(), runner)
+				r.emitIssue(binaryOpExpr.Range(), runner)
 			} else if tupleConsExpr, ok := binaryOpExpr.RHS.(*hclsyntax.TupleConsExpr); ok && len(tupleConsExpr.Exprs) == 0 {
-				r.emitEmptyListEqualityIssue(binaryOpExpr.Range(), runner)
+				r.emitIssue(binaryOpExpr.Range(), runner)
 			}
 		}
 		return nil
 	})
 }
 
-// emitEmptyListEqualityIssue emits issue for comparison with static empty list
-func (r *TerraformEmptyListEqualityRule) emitEmptyListEqualityIssue(exprRange hcl.Range, runner *tflint.Runner) {
+// emitIssue emits issue for comparison with static empty list
+func (r *TerraformEmptyListEqualityRule) emitIssue(exprRange hcl.Range, runner *tflint.Runner) {
 	runner.EmitIssue(
 		r,
 		"Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",

--- a/rules/terraformrules/terraform_empty_list_equality.go
+++ b/rules/terraformrules/terraform_empty_list_equality.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/terraform-linters/tflint/tflint"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // TerraformEmptyListEqualityRule checks whether is there a comparison with an empty list
@@ -55,40 +56,22 @@ func (r *TerraformEmptyListEqualityRule) Check(runner *tflint.Runner) error {
 // checkEmptyList visits all blocks that can contain expressions and checks for comparisons with static empty list
 func (r *TerraformEmptyListEqualityRule) checkEmptyList(runner *tflint.Runner) error {
 	return runner.WalkExpressions(func(expr hcl.Expression) error {
-		if conditionalExpr, ok := expr.(*hclsyntax.ConditionalExpr); ok {
-			var issuesRangeSet = make(map[hcl.Range]struct{})
-			r.searchEmptyList(conditionalExpr.Condition, runner, conditionalExpr.Range(), issuesRangeSet)
-			r.emitEmptyListEqualityIssues(issuesRangeSet, runner)
+		if binaryOpExpr, ok := expr.(*hclsyntax.BinaryOpExpr); ok && binaryOpExpr.Op.Type == cty.Bool {
+			if tupleConsExpr, ok := binaryOpExpr.LHS.(*hclsyntax.TupleConsExpr); ok && len(tupleConsExpr.Exprs) == 0 {
+				r.emitEmptyListEqualityIssue(binaryOpExpr.Range(), runner)
+			} else if tupleConsExpr, ok := binaryOpExpr.RHS.(*hclsyntax.TupleConsExpr); ok && len(tupleConsExpr.Exprs) == 0 {
+				r.emitEmptyListEqualityIssue(binaryOpExpr.Range(), runner)
+			}
 		}
 		return nil
 	})
 }
 
-// searchEmptyList Searches for comparisons with static empty list in the given expression
-func (r *TerraformEmptyListEqualityRule) searchEmptyList(expr hcl.Expression, runner *tflint.Runner, exprRange hcl.Range, issuesRangeSet map[hcl.Range]struct{}) {
-	if binaryOpExpr, ok := expr.(*hclsyntax.BinaryOpExpr); ok {
-		if binaryOpExpr.Op.Type.FriendlyName() == "bool" {
-			r.searchEmptyList(binaryOpExpr.RHS, runner, binaryOpExpr.Range(), issuesRangeSet)
-			r.searchEmptyList(binaryOpExpr.LHS, runner, binaryOpExpr.Range(), issuesRangeSet)
-		}
-	} else if binaryOpExpr, ok := expr.(*hclsyntax.BinaryOpExpr); ok {
-		r.searchEmptyList(binaryOpExpr, runner, binaryOpExpr.Range(), issuesRangeSet)
-	} else if parenthesesExpr, ok := expr.(*hclsyntax.ParenthesesExpr); ok {
-		r.searchEmptyList(parenthesesExpr.Expression, runner, parenthesesExpr.Range(), issuesRangeSet)
-	} else if tupleConsExpr, ok := expr.(*hclsyntax.TupleConsExpr); ok {
-		if len(tupleConsExpr.Exprs) == 0 {
-			issuesRangeSet[exprRange] = struct{}{}
-		}
-	}
-}
-
-// emitEmptyListEqualityIssues emits issues for each found comparison with static empty list
-func (r *TerraformEmptyListEqualityRule) emitEmptyListEqualityIssues(exprRanges map[hcl.Range]struct{}, runner *tflint.Runner) {
-	for exprRange := range exprRanges {
-		runner.EmitIssue(
-			r,
-			"Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",
-			exprRange,
-		)
-	}
+// emitEmptyListEqualityIssue emits issue for comparison with static empty list
+func (r *TerraformEmptyListEqualityRule) emitEmptyListEqualityIssue(exprRange hcl.Range, runner *tflint.Runner) {
+	runner.EmitIssue(
+		r,
+		"Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",
+		exprRange,
+	)
 }

--- a/rules/terraformrules/terraform_empty_list_equality.go
+++ b/rules/terraformrules/terraform_empty_list_equality.go
@@ -10,6 +10,7 @@ import (
 
 // TerraformEmptyListEqualityRule checks whether is there a comparison with an empty list
 type TerraformEmptyListEqualityRule struct{}
+type void struct{}
 
 // NewTerraformCommentSyntaxRule returns a new rule
 func NewTerraformEmptyListEqualityRule() *TerraformEmptyListEqualityRule {
@@ -55,33 +56,37 @@ func (r *TerraformEmptyListEqualityRule) Check(runner *tflint.Runner) error {
 func (r *TerraformEmptyListEqualityRule) checkEmptyList(runner *tflint.Runner) error {
 	return runner.WalkExpressions(func(expr hcl.Expression) error {
 		if conditionalExpr, ok := expr.(*hclsyntax.ConditionalExpr); ok {
-			searchEmptyList(conditionalExpr.Condition, runner, r, conditionalExpr.Range())
+			var issuesRangeSet = make(map[hcl.Range]void)
+			searchEmptyList(conditionalExpr.Condition, runner, r, conditionalExpr.Range(), issuesRangeSet)
+			emitEmptyListEqualityIssues(issuesRangeSet, runner, r)
 		}
 		return nil
 	})
 }
 
-func searchEmptyList(expr hcl.Expression, runner *tflint.Runner, r *TerraformEmptyListEqualityRule, exprRange hcl.Range) {
+func searchEmptyList(expr hcl.Expression, runner *tflint.Runner, r *TerraformEmptyListEqualityRule, exprRange hcl.Range, issuesRangeSet map[hcl.Range]void) {
 	if binaryOpExpr, ok := expr.(*hclsyntax.BinaryOpExpr); ok {
 		if binaryOpExpr.Op.Type.FriendlyName() == "bool" {
-			searchEmptyList(binaryOpExpr.RHS, runner, r, binaryOpExpr.Range())
-			searchEmptyList(binaryOpExpr.LHS, runner, r, binaryOpExpr.Range())
+			searchEmptyList(binaryOpExpr.RHS, runner, r, binaryOpExpr.Range(), issuesRangeSet)
+			searchEmptyList(binaryOpExpr.LHS, runner, r, binaryOpExpr.Range(), issuesRangeSet)
 		}
 	} else if binaryOpExpr, ok := expr.(*hclsyntax.BinaryOpExpr); ok {
-		searchEmptyList(binaryOpExpr, runner, r, binaryOpExpr.Range())
+		searchEmptyList(binaryOpExpr, runner, r, binaryOpExpr.Range(), issuesRangeSet)
 	} else if parenthesesExpr, ok := expr.(*hclsyntax.ParenthesesExpr); ok {
-		searchEmptyList(parenthesesExpr.Expression, runner, r, parenthesesExpr.Range())
+		searchEmptyList(parenthesesExpr.Expression, runner, r, parenthesesExpr.Range(), issuesRangeSet)
 	} else if tupleConsExpr, ok := expr.(*hclsyntax.TupleConsExpr); ok {
 		if len(tupleConsExpr.Exprs) == 0 {
-			emitIssue(exprRange, runner, r)
+			issuesRangeSet[exprRange] = void{}
 		}
 	}
 }
 
-func emitIssue(exprRange hcl.Range, runner *tflint.Runner, r *TerraformEmptyListEqualityRule) {
-	runner.EmitIssue(
-		r,
-		"Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",
-		exprRange,
-	)
+func emitEmptyListEqualityIssues(exprRanges map[hcl.Range]void, runner *tflint.Runner, r *TerraformEmptyListEqualityRule) {
+	for exprRange := range exprRanges {
+		runner.EmitIssue(
+			r,
+			"Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",
+			exprRange,
+		)
+	}
 }

--- a/rules/terraformrules/terraform_empty_list_equality.go
+++ b/rules/terraformrules/terraform_empty_list_equality.go
@@ -64,16 +64,16 @@ func (r *TerraformEmptyListEqualityRule) checkEmptyList(runner *tflint.Runner) e
 	})
 }
 
-func searchEmptyList(expr hcl.Expression, runner *tflint.Runner, r *TerraformEmptyListEqualityRule, exprRange hcl.Range, issuesRangeSet map[hcl.Range]void) {
+func searchEmptyList(expr hcl.Expression, runner *tflint.Runner, rule *TerraformEmptyListEqualityRule, exprRange hcl.Range, issuesRangeSet map[hcl.Range]void) {
 	if binaryOpExpr, ok := expr.(*hclsyntax.BinaryOpExpr); ok {
 		if binaryOpExpr.Op.Type.FriendlyName() == "bool" {
-			searchEmptyList(binaryOpExpr.RHS, runner, r, binaryOpExpr.Range(), issuesRangeSet)
-			searchEmptyList(binaryOpExpr.LHS, runner, r, binaryOpExpr.Range(), issuesRangeSet)
+			searchEmptyList(binaryOpExpr.RHS, runner, rule, binaryOpExpr.Range(), issuesRangeSet)
+			searchEmptyList(binaryOpExpr.LHS, runner, rule, binaryOpExpr.Range(), issuesRangeSet)
 		}
 	} else if binaryOpExpr, ok := expr.(*hclsyntax.BinaryOpExpr); ok {
-		searchEmptyList(binaryOpExpr, runner, r, binaryOpExpr.Range(), issuesRangeSet)
+		searchEmptyList(binaryOpExpr, runner, rule, binaryOpExpr.Range(), issuesRangeSet)
 	} else if parenthesesExpr, ok := expr.(*hclsyntax.ParenthesesExpr); ok {
-		searchEmptyList(parenthesesExpr.Expression, runner, r, parenthesesExpr.Range(), issuesRangeSet)
+		searchEmptyList(parenthesesExpr.Expression, runner, rule, parenthesesExpr.Range(), issuesRangeSet)
 	} else if tupleConsExpr, ok := expr.(*hclsyntax.TupleConsExpr); ok {
 		if len(tupleConsExpr.Exprs) == 0 {
 			issuesRangeSet[exprRange] = void{}
@@ -81,10 +81,10 @@ func searchEmptyList(expr hcl.Expression, runner *tflint.Runner, r *TerraformEmp
 	}
 }
 
-func emitEmptyListEqualityIssues(exprRanges map[hcl.Range]void, runner *tflint.Runner, r *TerraformEmptyListEqualityRule) {
+func emitEmptyListEqualityIssues(exprRanges map[hcl.Range]void, runner *tflint.Runner, rule *TerraformEmptyListEqualityRule) {
 	for exprRange := range exprRanges {
 		runner.EmitIssue(
-			r,
+			rule,
 			"Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",
 			exprRange,
 		)

--- a/rules/terraformrules/terraform_empty_list_equality_test.go
+++ b/rules/terraformrules/terraform_empty_list_equality_test.go
@@ -33,7 +33,7 @@ resource "aws_db_instance" "mysql" {
 			},
 		},
 		{
-			Name: "comparing with [] multiple times in the same statement is not recommended",
+			Name: "multiple comparisons with [] are not recommended",
 			Content: `
 resource "aws_db_instance" "mysql" {
 	count = [] == [] || [] == [] ? 1 : 0

--- a/rules/terraformrules/terraform_empty_list_equality_test.go
+++ b/rules/terraformrules/terraform_empty_list_equality_test.go
@@ -42,6 +42,34 @@ resource "aws_db_instance" "mysql" {
 			},
 		},
 		{
+			Name: "comparing with [] is not recommended (mixed with other conditions)",
+			Content: `
+resource "aws_db_instance" "mysql" {
+	count = true == true || false != true && (false == false || [] == []) ? 1 : 0
+	instance_class = "m4.2xlarge"
+}`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformEmptyListEqualityRule(),
+					Message: "Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 62},
+						End:      hcl.Pos{Line: 3, Column: 70},
+					},
+				},
+				{
+					Rule:    NewTerraformEmptyListEqualityRule(),
+					Message: "Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 62},
+						End:      hcl.Pos{Line: 3, Column: 70},
+					},
+				},
+			},
+		},
+		{
 			Name: "negatively comparing with [] is not recommended",
 			Content: `
 variable "my_list" {

--- a/rules/terraformrules/terraform_empty_list_equality_test.go
+++ b/rules/terraformrules/terraform_empty_list_equality_test.go
@@ -30,6 +30,25 @@ resource "aws_db_instance" "mysql" {
 						End:      hcl.Pos{Line: 3, Column: 18},
 					},
 				},
+			},
+		},
+		{
+			Name: "comparing with [] multiple times in the same statement is not recommended",
+			Content: `
+resource "aws_db_instance" "mysql" {
+	count = [] == [] || [] == [] ? 1 : 0
+	instance_class = "m4.2xlarge"
+}`,
+			Expected: tflint.Issues{
+				{
+					Rule:    NewTerraformEmptyListEqualityRule(),
+					Message: "Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 22},
+						End:      hcl.Pos{Line: 3, Column: 30},
+					},
+				},
 				{
 					Rule:    NewTerraformEmptyListEqualityRule(),
 					Message: "Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",
@@ -42,10 +61,10 @@ resource "aws_db_instance" "mysql" {
 			},
 		},
 		{
-			Name: "comparing with [] is not recommended (mixed with other conditions)",
+			Name: "comparing with [] inside parenthesis is not recommended",
 			Content: `
 resource "aws_db_instance" "mysql" {
-	count = true == true || false != true && (false == false || [] == []) ? 1 : 0
+	count = ([] == []) ? 1 : 0
 	instance_class = "m4.2xlarge"
 }`,
 			Expected: tflint.Issues{
@@ -54,17 +73,8 @@ resource "aws_db_instance" "mysql" {
 					Message: "Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",
 					Range: hcl.Range{
 						Filename: "resource.tf",
-						Start:    hcl.Pos{Line: 3, Column: 62},
-						End:      hcl.Pos{Line: 3, Column: 70},
-					},
-				},
-				{
-					Rule:    NewTerraformEmptyListEqualityRule(),
-					Message: "Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",
-					Range: hcl.Range{
-						Filename: "resource.tf",
-						Start:    hcl.Pos{Line: 3, Column: 62},
-						End:      hcl.Pos{Line: 3, Column: 70},
+						Start:    hcl.Pos{Line: 3, Column: 11},
+						End:      hcl.Pos{Line: 3, Column: 19},
 					},
 				},
 			},

--- a/rules/terraformrules/terraform_empty_list_equality_test.go
+++ b/rules/terraformrules/terraform_empty_list_equality_test.go
@@ -45,8 +45,8 @@ resource "aws_db_instance" "mysql" {
 					Message: "Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",
 					Range: hcl.Range{
 						Filename: "resource.tf",
-						Start:    hcl.Pos{Line: 3, Column: 22},
-						End:      hcl.Pos{Line: 3, Column: 30},
+						Start:    hcl.Pos{Line: 3, Column: 10},
+						End:      hcl.Pos{Line: 3, Column: 18},
 					},
 				},
 				{
@@ -54,8 +54,8 @@ resource "aws_db_instance" "mysql" {
 					Message: "Comparing a collection with an empty list is invalid. To detect an empty collection, check its length.",
 					Range: hcl.Range{
 						Filename: "resource.tf",
-						Start:    hcl.Pos{Line: 3, Column: 10},
-						End:      hcl.Pos{Line: 3, Column: 18},
+						Start:    hcl.Pos{Line: 3, Column: 22},
+						End:      hcl.Pos{Line: 3, Column: 30},
 					},
 				},
 			},


### PR DESCRIPTION
Fixes partially https://github.com/terraform-linters/tflint/issues/1424 to be able to also detect empty lists on more complex conditional expressions such as `var.enabled && var.proxy_subnets != [] ? 1 : 0`.

As @bendrucker referred [here](https://github.com/terraform-linters/tflint/issues/1424#issuecomment-1165980739), the evaluation of complex attribute values is a deeper issue (https://github.com/terraform-linters/tflint/issues/1257) and this PR does not fix that part.