### PR TITLE
terraform: Finalize variable values in Evaluator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/bmatcuk/doublestar v1.1.5
 	github.com/fatih/color v1.13.0
+	github.com/go-test/deep v1.0.8
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v35 v35.3.0
@@ -43,7 +44,6 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.42.43 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
-	github.com/go-test/deep v1.0.8 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,7 +89,6 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/terraform/variable.go
+++ b/terraform/variable.go
@@ -23,6 +23,7 @@ type Variable struct {
 
 	ParsingMode VariableParsingMode
 	Sensitive   bool
+	Nullable    bool
 }
 
 func decodeVairableBlock(block *hclext.Block) (*Variable, hcl.Diagnostics) {
@@ -46,6 +47,15 @@ func decodeVairableBlock(block *hclext.Block) (*Variable, hcl.Diagnostics) {
 	if attr, exists := block.Body.Attributes["sensitive"]; exists {
 		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &v.Sensitive)
 		diags = diags.Extend(valDiags)
+	}
+
+	if attr, exists := block.Body.Attributes["nullable"]; exists {
+		valDiags := gohcl.DecodeExpression(attr.Expr, nil, &v.Nullable)
+		diags = append(diags, valDiags...)
+	} else {
+		// The current default is true, which is subject to change in a future
+		// language edition.
+		v.Nullable = true
 	}
 
 	if attr, exists := block.Body.Attributes["default"]; exists {
@@ -209,6 +219,9 @@ var variableBlockSchema = &hclext.BodySchema{
 		},
 		{
 			Name: "sensitive",
+		},
+		{
+			Name: "nullable",
 		},
 	},
 }

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -50,6 +50,7 @@ func Test_NewModuleRunners_nestedModules(t *testing.T) {
 					Name:        "override",
 					Default:     cty.StringVal("foo"),
 					Type:        cty.DynamicPseudoType,
+					Nullable:    true,
 					ParsingMode: terraform.VariableParseLiteral,
 					DeclRange: hcl.Range{
 						Filename: filepath.Join("module", "module.tf"),
@@ -61,6 +62,7 @@ func Test_NewModuleRunners_nestedModules(t *testing.T) {
 					Name:        "no_default",
 					Default:     cty.StringVal("bar"),
 					Type:        cty.DynamicPseudoType,
+					Nullable:    true,
 					ParsingMode: terraform.VariableParseLiteral,
 					DeclRange: hcl.Range{
 						Filename: filepath.Join("module", "module.tf"),
@@ -72,6 +74,7 @@ func Test_NewModuleRunners_nestedModules(t *testing.T) {
 					Name:        "unknown",
 					Default:     cty.UnknownVal(cty.DynamicPseudoType),
 					Type:        cty.DynamicPseudoType,
+					Nullable:    true,
 					ParsingMode: terraform.VariableParseLiteral,
 					DeclRange: hcl.Range{
 						Filename: filepath.Join("module", "module.tf"),
@@ -85,6 +88,7 @@ func Test_NewModuleRunners_nestedModules(t *testing.T) {
 					Name:        "override",
 					Default:     cty.StringVal("foo"),
 					Type:        cty.DynamicPseudoType,
+					Nullable:    true,
 					ParsingMode: terraform.VariableParseLiteral,
 					DeclRange: hcl.Range{
 						Filename: filepath.Join("module", "module1", "resource.tf"),
@@ -96,6 +100,7 @@ func Test_NewModuleRunners_nestedModules(t *testing.T) {
 					Name:        "no_default",
 					Default:     cty.StringVal("bar"),
 					Type:        cty.DynamicPseudoType,
+					Nullable:    true,
 					ParsingMode: terraform.VariableParseLiteral,
 					DeclRange: hcl.Range{
 						Filename: filepath.Join("module", "module1", "resource.tf"),
@@ -107,6 +112,7 @@ func Test_NewModuleRunners_nestedModules(t *testing.T) {
 					Name:        "unknown",
 					Default:     cty.UnknownVal(cty.DynamicPseudoType),
 					Type:        cty.DynamicPseudoType,
+					Nullable:    true,
 					ParsingMode: terraform.VariableParseLiteral,
 					DeclRange: hcl.Range{
 						Filename: filepath.Join("module", "module1", "resource.tf"),


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1436

The Terraform evaluator no longer converts variables or applies default values in #1403.
https://github.com/terraform-linters/tflint/pull/1403/files#diff-2c53c5f250b940a59cca6fbb5c22a2ab9387a40b24b6c77375fd9aaa942f91cf

This merged Terraform v1.2 changes, commented as follows:

> d.Evaluator.VariableValues should always contain valid "final values" for variables, which is to say that they have already had type conversions, validations, and default value handling applied to them. Those are the responsibility of the graph notes representing the variable declarations. Therefore here we just trust that we already have a correct value.

This description is correct in Terraform, but not in TFLint. I will quote the Terraform architecture diagram:

<img src="https://raw.githubusercontent.com/hashicorp/terraform/v1.2.5/docs/images/architecture-overview.png" />

https://github.com/hashicorp/terraform/blob/v1.2.5/docs/architecture.md

TFLint has a policy of reproducing the `terraform.Context` only from Configuration Loader without using Backend and State Manager, and evaluating the configuration file as it is, not Vertex Evaluation. That is, there are no steps by Graph Builder compared to Terraform.

As explained above, in Terraform, the `RootVariableTransformer`, which is part of the Graph Builder step, finalizes the input values:
https://github.com/hashicorp/terraform/blob/v1.2.5/internal/terraform/graph_builder_eval.go#L67
https://github.com/hashicorp/terraform/blob/v1.2.5/internal/terraform/transform_variable.go#L32
https://github.com/hashicorp/terraform/blob/v1.2.5/internal/terraform/node_root_variable.go#L82
https://github.com/hashicorp/terraform/blob/v1.2.5/internal/terraform/eval_variable.go#L18

Since TFLint does not have the finalization equivalent to this `prepareFinalInputVariableValue`, it is necessary to continue finalizing variable values in the Evaluator.