### PR TITLE
Revert "Add a notice about verification of keyless signing"

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,12 @@ gpg --verify checksum.txt.sig checksum.txt
 sha256sum --ignore-missing -c checksums.txt
 ```
 
-Cosign (experimental)
+Cosign
 
 ```
 cosign verify-blob --cert checksums.txt.pem --signature checksums.txt.keyless.sig --certificate-github-workflow-repository=terraform-linters/tflint checksums.txt
 sha256sum --ignore-missing -c checksums.txt
 ```
-
-**IMPORTANT:** Keyless Signing is in development and you should not completely trust this way. For instance, you have not validated the certificate chain against the Fulcio root trust, so it is not guaranteed to be the public key issued by the maintainers.
 
 ### Docker
 


### PR DESCRIPTION
Reverts terraform-linters/tflint#1472

Cosign v1.11 now verifies the certificate chain by default when passing the `--cert` option. 
https://github.com/sigstore/cosign/pull/2139

The certificate must be generated on the GitHub Actions workflow of the `terraform-linters/tflint` repository, otherwise an error will occur for the malformed certificate. This leaves no room for spoofing the public key in a verification flow using Cosign.

The only attack surface is for an attacker to take control of this repository, delete existing releases, and recreate releases, which should be sufficiently difficult compared to traditional attack ways.