### PR TITLE
plugin: Make GetRuleConfigContent doesn't return an error even if config not found

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/sourcegraph/jsonrpc2 v0.1.0
 	github.com/spf13/afero v1.9.2
-	github.com/terraform-linters/tflint-plugin-sdk v0.11.1-0.20220806124604-77ef4504052f
+	github.com/terraform-linters/tflint-plugin-sdk v0.11.1-0.20220812135228-391859ca83f5
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.10.0
 	github.com/zclconf/go-cty-yaml v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/terraform-linters/tflint-plugin-sdk v0.11.1-0.20220806124604-77ef4504052f h1:lhrE318Jy4OlkeO/Y5s8CH58TmqpzSW506E/vToKY9g=
-github.com/terraform-linters/tflint-plugin-sdk v0.11.1-0.20220806124604-77ef4504052f/go.mod h1:g5BTK4enaWI/EPr2qWfRDJU/Qqnu84Y33JTETyVxxMA=
+github.com/terraform-linters/tflint-plugin-sdk v0.11.1-0.20220812135228-391859ca83f5 h1:U90aIT3pRv9zDCf1aIWclXyRnjIILe6BvrDDywrGBMo=
+github.com/terraform-linters/tflint-plugin-sdk v0.11.1-0.20220812135228-391859ca83f5/go.mod h1:g5BTK4enaWI/EPr2qWfRDJU/Qqnu84Y33JTETyVxxMA=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/integrationtest/inspection/enable-config-rule-by-cli/.tflint.hcl
+++ b/integrationtest/inspection/enable-config-rule-by-cli/.tflint.hcl
@@ -1,0 +1,3 @@
+plugin "testing" {
+  enabled = true
+}

--- a/integrationtest/inspection/enable-config-rule-by-cli/main.tf
+++ b/integrationtest/inspection/enable-config-rule-by-cli/main.tf
@@ -1,0 +1,3 @@
+resource "aws_db_instance" "main" {
+  name = "staging"
+}

--- a/integrationtest/inspection/enable-config-rule-by-cli/result.json
+++ b/integrationtest/inspection/enable-config-rule-by-cli/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_db_instance_with_default_config_example",
+        "severity": "warning",
+        "link": ""
+      },
+      "message": "DB name is staging, config=default",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 2,
+          "column": 10
+        },
+        "end": {
+          "line": 2,
+          "column": 19
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/inspection/inspection_test.go
+++ b/integrationtest/inspection/inspection_test.go
@@ -93,6 +93,11 @@ func TestIntegration(t *testing.T) {
 			Dir:     "enable-required-config-rule-by-cli",
 		},
 		{
+			Name:    "enable rule which does not have required configuration by CLI options",
+			Command: "./tflint --format json --enable-rule aws_db_instance_with_default_config_example",
+			Dir:     "enable-config-rule-by-cli",
+		},
+		{
 			Name:    "heredoc",
 			Command: "./tflint --format json",
 			Dir:     "heredoc",
@@ -146,6 +151,16 @@ func TestIntegration(t *testing.T) {
 			Name:    "rule config with --only",
 			Command: "tflint --only aws_s3_bucket_with_config_example --format json",
 			Dir:     "rule-config",
+		},
+		{
+			Name:    "rule config without required attributes",
+			Command: "tflint --format json",
+			Dir:     "rule-required-config",
+		},
+		{
+			Name:    "rule config without optional attributes",
+			Command: "tflint --format json",
+			Dir:     "rule-optional-config",
 		},
 		{
 			Name:    "enable plugin by CLI",

--- a/integrationtest/inspection/rule-optional-config/.tflint.hcl
+++ b/integrationtest/inspection/rule-optional-config/.tflint.hcl
@@ -1,0 +1,7 @@
+plugin "testing" {
+  enabled = true
+}
+
+rule "aws_db_instance_with_default_config_example" {
+  enabled = true
+}

--- a/integrationtest/inspection/rule-optional-config/main.tf
+++ b/integrationtest/inspection/rule-optional-config/main.tf
@@ -1,0 +1,3 @@
+resource "aws_db_instance" "main" {
+  name = "staging"
+}

--- a/integrationtest/inspection/rule-optional-config/result.json
+++ b/integrationtest/inspection/rule-optional-config/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_db_instance_with_default_config_example",
+        "severity": "warning",
+        "link": ""
+      },
+      "message": "DB name is staging, config=default",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 2,
+          "column": 10
+        },
+        "end": {
+          "line": 2,
+          "column": 19
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/inspection/rule-required-config/.tflint.hcl
+++ b/integrationtest/inspection/rule-required-config/.tflint.hcl
@@ -1,0 +1,7 @@
+plugin "testing" {
+  enabled = true
+}
+
+rule "aws_s3_bucket_with_config_example" {
+  enabled = true
+}

--- a/integrationtest/inspection/rule-required-config/result.json
+++ b/integrationtest/inspection/rule-required-config/result.json
@@ -1,0 +1,9 @@
+{
+  "issues": [],
+  "errors": [
+    {
+      "message": "Failed to check ruleset; Failed to check `aws_s3_bucket_with_config_example` rule: .tflint.hcl:5,42-42: Missing required argument; The argument \"name\" is required, but no definition was found.",
+      "severity": "error"
+    }
+  ]
+}

--- a/plugin/server_test.go
+++ b/plugin/server_test.go
@@ -303,16 +303,24 @@ rule "test_in_file" {
 					Attributes: []hclext.AttributeSchema{{Name: "foo"}},
 				}
 			},
-			Want: nil,
-			ErrCheck: func(err error) bool {
-				return err == nil || err.Error() != "rule `not_found` is not found in config"
-			},
+			Want:     &hclext.BodyContent{},
+			ErrCheck: neverHappend,
 		},
 		{
-			Name: "get rule enabled by CLI",
+			Name: "get rule enabled by CLI without required attribute",
 			Args: func() (string, *hclext.BodySchema) {
 				return "test_in_cli", &hclext.BodySchema{
 					Attributes: []hclext.AttributeSchema{{Name: "foo"}},
+				}
+			},
+			Want:     &hclext.BodyContent{Blocks: hclext.Blocks{}, Attributes: hclext.Attributes{}},
+			ErrCheck: neverHappend,
+		},
+		{
+			Name: "get rule enabled by CLI with required attribute",
+			Args: func() (string, *hclext.BodySchema) {
+				return "test_in_cli", &hclext.BodySchema{
+					Attributes: []hclext.AttributeSchema{{Name: "foo", Required: true}},
 				}
 			},
 			Want: nil,

--- a/plugin/stub-generator/sources/testing/main.go
+++ b/plugin/stub-generator/sources/testing/main.go
@@ -19,6 +19,7 @@ func main() {
 				rules.NewAwsInstanceMapEvalExampleRule(),
 				rules.NewAwsS3BucketWithConfigExampleRule(),
 				rules.NewAwsRoute53RecordEvalOnRootCtxExampleRule(),
+				rules.NewAwsDBInstanceWithDefaultConfigExampleRule(),
 			},
 		},
 	})

