### PR TITLE
Ignore invalid references in referencesInExpr

### DIFF
--- a/rules/terraformrules/terraform_unused_declaration.go
+++ b/rules/terraformrules/terraform_unused_declaration.go
@@ -132,13 +132,7 @@ func (r *TerraformUnusedDeclarationsRule) declarations(runner *tflint.Runner) (*
 }
 
 func (r *TerraformUnusedDeclarationsRule) checkForRefsInExpr(expr hcl.Expression, decl *declarations) error {
-	refs, diags := referencesInExpr(expr)
-	if diags.HasErrors() {
-		log.Printf("[DEBUG] Cannot find references in expression, ignoring: %v", diags)
-		return nil
-	}
-
-	for _, ref := range refs {
+	for _, ref := range referencesInExpr(expr) {
 		switch sub := ref.subject.(type) {
 		case inputVariableReference:
 			delete(decl.Variables, sub.name)

--- a/rules/terraformrules/terraform_workspace_remote.go
+++ b/rules/terraformrules/terraform_workspace_remote.go
@@ -92,12 +92,7 @@ func (r *TerraformWorkspaceRemoteRule) checkForTerraformWorkspaceInExpr(runner *
 		return nil
 	}
 
-	refs, diags := referencesInExpr(expr)
-	if diags.HasErrors() {
-		return diags
-	}
-
-	for _, ref := range refs {
+	for _, ref := range referencesInExpr(expr) {
 		switch sub := ref.subject.(type) {
 		case terraformReference:
 			if sub.name == "workspace" {

--- a/rules/terraformrules/terraform_workspace_remote_test.go
+++ b/rules/terraformrules/terraform_workspace_remote_test.go
@@ -236,6 +236,24 @@ resource "aws_instance" "foo" {
 				},
 			},
 		},
+		{
+			Name: "with ignore_changes",
+			Content: `
+terraform {
+  backend "remote" {}
+}
+
+resource "kubernetes_secret" "my_secret" {
+  data = {}
+
+  lifecycle {
+    ignore_changes = [
+      data
+    ]
+  }
+}`,
+			Expected: tflint.Issues{},
+		},
 	}
 
 	rule := NewTerraformWorkspaceRemoteRule()


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1474

All expressions are now handled by `WalkExpressions` in #1432, so there are cases where reference parsing fails. For example, `ignore_changes` contains various keywords, which are invalid references.

Often these keywords are not expected and are ignored by `referencesInExpr`. However, if the name conflicts with an existing reference such as `data` or `terraform`, it may be misidentified as a valid reference and fail to parse.

This PR changes it so that it doesn't return diagnostics if it fails to parse, even for valid references like `data` and `terraform`. This might make it impossible to detect errors in valid references, but checking references is not the responsibility of this rule, so it makes sense to ignore them here.