### PR TITLE
formatter(compact): print `hcl.Diagnostics` errors in compact format

### DIFF
--- a/formatter/compact.go
+++ b/formatter/compact.go
@@ -32,12 +32,13 @@ func (f *Formatter) compactPrint(issues tflint.Issues, appErr error, sources map
 			for _, diag := range diags {
 				fmt.Fprintf(
 					f.Stdout,
-					"%s:%d:%d: %s - %s\n",
+					"%s:%d:%d: %s - %s. %s\n",
 					diag.Subject.Filename,
 					diag.Subject.Start.Line,
 					diag.Subject.Start.Column,
 					fromHclSeverity(diag.Severity),
 					diag.Summary,
+					diag.Detail,
 				)
 			}
 

--- a/formatter/compact_test.go
+++ b/formatter/compact_test.go
@@ -49,7 +49,7 @@ test.tf:1:1: Error - test (test_rule)
 		{
 			Name:   "diagnostics",
 			Error:  hclDiags(`resource "foo" "bar" {`),
-			Stdout: "main.tf:1:22: error - Unclosed configuration block\n",
+			Stdout: "main.tf:1:22: error - Unclosed configuration block. There is no closing brace for this block before the end of the file. This may be caused by incorrect brace nesting elsewhere in this file.\n",
 		},
 	}
 
@@ -61,11 +61,11 @@ test.tf:1:1: Error - test (test_rule)
 		formatter.compactPrint(tc.Issues, tc.Error, map[string][]byte{})
 
 		if stdout.String() != tc.Stdout {
-			t.Fatalf("Failed %s test: expected=%s, stdout=%s", tc.Name, tc.Stdout, stdout.String())
+			t.Errorf("Failed %s test: expected=%s, stdout=%s", tc.Name, tc.Stdout, stdout.String())
 		}
 
 		if stderr.String() != tc.Stderr {
-			t.Fatalf("Failed %s test: expected=%s, stderr=%s", tc.Name, tc.Stderr, stderr.String())
+			t.Errorf("Failed %s test: expected=%s, stderr=%s", tc.Name, tc.Stderr, stderr.String())
 		}
 	}
 }


### PR DESCRIPTION
When `--formatter compact` is set and an error occurs that is/wraps `hcl.Diagnostics`, print each diagnostic in a format similar to the format used for issues raised by rules. In an environment like GitHub Actions where output is matched and associated with lines in a PR, this could help show syntax errors that prevented TFLint's execution in the context that triggered them.

The JSON and Sarif formatters similarly handle `hcl.Diagnostics` and while there's not much boilerplate more code could definitely be shared among the formatters in the future.

Closes #1461 