### PR TITLE
terraformrules: Get module contents with `IncludeNotCreated: true`

### DIFF
--- a/rules/terraformrules/terraform_documented_outputs.go
+++ b/rules/terraformrules/terraform_documented_outputs.go
@@ -57,7 +57,7 @@ func (r *TerraformDocumentedOutputsRule) Check(runner *tflint.Runner) error {
 				},
 			},
 		},
-	}, sdk.GetModuleContentOption{})
+	}, sdk.GetModuleContentOption{IncludeNotCreated: true})
 	if diags.HasErrors() {
 		return diags
 	}

--- a/rules/terraformrules/terraform_documented_variables.go
+++ b/rules/terraformrules/terraform_documented_variables.go
@@ -57,7 +57,7 @@ func (r *TerraformDocumentedVariablesRule) Check(runner *tflint.Runner) error {
 				},
 			},
 		},
-	}, sdk.GetModuleContentOption{})
+	}, sdk.GetModuleContentOption{IncludeNotCreated: true})
 	if diags.HasErrors() {
 		return diags
 	}

--- a/rules/terraformrules/terraform_module_pinned_source.go
+++ b/rules/terraformrules/terraform_module_pinned_source.go
@@ -66,7 +66,7 @@ func (r *TerraformModulePinnedSourceRule) Check(runner *tflint.Runner) error {
 		return err
 	}
 
-	body, diags := runner.GetModuleContent(moduleCallSchema, sdk.GetModuleContentOption{})
+	body, diags := runner.GetModuleContent(moduleCallSchema, sdk.GetModuleContentOption{IncludeNotCreated: true})
 	if diags.HasErrors() {
 		return diags
 	}

--- a/rules/terraformrules/terraform_module_version.go
+++ b/rules/terraformrules/terraform_module_version.go
@@ -62,7 +62,7 @@ func (r *TerraformModuleVersionRule) Check(runner *tflint.Runner) error {
 		return err
 	}
 
-	body, diags := runner.GetModuleContent(moduleCallSchema, sdk.GetModuleContentOption{})
+	body, diags := runner.GetModuleContent(moduleCallSchema, sdk.GetModuleContentOption{IncludeNotCreated: true})
 	if diags.HasErrors() {
 		return diags
 	}

--- a/rules/terraformrules/terraform_naming_convention.go
+++ b/rules/terraformrules/terraform_naming_convention.go
@@ -123,7 +123,7 @@ func (r *TerraformNamingConventionRule) Check(runner *tflint.Runner) error {
 				Body:       &hclext.BodySchema{},
 			},
 		},
-	}, sdk.GetModuleContentOption{})
+	}, sdk.GetModuleContentOption{IncludeNotCreated: true})
 	if diags.HasErrors() {
 		return diags
 	}

--- a/rules/terraformrules/terraform_required_providers.go
+++ b/rules/terraformrules/terraform_required_providers.go
@@ -61,7 +61,7 @@ func (r *TerraformRequiredProvidersRule) Check(runner *tflint.Runner) error {
 				},
 			},
 		},
-	}, sdk.GetModuleContentOption{})
+	}, sdk.GetModuleContentOption{IncludeNotCreated: true})
 	if diags.HasErrors() {
 		return diags
 	}
@@ -102,7 +102,7 @@ func (r *TerraformRequiredProvidersRule) Check(runner *tflint.Runner) error {
 				},
 			},
 		},
-	}, sdk.GetModuleContentOption{})
+	}, sdk.GetModuleContentOption{IncludeNotCreated: true})
 	if diags.HasErrors() {
 		return diags
 	}

--- a/rules/terraformrules/terraform_required_version.go
+++ b/rules/terraformrules/terraform_required_version.go
@@ -55,7 +55,7 @@ func (r *TerraformRequiredVersionRule) Check(runner *tflint.Runner) error {
 				},
 			},
 		},
-	}, sdk.GetModuleContentOption{})
+	}, sdk.GetModuleContentOption{IncludeNotCreated: true})
 	if diags.HasErrors() {
 		return diags
 	}

--- a/rules/terraformrules/terraform_standard_module_structure.go
+++ b/rules/terraformrules/terraform_standard_module_structure.go
@@ -67,7 +67,7 @@ func (r *TerraformStandardModuleStructureRule) Check(runner *tflint.Runner) erro
 				Body:       &hclext.BodySchema{},
 			},
 		},
-	}, sdk.GetModuleContentOption{})
+	}, sdk.GetModuleContentOption{IncludeNotCreated: true})
 	if diags.HasErrors() {
 		return diags
 	}

--- a/rules/terraformrules/terraform_typed_variables.go
+++ b/rules/terraformrules/terraform_typed_variables.go
@@ -56,7 +56,7 @@ func (r *TerraformTypedVariablesRule) Check(runner *tflint.Runner) error {
 				},
 			},
 		},
-	}, sdk.GetModuleContentOption{})
+	}, sdk.GetModuleContentOption{IncludeNotCreated: true})
 	if diags.HasErrors() {
 		return diags
 	}

--- a/rules/terraformrules/terraform_unused_declaration.go
+++ b/rules/terraformrules/terraform_unused_declaration.go
@@ -109,7 +109,7 @@ func (r *TerraformUnusedDeclarationsRule) declarations(runner *tflint.Runner) (*
 				Body:       &hclext.BodySchema{},
 			},
 		},
-	}, sdk.GetModuleContentOption{})
+	}, sdk.GetModuleContentOption{IncludeNotCreated: true})
 	if diags.HasErrors() {
 		return decl, diags
 	}

--- a/rules/terraformrules/terraform_unused_required_providers_test.go
+++ b/rules/terraformrules/terraform_unused_required_providers_test.go
@@ -239,6 +239,25 @@ func Test_TerraformUnusedRequiredProvidersRule(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "used - unevaluated resource",
+			Content: `
+				terraform {
+					required_providers {
+						null = {
+							source = "hashicorp/null"
+						}
+					}
+				}
+
+				variable "foo" {}
+
+				resource "null_resource" "foo" {
+					count = var.foo
+				}
+			`,
+			Expected: tflint.Issues{},
+		},
 	}
 
 	rule := NewTerraformUnusedRequiredProvidersRule()

--- a/rules/terraformrules/terraform_workspace_remote.go
+++ b/rules/terraformrules/terraform_workspace_remote.go
@@ -64,7 +64,7 @@ func (r *TerraformWorkspaceRemoteRule) Check(runner *tflint.Runner) error {
 				},
 			},
 		},
-	}, sdk.GetModuleContentOption{})
+	}, sdk.GetModuleContentOption{IncludeNotCreated: true})
 	if diags.HasErrors() {
 		return diags
 	}

--- a/rules/terraformrules/utils.go
+++ b/rules/terraformrules/utils.go
@@ -155,7 +155,7 @@ func getProviderRefs(runner *tflint.Runner) (map[string]*providerRef, hcl.Diagno
 				},
 			},
 		},
-	}, sdk.GetModuleContentOption{})
+	}, sdk.GetModuleContentOption{IncludeNotCreated: true})
 	if diags.HasErrors() {
 		return providerRefs, diags
 	}


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1455

By default, the `GetModuleContent` API follows the Terraform semantics and does not return resources with `count = 0` or `for_each = []`. The same is true if these values cannot be evaluated (e.g. local value).

All resources can always be returned by using the `IncludeNotCreated` option. Terraform rules are more concerned with the definition and structure itself than whether the resource is created, so we should basically enable this option.

