### PR TITLE
plugin: Return a file from other modules

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -98,7 +98,7 @@ func (cli *CLI) inspect(opts Options, dir string, filterFiles []string) int {
 
 	for _, ruleset := range rulesetPlugin.RuleSets {
 		for _, runner := range runners {
-			err = ruleset.Check(plugin.NewGRPCServer(runner, rootRunner, cli.loader.Sources()))
+			err = ruleset.Check(plugin.NewGRPCServer(runner, rootRunner, cli.loader.Files()))
 			if err != nil {
 				cli.formatter.Print(tflint.Issues{}, fmt.Errorf("Failed to check ruleset; %w", err), cli.loader.Sources())
 				return ExitCodeError

--- a/integrationtest/inspection/eval-on-root-context/.terraform/modules/modules.json
+++ b/integrationtest/inspection/eval-on-root-context/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"route53_records","Source":"./module","Dir":"module"},{"Key":"","Source":"","Dir":"."}]}

--- a/integrationtest/inspection/eval-on-root-context/.tflint.hcl
+++ b/integrationtest/inspection/eval-on-root-context/.tflint.hcl
@@ -1,0 +1,3 @@
+plugin "testing" {
+  enabled = true
+}

--- a/integrationtest/inspection/eval-on-root-context/module.tf
+++ b/integrationtest/inspection/eval-on-root-context/module.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = "www.example.com"
+  type    = "A"
+  ttl     = 300
+  records = [aws_eip.lb.public_ip]
+}
+
+module "route53_records" {
+  source = "./module"
+}

--- a/integrationtest/inspection/eval-on-root-context/module/template.tf
+++ b/integrationtest/inspection/eval-on-root-context/module/template.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_record" "help" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = "help.example.com"
+  type    = "A"
+  ttl     = 300
+  records = [aws_eip.lb.public_ip]
+}

