### PR TITLE
Fix panic that occurs when using sensitive count

### DIFF
--- a/tflint/runner_eval.go
+++ b/tflint/runner_eval.go
@@ -159,6 +159,7 @@ func (r *Runner) isEvaluableCountArgument(expr hcl.Expression) (bool, error) {
 	if err != nil {
 		return isEvaluableMetaArgumentsOnError(err)
 	}
+	val, _ = val.Unmark()
 
 	count := 1
 	if err := gocty.FromCtyValue(val, &count); err != nil {

--- a/tflint/runner_eval_test.go
+++ b/tflint/runner_eval_test.go
@@ -898,6 +898,19 @@ resource "null_resource" "test" {
 			Expected: 0,
 		},
 		{
+			Name: "count is sensitive",
+			Content: `
+variable "foo" {
+  default = 1
+  sensitive = true
+}
+
+resource "null_resource" "test" {
+  count = var.foo
+}`,
+			Expected: 1,
+		},
+		{
 			Name: "count is unevaluable",
 			Content: `
 resource "null_resource" "test" {


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1447

When retrieving a value from a `cty.Value` marked as sensitive, the safety mechanism causes a panic. We avoid panic by unmarking in the same way as Terraform:
https://github.com/hashicorp/terraform/blob/v1.2.6/internal/terraform/eval_count.go#L61-L63