### PR TITLE
Update verification steps for the latest Cosign

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,12 @@ gpg --verify checksum.txt.sig checksum.txt
 sha256sum --ignore-missing -c checksums.txt
 ```
 
-Cosign (experimental)
+Cosign
 
 ```
-COSIGN_EXPERIMENTAL=1 cosign verify-blob --signature checksums.txt.keyless.sig checksums.txt
+cosign verify-blob --cert checksums.txt.pem --signature checksums.txt.keyless.sig --certificate-github-workflow-repository=terraform-linters/tflint checksums.txt
 sha256sum --ignore-missing -c checksums.txt
 ```
-
-**IMPORTANT:** Keyless Signing is in development and you should not completely trust this way. For instance, you have not validated the OIDC subject claim, so it is not guaranteed to be the public key issued by the maintainers.
 
 ### Docker
 


### PR DESCRIPTION
In Cosign v1.10, the `--certificate-github-workflow-repository` option has been added to allow verification of OIDC subject claims on certificates.

Ideally, it's better to get the certificate from Rekor (`COSIGN_EXPERIMENTAL=1`), but it's also safe if you can validate the certificate chain, even if downloaded individually from GitHub. We will adopt a way to download certificates individually because it is more stable.