--- a/integrationtest/inspection/eval-on-root-context/result.json
+++ b/integrationtest/inspection/eval-on-root-context/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_route53_record_eval_on_root_ctx_example",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "record name (root): \"www.example.com\"",
+      "range": {
+        "filename": "module.tf",
+        "start": {
+          "line": 3,
+          "column": 13
+        },
+        "end": {
+          "line": 3,
+          "column": 30
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/inspection/inspection_test.go
+++ b/integrationtest/inspection/inspection_test.go
@@ -152,6 +152,11 @@ func TestIntegration(t *testing.T) {
 			Command: "tflint --enable-plugin testing --format json",
 			Dir:     "enable-plugin-by-cli",
 		},
+		{
+			Name:    "eval on root context",
+			Command: "tflint --module --format json",
+			Dir:     "eval-on-root-context",
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -196,7 +196,7 @@ func (h *handler) inspect() (map[string][]lsp.Diagnostic, error) {
 			return ret, fmt.Errorf("Failed to apply config to `%s` plugin", name)
 		}
 		for _, runner := range runners {
-			err = ruleset.Check(plugin.NewGRPCServer(runner, runners[len(runners)-1], loader.Sources()))
+			err = ruleset.Check(plugin.NewGRPCServer(runner, runners[len(runners)-1], loader.Files()))
 			if err != nil {
 				return ret, fmt.Errorf("Failed to check ruleset: %w", err)
 			}

--- a/plugin/server.go
+++ b/plugin/server.go
@@ -15,12 +15,12 @@ import (
 type GRPCServer struct {
 	runner     *tflint.Runner
 	rootRunner *tflint.Runner
-	sources    map[string][]byte
+	files      map[string]*hcl.File
 }
 
 // NewGRPCServer initializes a gRPC server for plugins.
-func NewGRPCServer(runner *tflint.Runner, rootRunner *tflint.Runner, sources map[string][]byte) *GRPCServer {
-	return &GRPCServer{runner: runner, rootRunner: rootRunner, sources: sources}
+func NewGRPCServer(runner *tflint.Runner, rootRunner *tflint.Runner, files map[string]*hcl.File) *GRPCServer {
+	return &GRPCServer{runner: runner, rootRunner: rootRunner, files: files}
 }
 
 // GetModuleContent returns module content based on the passed schema and options.
@@ -37,7 +37,7 @@ func (s *GRPCServer) GetModuleContent(bodyS *hclext.BodySchema, opts sdk.GetModu
 
 // GetFile returns the hcl.File based on passed the file name.
 func (s *GRPCServer) GetFile(name string) (*hcl.File, error) {
-	return s.runner.File(name), nil
+	return s.files[name], nil
 }
 
 // GetFiles returns all hcl.File in the module.

--- a/plugin/stub-generator/sources/testing/main.go
+++ b/plugin/stub-generator/sources/testing/main.go
@@ -18,6 +18,7 @@ func main() {
 				rules.NewAwsS3BucketExampleLifecycleRuleRule(),
 				rules.NewAwsInstanceMapEvalExampleRule(),
 				rules.NewAwsS3BucketWithConfigExampleRule(),
+				rules.NewAwsRoute53RecordEvalOnRootCtxExampleRule(),
 			},
 		},
 	})

--- a/plugin/stub-generator/sources/testing/rules/aws_route53_record_eval_on_root_ctx_example.go
+++ b/plugin/stub-generator/sources/testing/rules/aws_route53_record_eval_on_root_ctx_example.go
@@ -1,0 +1,71 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// AwsRoute53RecordEvalOnRootCtxExampleRule checks whether ...
+type AwsRoute53RecordEvalOnRootCtxExampleRule struct {
+	tflint.DefaultRule
+}
+
+// NewAwsRoute53RecordEvalOnRootCtxExampleRule returns a new rule
+func NewAwsRoute53RecordEvalOnRootCtxExampleRule() *AwsRoute53RecordEvalOnRootCtxExampleRule {
+	return &AwsRoute53RecordEvalOnRootCtxExampleRule{}
+}
+
+// Name returns the rule name
+func (r *AwsRoute53RecordEvalOnRootCtxExampleRule) Name() string {
+	return "aws_route53_record_eval_on_root_ctx_example"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsRoute53RecordEvalOnRootCtxExampleRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsRoute53RecordEvalOnRootCtxExampleRule) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsRoute53RecordEvalOnRootCtxExampleRule) Link() string {
+	return ""
+}
+
+// Check checks whether ...
+func (r *AwsRoute53RecordEvalOnRootCtxExampleRule) Check(runner tflint.Runner) error {
+	resources, err := runner.GetResourceContent("aws_route53_record", &hclext.BodySchema{
+		Attributes: []hclext.AttributeSchema{{Name: "name"}},
+	}, &tflint.GetModuleContentOption{ModuleCtx: tflint.RootModuleCtxType})
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		attribute, exists := resource.Body.Attributes["name"]
+		if !exists {
+			continue
+		}
+
+		var name string
+		err := runner.EvaluateExpr(attribute.Expr, &name, &tflint.EvaluateExprOption{ModuleCtx: tflint.RootModuleCtxType})
+
+		err = runner.EnsureNoError(err, func() error {
+			return runner.EmitIssue(
+				r,
+				fmt.Sprintf("record name (root): %#v", name),
+				attribute.Expr.Range(),
+			)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/terraform/parser.go
+++ b/terraform/parser.go
@@ -160,6 +160,13 @@ func (p *Parser) Sources() map[string][]byte {
 	return p.p.Sources()
 }
 
+// Files returns a map of the cached HCL file objects for all files that
+// have been loaded through this parser, with source filenames (as requested
+// when each file was opened) as the keys.
+func (p *Parser) Files() map[string]*hcl.File {
+	return p.p.Files()
+}
+
 // ConfigDirFiles returns lists of the primary and override files configuration
 // files in the given directory.
 //

--- a/tflint/loader.go
+++ b/tflint/loader.go
@@ -25,6 +25,7 @@ type AbstractLoader interface {
 	LoadAnnotations(string) (map[string]Annotations, error)
 	LoadValuesFiles(...string) ([]terraform.InputValues, error)
 	Sources() map[string][]byte
+	Files() map[string]*hcl.File
 }
 
 // Loader is a wrapper of Terraform's configload.Loader
@@ -167,6 +168,10 @@ func (l *Loader) LoadValuesFiles(files ...string) ([]terraform.InputValues, erro
 
 func (l *Loader) Sources() map[string][]byte {
 	return l.tfparser.Sources()
+}
+
+func (l *Loader) Files() map[string]*hcl.File {
+	return l.tfparser.Files()
 }
 
 // autoLoadValuesFiles returns all files which match *.auto.tfvars present in the current directory

--- a/tflint/loader_mock.go
+++ b/tflint/loader_mock.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v2 "github.com/hashicorp/hcl/v2"
 	terraform "github.com/terraform-linters/tflint/terraform"
 )
 
@@ -32,6 +33,20 @@ func NewMockAbstractLoader(ctrl *gomock.Controller) *MockAbstractLoader {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAbstractLoader) EXPECT() *MockAbstractLoaderMockRecorder {
 	return m.recorder
+}
+
+// Files mocks base method.
+func (m *MockAbstractLoader) Files() map[string]*v2.File {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Files")
+	ret0, _ := ret[0].(map[string]*v2.File)
+	return ret0
+}
+
+// Files indicates an expected call of Files.
+func (mr *MockAbstractLoaderMockRecorder) Files() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Files", reflect.TypeOf((*MockAbstractLoader)(nil).Files))
 }
 
 // LoadAnnotations mocks base method.


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1468

https://github.com/terraform-linters/tflint/pull/1428 caused the gRPC server to only return files within the same module for `GetFile` requests. However, some examples of evaluating expressions in the root context may refer to files from other modules (especially the root module). From the above, the `GetFile` endpoint should be able to return all files regardless of module context.

In this PR, instead of returning the runner's parsed files (files in modules), return all the files loaded by the Loader. This allows `GetFile` to return arbitrary files regardless of module context.