### PR TITLE
Remove `--loglevel` CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Application Options:
       --force                                                   Return zero exit status even if issues found
       --color                                                   Enable colorized output
       --no-color                                                Disable colorized output
-      --loglevel=[trace|debug|info|warn|error]                  Change the loglevel
 
 Help Options:
   -h, --help                                                    Show this help message

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -64,11 +64,6 @@ func (cli *CLI) Run(args []string) int {
 		cli.formatter.NoColor = true
 	}
 	level := os.Getenv("TFLINT_LOG")
-	if opts.LogLevel != "" {
-		level = opts.LogLevel
-		// Pass log level to plugin processes
-		os.Setenv("TFLINT_LOG", level)
-	}
 	log.SetOutput(&logutils.LevelFilter{
 		Levels:   []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"},
 		MinLevel: logutils.LogLevel(strings.ToUpper(level)),
@@ -168,6 +163,9 @@ func unknownOptionHandler(option string, arg flags.SplitArgument, args []string)
 	}
 	if option == "aws-access-key" || option == "aws-secret-key" || option == "aws-profile" || option == "aws-creds-file" || option == "aws-region" {
 		return []string{}, fmt.Errorf("`%s` option was removed in v0.23.0. AWS rules are provided by the AWS plugin, so please configure the plugin instead", option)
+	}
+	if option == "loglevel" {
+		return []string{}, errors.New("`loglevel` option was removed in v0.40.0. Please set `TFLINT_LOG` environment variables instead")
 	}
 	return []string{}, fmt.Errorf("`%s` is unknown option. Please run `tflint --help`", option)
 }

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -25,7 +25,6 @@ type Options struct {
 	Force              bool     `long:"force" description:"Return zero exit status even if issues found"`
 	Color              bool     `long:"color" description:"Enable colorized output"`
 	NoColor            bool     `long:"no-color" description:"Disable colorized output"`
-	LogLevel           string   `long:"loglevel" description:"Change the loglevel" choice:"trace" choice:"debug" choice:"info" choice:"warn" choice:"error"`
 	ActAsBundledPlugin bool     `long:"act-as-bundled-plugin" hidden:"true"`
 }
 

