### PR TITLE
`terraform_required_providers`: fix regression with `configuration_aliases`

### DIFF
--- a/rules/terraformrules/terraform_required_providers_test.go
+++ b/rules/terraformrules/terraform_required_providers_test.go
@@ -206,6 +206,26 @@ provider "template" {
 			},
 		},
 		{
+			Name: "version set with configuration_aliases",
+			Content: `
+terraform {
+  required_providers {
+    template = {
+			source = "hashicorp/template"
+			version = "~> 2"
+
+			configuration_aliases = [template.alias]
+		}
+  }
+}
+
+data "template_file" "foo" {
+	provider = template.alias
+}
+`,
+			Expected: tflint.Issues{},
+		},
+		{
 			Name: "version set with alias",
 			Content: `
 terraform {


### PR DESCRIPTION
Fixes a regression, described in #1450. When evaluating an entry in `required_providers`, this adds a variable (dynamic value) with the provider's name, allowing the evaluation of `configuration_aliases`. This evaluation is looser than Terraform would perform, e.g., `configuration_aliases = [aws.foo.bar]` would presumably be considered valid. References to other providers should still fail.

Closes #1450