### PR TITLE
annotations: allow ignoring multiple rules

### DIFF
--- a/docs/user-guide/annotations.md
+++ b/docs/user-guide/annotations.md
@@ -9,4 +9,20 @@ resource "aws_instance" "foo" {
 }
 ```
 
-The annotation works only for the same line or the line below it. You can also use `tflint-ignore: all` if you want to ignore all the rules.
+Multiple rules can be specified as a comma-separated list:
+
+```hcl
+resource "aws_instance" "foo" {
+    # tflint-ignore: aws_instance_invalid_type, other_rule
+    instance_type = "t1.2xlarge"
+}
+```
+
+All rules can be ignored by specifying the `all` keyword:
+
+```hcl
+resource "aws_instance" "foo" {
+    # tflint-ignore: all
+    instance_type = "t1.2xlarge"
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	go.opencensus.io v0.22.5 // indirect
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect

--- a/go.sum
+++ b/go.sum
@@ -324,6 +324,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/tflint/annotation.go
+++ b/tflint/annotation.go
@@ -3,8 +3,10 @@ package tflint
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"golang.org/x/exp/slices"
 )
 
 var annotationPattern = regexp.MustCompile(`tflint-ignore: (\S+)`)
@@ -45,7 +47,13 @@ func (a *Annotation) IsAffected(issue *Issue) bool {
 	if a.Token.Range.Filename != issue.Range.Filename {
 		return false
 	}
-	if a.Content == issue.Rule.Name() || a.Content == "all" {
+
+	rules := strings.Split(a.Content, ",")
+	for i, rule := range rules {
+		rules[i] = strings.TrimSpace(rule)
+	}
+
+	if slices.Contains(rules, issue.Rule.Name()) || slices.Contains(rules, "all") {
 		if a.Token.Range.Start.Line == issue.Range.Start.Line {
 			return true
 		}

--- a/tflint/annotation_test.go
+++ b/tflint/annotation_test.go
@@ -122,6 +122,34 @@ func Test_IsAffected(t *testing.T) {
 			Expected: true,
 		},
 		{
+			Name: "affected (multiple rules)",
+			Annotation: Annotation{
+				Content: "other_rule, test_rule",
+				Token: hclsyntax.Token{
+					Type: hclsyntax.TokenComment,
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2},
+					},
+				},
+			},
+			Expected: true,
+		},
+		{
+			Name: "not affected (multiple rules)",
+			Annotation: Annotation{
+				Content: "other_rule_a, other_rule_b",
+				Token: hclsyntax.Token{
+					Type: hclsyntax.TokenComment,
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2},
+					},
+				},
+			},
+			Expected: false,
+		},
+		{
 			Name: "not affected (under line)",
 			Annotation: Annotation{
 				Content: "test_rule",


### PR DESCRIPTION
Allows annotations to specify multiple rules to ignore, separated by commas and optional whitespace. 

Closes #1488