--- a/plugin/stub-generator/sources/testing/rules/aws_db_instance_with_default_config_example.go
+++ b/plugin/stub-generator/sources/testing/rules/aws_db_instance_with_default_config_example.go
@@ -1,0 +1,80 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// AwsDBInstanceWithDefaultConfigExampleRule checks whether ...
+type AwsDBInstanceWithDefaultConfigExampleRule struct {
+	tflint.DefaultRule
+}
+
+type awsDBInstanceWithDefaultConfigExampleRule struct {
+	Name string `hclext:"name,optional"`
+}
+
+// NewAwsDBInstanceWithDefaultConfigExampleRule returns a new rule
+func NewAwsDBInstanceWithDefaultConfigExampleRule() *AwsDBInstanceWithDefaultConfigExampleRule {
+	return &AwsDBInstanceWithDefaultConfigExampleRule{}
+}
+
+// Name returns the rule name
+func (r *AwsDBInstanceWithDefaultConfigExampleRule) Name() string {
+	return "aws_db_instance_with_default_config_example"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsDBInstanceWithDefaultConfigExampleRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsDBInstanceWithDefaultConfigExampleRule) Severity() tflint.Severity {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *AwsDBInstanceWithDefaultConfigExampleRule) Link() string {
+	return ""
+}
+
+// Check checks whether ...
+func (r *AwsDBInstanceWithDefaultConfigExampleRule) Check(runner tflint.Runner) error {
+	config := awsDBInstanceWithDefaultConfigExampleRule{Name: "default"}
+	if err := runner.DecodeRuleConfig(r.Name(), &config); err != nil {
+		return err
+	}
+
+	resources, err := runner.GetResourceContent("aws_db_instance", &hclext.BodySchema{
+		Attributes: []hclext.AttributeSchema{{Name: "name"}},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		attribute, exists := resource.Body.Attributes["name"]
+		if !exists {
+			continue
+		}
+
+		var name string
+		err := runner.EvaluateExpr(attribute.Expr, &name, nil)
+
+		err = runner.EnsureNoError(err, func() error {
+			return runner.EmitIssue(
+				r,
+				fmt.Sprintf("DB name is %s, config=%s", name, config.Name),
+				attribute.Expr.Range(),
+			)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/plugin/stub-generator/sources/testing/rules/aws_s3_bucket_with_config_example.go
+++ b/plugin/stub-generator/sources/testing/rules/aws_s3_bucket_with_config_example.go
@@ -28,7 +28,7 @@ func (r *AwsS3BucketWithConfigExampleRule) Name() string {
 
 // Enabled returns whether the rule is enabled by default
 func (r *AwsS3BucketWithConfigExampleRule) Enabled() bool {
-	return false
+	return true
 }
 
 // Severity returns the rule severity


### PR DESCRIPTION
Currently, The `GetRuleConfigContent` returns an error when the passed rule config is not found. However, this behavior is inconvenient when calling `DecodeRuleConfig` on rules with default config.

If the rule config is not found, the rule should just adopt the default config, but `DecodeRuleConfig` will fail because `GetRuleConfigContent` will return an error. In order to properly adopt the default config in this situation, you must correctly handle the "rule config not found" error returned by `GetRuleConfigContent`.

This PR changes the behavior of the `GetRuleConfigContent` API to simply return an empty body if the rule config is not found. This allows the caller of `DecodeRuleConfig` to not care whether the rule config exists.

Be careful with the behavior when there are required attributes. It will behave like this:

- If the rule config does not exist, no error will be returned even if the rule has required attributes.
  - This behavior contradicts the name of the "required" attribute, but here we interpret it as "required if a config exists". Rules must be implemented taking into account that required attributes are not necessarily set. If you want to avoid that, disable the rule by default.
  - Previously, it always returns an error.
- Rules with required attributes will fail if the rule is enabled via the CLI, such as the `--enable-rule` option.
  - This is because if a user explicitly enables it, not properly passing the required config is likely to cause unexpected behavior.
  - Previously, GetRuleConfigContent called for a rule that enabled by CLI would return an error, regardless of whether the config was required or not.
- If a rule is enabled in the config file, it will fail if the required attributes are not set.

This behavior is expected to be guaranteed by E2E testing. This behavior is the same as the old `DecodeRuleConfig`:
https://github.com/terraform-linters/tflint/blob/v0.39.3/tflint/runner.go#L391-L408
