### PR TITLE
terraformrules: Walk map/list expressions deeply

### DIFF
--- a/rules/terraformrules/terraform_workspace_remote.go
+++ b/rules/terraformrules/terraform_workspace_remote.go
@@ -4,6 +4,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/json"
 	"github.com/terraform-linters/tflint/terraform/addrs"
 	"github.com/terraform-linters/tflint/terraform/lang"
 	"github.com/terraform-linters/tflint/tflint"
@@ -58,6 +60,11 @@ func (r *TerraformWorkspaceRemoteRule) Check(runner *tflint.Runner) error {
 }
 
 func (r *TerraformWorkspaceRemoteRule) checkForTerraformWorkspaceInExpr(runner *tflint.Runner, expr hcl.Expression) error {
+	_, isScopeTraversalExpr := expr.(*hclsyntax.ScopeTraversalExpr)
+	if !isScopeTraversalExpr && !json.IsJSONExpression(expr) {
+		return nil
+	}
+
 	refs, diags := lang.ReferencesInExpr(expr)
 	if diags.HasErrors() {
 		log.Printf("[DEBUG] Cannot find references in expression, ignoring: %v", diags.Err())

--- a/tflint/runner_walk_test.go
+++ b/tflint/runner_walk_test.go
@@ -24,16 +24,8 @@ resource "null_resource" "test" {
   key = "foo"
 }`,
 			Expressions: []hcl.Range{
-				{
-					Start: hcl.Pos{
-						Line:   3,
-						Column: 9,
-					},
-					End: hcl.Pos{
-						Line:   3,
-						Column: 14,
-					},
-				},
+				{Start: hcl.Pos{Line: 3, Column: 9}, End: hcl.Pos{Line: 3, Column: 14}},
+				{Start: hcl.Pos{Line: 3, Column: 10}, End: hcl.Pos{Line: 3, Column: 13}},
 			},
 		},
 		{
@@ -43,16 +35,8 @@ data "null_dataresource" "test" {
   key = "foo"
 }`,
 			Expressions: []hcl.Range{
-				{
-					Start: hcl.Pos{
-						Line:   3,
-						Column: 9,
-					},
-					End: hcl.Pos{
-						Line:   3,
-						Column: 14,
-					},
-				},
+				{Start: hcl.Pos{Line: 3, Column: 9}, End: hcl.Pos{Line: 3, Column: 14}},
+				{Start: hcl.Pos{Line: 3, Column: 10}, End: hcl.Pos{Line: 3, Column: 13}},
 			},
 		},
 		{
@@ -63,83 +47,43 @@ module "m" {
   key    = "foo"
 }`,
 			Expressions: []hcl.Range{
-				{
-					Start: hcl.Pos{
-						Line:   3,
-						Column: 12,
-					},
-					End: hcl.Pos{
-						Line:   3,
-						Column: 22,
-					},
-				},
-				{
-					Start: hcl.Pos{
-						Line:   4,
-						Column: 12,
-					},
-					End: hcl.Pos{
-						Line:   4,
-						Column: 17,
-					},
-				},
+				{Start: hcl.Pos{Line: 3, Column: 12}, End: hcl.Pos{Line: 3, Column: 22}},
+				{Start: hcl.Pos{Line: 3, Column: 13}, End: hcl.Pos{Line: 3, Column: 21}},
+				{Start: hcl.Pos{Line: 4, Column: 12}, End: hcl.Pos{Line: 4, Column: 17}},
+				{Start: hcl.Pos{Line: 4, Column: 13}, End: hcl.Pos{Line: 4, Column: 16}},
 			},
 		},
 		{
 			Name: "provider config",
 			Content: `
 provider "p" {
-  key = "foo"	
+  key = "foo"
 }`,
 			Expressions: []hcl.Range{
-				{
-					Start: hcl.Pos{
-						Line:   3,
-						Column: 9,
-					},
-					End: hcl.Pos{
-						Line:   3,
-						Column: 14,
-					},
-				},
+				{Start: hcl.Pos{Line: 3, Column: 9}, End: hcl.Pos{Line: 3, Column: 14}},
+				{Start: hcl.Pos{Line: 3, Column: 10}, End: hcl.Pos{Line: 3, Column: 13}},
 			},
 		},
 		{
 			Name: "locals",
 			Content: `
 locals {
-  key = "foo"	
+  key = "foo"
 }`,
 			Expressions: []hcl.Range{
-				{
-					Start: hcl.Pos{
-						Line:   3,
-						Column: 9,
-					},
-					End: hcl.Pos{
-						Line:   3,
-						Column: 14,
-					},
-				},
+				{Start: hcl.Pos{Line: 3, Column: 9}, End: hcl.Pos{Line: 3, Column: 14}},
+				{Start: hcl.Pos{Line: 3, Column: 10}, End: hcl.Pos{Line: 3, Column: 13}},
 			},
 		},
 		{
 			Name: "output",
 			Content: `
 output "o" {
-  value = "foo"	
+  value = "foo"
 }`,
 			Expressions: []hcl.Range{
-				{
-					Start: hcl.Pos{
-						Line:   3,
-						Column: 11,
-					},
-					End: hcl.Pos{
-						Line:   3,
-						Column: 16,
-					},
-				},
+				{Start: hcl.Pos{Line: 3, Column: 11}, End: hcl.Pos{Line: 3, Column: 16}},
+				{Start: hcl.Pos{Line: 3, Column: 12}, End: hcl.Pos{Line: 3, Column: 15}},
 			},
 		},
 		{
@@ -147,32 +91,16 @@ output "o" {
 			Content: `
 resource "null_resource" "test" {
   key = "foo"
-  
+
   lifecycle {
     ignore_changes = [key]
   }
 }`,
 			Expressions: []hcl.Range{
-				{
-					Start: hcl.Pos{
-						Line:   3,
-						Column: 9,
-					},
-					End: hcl.Pos{
-						Line:   3,
-						Column: 14,
-					},
-				},
-				{
-					Start: hcl.Pos{
-						Line:   6,
-						Column: 22,
-					},
-					End: hcl.Pos{
-						Line:   6,
-						Column: 27,
-					},
-				},
+				{Start: hcl.Pos{Line: 3, Column: 9}, End: hcl.Pos{Line: 3, Column: 14}},
+				{Start: hcl.Pos{Line: 3, Column: 10}, End: hcl.Pos{Line: 3, Column: 13}},
+				{Start: hcl.Pos{Line: 6, Column: 22}, End: hcl.Pos{Line: 6, Column: 27}},
+				{Start: hcl.Pos{Line: 6, Column: 23}, End: hcl.Pos{Line: 6, Column: 26}},
 			},
 		},
 		{
@@ -195,36 +123,7 @@ resource "null_resource" "test" {
   }
 }`,
 			Expressions: []hcl.Range{
-				{
-					Start: hcl.Pos{
-						Line:   6,
-						Column: 16,
-					},
-					End: hcl.Pos{
-						Line:   6,
-						Column: 21,
-					},
-				},
-				{
-					Start: hcl.Pos{
-						Line:   7,
-						Column: 19,
-					},
-					End: hcl.Pos{
-						Line:   9,
-						Column: 10,
-					},
-				},
-				{
-					Start: hcl.Pos{
-						Line:   10,
-						Column: 17,
-					},
-					End: hcl.Pos{
-						Line:   12,
-						Column: 11,
-					},
-				},
+				{Start: hcl.Pos{Line: 3, Column: 15}, End: hcl.Pos{Line: 15, Column: 4}},
 			},
 		},
 		{
@@ -245,45 +144,82 @@ provider "aws" {
     role_arn = null
   }
 }`,
-			Expressions: []hcl.Range{},
+			Expressions: []hcl.Range{
+				{Start: hcl.Pos{Line: 3, Column: 12}, End: hcl.Pos{Line: 3, Column: 23}, Filename: "main.tf"},
+				{Start: hcl.Pos{Line: 3, Column: 13}, End: hcl.Pos{Line: 3, Column: 22}, Filename: "main.tf"},
+				{Start: hcl.Pos{Line: 6, Column: 16}, End: hcl.Pos{Line: 6, Column: 60}, Filename: "main.tf"},
+				{Start: hcl.Pos{Line: 6, Column: 17}, End: hcl.Pos{Line: 6, Column: 59}, Filename: "main.tf"},
+				{Start: hcl.Pos{Line: 3, Column: 12}, End: hcl.Pos{Line: 3, Column: 23}, Filename: "main_override.tf"},
+				{Start: hcl.Pos{Line: 3, Column: 13}, End: hcl.Pos{Line: 3, Column: 22}, Filename: "main_override.tf"},
+				{Start: hcl.Pos{Line: 6, Column: 16}, End: hcl.Pos{Line: 6, Column: 20}, Filename: "main_override.tf"},
+			},
+		},
+		{
+			Name: "nested attributes",
+			Content: `
+data "terraform_remote_state" "remote_state" {
+  backend = "remote"
+
+  config = {
+    organization = "Organization"
+    workspaces = {
+      name = "${var.environment}"
+    }
+  }
+}`,
+			Expressions: []hcl.Range{
+				{Start: hcl.Pos{Line: 3, Column: 13}, End: hcl.Pos{Line: 3, Column: 21}},
+				{Start: hcl.Pos{Line: 3, Column: 14}, End: hcl.Pos{Line: 3, Column: 20}},
+				{Start: hcl.Pos{Line: 5, Column: 12}, End: hcl.Pos{Line: 10, Column: 4}},
+				{Start: hcl.Pos{Line: 6, Column: 5}, End: hcl.Pos{Line: 6, Column: 17}},
+				{Start: hcl.Pos{Line: 6, Column: 20}, End: hcl.Pos{Line: 6, Column: 34}},
+				{Start: hcl.Pos{Line: 6, Column: 21}, End: hcl.Pos{Line: 6, Column: 33}},
+				{Start: hcl.Pos{Line: 7, Column: 5}, End: hcl.Pos{Line: 7, Column: 15}},
+				{Start: hcl.Pos{Line: 7, Column: 18}, End: hcl.Pos{Line: 9, Column: 6}},
+				{Start: hcl.Pos{Line: 8, Column: 7}, End: hcl.Pos{Line: 8, Column: 11}},
+				{Start: hcl.Pos{Line: 8, Column: 14}, End: hcl.Pos{Line: 8, Column: 34}},
+				{Start: hcl.Pos{Line: 8, Column: 17}, End: hcl.Pos{Line: 8, Column: 32}},
+			},
 		},
 	}
 
 	for _, tc := range cases {
-		filename := "main.tf"
-		override := "main_override.tf"
-		if tc.JSON {
-			filename += ".json"
-			override += ".json"
-		}
+		t.Run(tc.Name, func(t *testing.T) {
+			filename := "main.tf"
+			override := "main_override.tf"
+			if tc.JSON {
+				filename += ".json"
+				override += ".json"
+			}
 
-		var runner *Runner
-		if tc.Override != "" {
-			runner = TestRunner(t, map[string]string{filename: tc.Content, override: tc.Override})
-		} else {
-			runner = TestRunner(t, map[string]string{filename: tc.Content})
-		}
-		expressions := make([]hcl.Range, 0)
+			var runner *Runner
+			if tc.Override != "" {
+				runner = TestRunner(t, map[string]string{filename: tc.Content, override: tc.Override})
+			} else {
+				runner = TestRunner(t, map[string]string{filename: tc.Content})
+			}
+			expressions := make([]hcl.Range, 0)
 
-		err := runner.WalkExpressions(func(expr hcl.Expression) error {
-			expressions = append(expressions, expr.Range())
-			return nil
+			err := runner.WalkExpressions(func(expr hcl.Expression) error {
+				expressions = append(expressions, expr.Range())
+				return nil
+			})
+			if err == nil {
+				if tc.ErrorText != "" {
+					t.Fatalf("expected error is not occurred `%s`", tc.ErrorText)
+				}
+
+				opts := cmp.Options{
+					cmpopts.IgnoreFields(hcl.Range{}, "Filename"),
+					cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
+					cmpopts.SortSlices(func(x, y hcl.Range) bool { return x.String() > y.String() }),
+				}
+				if diff := cmp.Diff(expressions, tc.Expressions, opts); diff != "" {
+					t.Fatal(diff)
+				}
+			} else if err.Error() != tc.ErrorText {
+				t.Fatalf("expected error is %s, but get %s", tc.ErrorText, err)
+			}
 		})
-		if err == nil {
-			if tc.ErrorText != "" {
-				t.Fatalf("Failed `%s` test: expected error is not occurred `%s`", tc.Name, tc.ErrorText)
-			}
-
-			opts := cmp.Options{
-				cmpopts.IgnoreFields(hcl.Range{}, "Filename"),
-				cmpopts.IgnoreFields(hcl.Pos{}, "Byte"),
-				cmpopts.SortSlices(func(x, y hcl.Range) bool { return x.String() > y.String() }),
-			}
-			if !cmp.Equal(expressions, tc.Expressions, opts) {
-				t.Fatalf("Failed `%s` test: diff=%s", tc.Name, cmp.Diff(expressions, tc.Expressions, opts))
-			}
-		} else if err.Error() != tc.ErrorText {
-			t.Fatalf("Failed `%s` test: expected error is %s, but get %s", tc.Name, tc.ErrorText, err)
-		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1257

Previously, `WalkExpressions` visited expressions based on the structure parsed by Terraform's internal API. Therefore, when the expression is nested in an expression such as map or list, there is an issue that it is not possible to walk the nested expression correctly.

This PR changes to use the HCL's native `Walk` function instead of the structure parsed by Terraform's internal API to walk expressions deeply. Note that this change will inspect the overridden configuration. This is because all files are inspected, regardless of Terraform semantics.

Also, there are some caveats when walking the JSON expressions. Unlike the native HCL syntax, the JSON syntax does not provide a `Walk` function, so we cannot walk for an expression in an expression. This has room for improvement, but at this point, it only walks top-level expressions. Therefore, it is possible that a wider range than the original expression range will be reported.