### PR TITLE
Add a notice about verification of keyless signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ gpg --verify checksum.txt.sig checksum.txt
 sha256sum --ignore-missing -c checksums.txt
 ```
 
-Cosign
+Cosign (experimental)
 
 ```
 cosign verify-blob --cert checksums.txt.pem --signature checksums.txt.keyless.sig --certificate-github-workflow-repository=terraform-linters/tflint checksums.txt
 sha256sum --ignore-missing -c checksums.txt
 ```
+
+**IMPORTANT:** Keyless Signing is in development and you should not completely trust this way. For instance, you have not validated the certificate chain against the Fulcio root trust, so it is not guaranteed to be the public key issued by the maintainers.
 
 ### Docker
 


### PR DESCRIPTION
Verification by Cosign is not perfect. Currently, the `cosign verify-blob` command does not verify the certificate chain against the Fulcio root trust, so the attacker can replace `checksum.txt`, `checksum.txt.keyless.sig`, and `checksum.txt.pem`.

This way is the same as distributing a different public key for each release and having users download it. That is, verifiers must find a way to safely get `checksum.txt.pem` (in a different way than `checksum.txt`).