### PR TITLE
build: Improve Go workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,20 +25,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
-    - id: cache-paths
-      name: Get cache paths
-      run: |
-        echo "::set-output name=go-cache::$(go env GOCACHE)"
-        echo "::set-output name=go-mod-cache::$(go env GOMODCACHE)"
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ${{ steps.cache-paths.outputs.go-cache }}
-          ${{ steps.cache-paths.outputs.go-mod-cache }}
-        key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        go-version-file: 'go.mod'
+        cache: true
     - name: Run test
       run: make test
     - name: Run build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,19 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
-    - id: cache-paths
-      name: Get cache paths
-      run: |
-        echo "::set-output name=go-cache::$(go env GOCACHE)"
-        echo "::set-output name=go-mod-cache::$(go env GOMODCACHE)"
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ${{ steps.cache-paths.outputs.go-cache }}
-          ${{ steps.cache-paths.outputs.go-mod-cache }}
-        key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        go-version-file: 'go.mod'
+        cache: true
     - name: Run e2e
       run: make e2e

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,20 +13,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
-    - id: cache-paths
-      name: Get cache paths
-      run: |
-        echo "::set-output name=go-cache::$(go env GOCACHE)"
-        echo "::set-output name=go-mod-cache::$(go env GOMODCACHE)"
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ${{ steps.cache-paths.outputs.go-cache }}
-          ${{ steps.cache-paths.outputs.go-mod-cache }}
-        key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        go-version-file: 'go.mod'
+        cache: true
     - run: go generate ./...
     - run: git add --intent-to-add .
     - run: git diff --exit-code

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: 'go.mod'
     - name: goreleaser check
       uses: goreleaser/goreleaser-action@v3
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: 'go.mod'
     - name: Run linters
       uses: golangci/golangci-lint-action@v3.2.0
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version-file: 'go.mod'
     - name: Install Cosign
       uses: sigstore/cosign-installer@v2.5.0
       with:


### PR DESCRIPTION
This PR switches the Go version declaration in each workflow file to `go-version-file`.
https://github.com/actions/setup-go/pull/62

Additionally, enable the `cache` option to remove the dependency of actions/cache
https://github.com/actions/setup-go/pull/228