### PR TITLE
`terraform_required_version`: fix regression with multiple blocks

### DIFF
--- a/rules/terraformrules/terraform_required_version.go
+++ b/rules/terraformrules/terraform_required_version.go
@@ -60,14 +60,19 @@ func (r *TerraformRequiredVersionRule) Check(runner *tflint.Runner) error {
 		return diags
 	}
 
+	var exists bool
+
 	for _, block := range body.Blocks {
-		if _, exists := block.Body.Attributes["required_version"]; !exists {
-			runner.EmitIssue(
-				r,
-				`terraform "required_version" attribute is required`,
-				hcl.Range{},
-			)
-		}
+		_, ok := block.Body.Attributes["required_version"]
+		exists = exists || ok
+	}
+
+	if !exists {
+		runner.EmitIssue(
+			r,
+			`terraform "required_version" attribute is required`,
+			hcl.Range{},
+		)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes a regression where multiple `terraform {}` blocks results in a false positive issue being emitted. https://github.com/terraform-linters/tflint/pull/1433/files#diff-0ec954b5c7913111444d96417f3325c4a2f5d91507770a89022bcbd4b05319cb, which rewrote chunks of the `terraformrules` package to eliminate dependencies on Terraform internals, introduced this regression. The new code, which operates on the generic HCL structure rather than the parsed Terraform internal representation has a simple logic error:

```go
for _, block := range body.Blocks {
	if _, exists := block.Body.Attributes["required_version"]; !exists {
```

This processes every `terraform` block and emits and error if `required_version` is unset. Instead, the rule should process all the blocks and emit a single error if _none_ has the attribute set. 

Fixes #1451