--- a/integrationtest/cli/cli_test.go
+++ b/integrationtest/cli/cli_test.go
@@ -155,6 +155,13 @@ func TestIntegration(t *testing.T) {
 			stderr:  "`aws-region` option was removed in v0.23.0. AWS rules are provided by the AWS plugin, so please configure the plugin instead",
 		},
 		{
+			name:    "removed `--loglevel` option",
+			command: "./tflint --loglevel debug",
+			dir:     "no_issues",
+			status:  cmd.ExitCodeError,
+			stderr:  "`loglevel` option was removed in v0.40.0. Please set `TFLINT_LOG` environment variables instead",
+		},
+		{
 			name:    "invalid options",
 			command: "./tflint --unknown",
 			dir:     "no_issues",


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/1070

TFLint launches plugins as separate processes, so when setting log levels, an easy way to share between processes is to set an environment variable. As a matter of fact, currently, the log output is different depending on the setting with `--loglevel` and the setting with the `TFLINT_LOG` environment variable:

**TFLINT_LOG**

```
% cd integrationtest/inspection/basic
% TFLINT_LOG=trace tflint
15:18:12 config.go:115: [INFO] Load config: .tflint.hcl
15:18:12 config.go:242: [DEBUG] Config loaded
15:18:12 config.go:243: [DEBUG]   Module: false
15:18:12 config.go:244: [DEBUG]   Force: false
15:18:12 config.go:245: [DEBUG]   IgnoreModules:
15:18:12 config.go:249: [DEBUG]   Varfiles:
15:18:12 config.go:250: [DEBUG]   Variables:

...<snip>...

15:18:12 provider.go:92: [INFO]   5 default rules enabled
15:18:12 terraform_deprecated_interpolation.go:48: [TRACE] Check `terraform_deprecated_interpolation` rule for `root` runne
r
15:18:12 terraform_empty_list_equality.go:46: [TRACE] Check `terraform_empty_list_equality` rule for `root` runner
15:18:12 terraform_module_pinned_source.go:61: [TRACE] Check `terraform_module_pinned_source` rule for `root` runner
15:18:12 terraform_module_version.go:58: [TRACE] Check `terraform_module_version` rule for `root` runner
15:18:12 terraform_workspace_remote.go:50: [TRACE] Check `terraform_workspace_remote` rule for `root` runner
15:18:12 [DEBUG] host2plugin/client.go:101: starting host-side gRPC server
15:18:12 [DEBUG] runtime/asm_amd64.s:1571: tflint-ruleset-testing: 15:18:12 [TRACE] interceptor/logging.go:15: gRPC request
: direction=host2plugin method=/proto.RuleSet/Check req=runner:1
15:18:12 [TRACE] interceptor/logging.go:15: gRPC request: direction=plugin2host method=/proto.Runner/GetModuleContent req="
schema:{blocks:{type:\"resource\"  label_names:\"type\"  label_names:\"name\"  body:{attributes:{name:\"tags\"}}}}  option:
{module_ctx:MODULE_CTX_TYPE_SELF  hint:{resource_type:\"aws_autoscaling_group\"}}"
15:18:12 [TRACE] interceptor/logging.go:15: gRPC request: direction=plugin2host method=/proto.Runner/GetModuleContent req="
schema:{blocks:{type:\"resource\"  label_names:\"type\"  label_names:\"name\"  body:{attributes:{name:\"name\"}}}}  option:
{module_ctx:MODULE_CTX_TYPE_SELF  hint:{resource_type:\"aws_iam_policy\"}  include_not_created:true}"
15:18:12 [TRACE] interceptor/logging.go:15: gRPC request: direction=plugin2host method=/proto.Runner/GetModuleContent req="
schema:{blocks:{type:\"resource\"  label_names:\"type\"  label_names:\"name\"  body:{attributes:{name:\"instance_type\"}}}}
  option:{module_ctx:MODULE_CTX_TYPE_SELF  hint:{resource_type:\"aws_instance\"}}"
15:18:12 [TRACE] interceptor/logging.go:15: gRPC request: direction=plugin2host method=/proto.Runner/GetFile req="name:\"te
mplate.tf\""

...<snip>...

15:18:12 [TRACE] interceptor/logging.go:15: gRPC request: direction=plugin2host method=/proto.Runner/GetModuleContent req="schema:{blocks:{type:\"resource\"  label_names:\"type\"  label_names:\"name\"  body:{attributes:{name:\"tags\"}}}}  option:{module_ctx:MODULE_CTX_TYPE_SELF  hint:{resource_type:\"aws_instance\"}}"
1 issue(s) found:

Error: instance type is t2.micro (aws_instance_example_type)

  on template.tf line 2:
   2:   instance_type = "t2.micro"

15:18:12 [DEBUG] runtime/asm_amd64.s:1571: tflint-ruleset-testing: 15:18:12 [TRACE] interceptor/logging.go:15: gRPC request: direction=host2plugin method=/plugin.GRPCController/Shutdown req=
15:18:12 [DEBUG] runtime/asm_amd64.s:1571: stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: read unix @->/tmp/plugin3188026334: read: connection reset by peer"
15:18:12 [INFO]  runtime/asm_amd64.s:1571: plugin process exited: path=/home/codespace/.tflint.d/plugins/tflint-ruleset-testing pid=32007
15:18:12 [DEBUG] plugin/plugin.go:26: plugin exited
```

**--loglevel**

```
% cd integrationtest/inspection/basic
% tflint --loglevel trace
15:20:39 config.go:115: [INFO] Load config: .tflint.hcl
15:20:39 config.go:242: [DEBUG] Config loaded
15:20:39 config.go:243: [DEBUG]   Module: false
15:20:39 config.go:244: [DEBUG]   Force: false
15:20:39 config.go:245: [DEBUG]   IgnoreModules:
15:20:39 config.go:249: [DEBUG]   Varfiles:
15:20:39 config.go:250: [DEBUG]   Variables:

...<snip>...

15:20:39 provider.go:92: [INFO]   5 default rules enabled
15:20:39 terraform_deprecated_interpolation.go:48: [TRACE] Check `terraform_deprecated_interpolation` rule for `root` runner
15:20:39 terraform_empty_list_equality.go:46: [TRACE] Check `terraform_empty_list_equality` rule for `root` runner
15:20:39 terraform_module_pinned_source.go:61: [TRACE] Check `terraform_module_pinned_source` rule for `root` runner
15:20:39 terraform_module_version.go:58: [TRACE] Check `terraform_module_version` rule for `root` runner
15:20:39 terraform_workspace_remote.go:50: [TRACE] Check `terraform_workspace_remote` rule for `root` runner
15:20:39 runner.go:424: [INFO] template.tf:7,19-29 (aws_instance_example_type) is ignored by annotation:aws_instance_example_type (template.tf:6,3-7,1)
1 issue(s) found:

Error: instance type is t2.micro (aws_instance_example_type)

  on template.tf line 2:
   2:   instance_type = "t2.micro"

```

I don't know why there is this difference, but I think it's better in a term of maintainability to simply remove the option, as mentioned in #1070.