### PR TITLE
plugin: Fix an error when evaluating sensitive values

### DIFF
--- a/integrationtest/inspection/inspection_test.go
+++ b/integrationtest/inspection/inspection_test.go
@@ -172,6 +172,11 @@ func TestIntegration(t *testing.T) {
 			Command: "tflint --module --format json",
 			Dir:     "eval-on-root-context",
 		},
+		{
+			Name:    "sensitve variable",
+			Command: "tflint --format json",
+			Dir:     "sensitive",
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/integrationtest/inspection/sensitive/.tflint.hcl
+++ b/integrationtest/inspection/sensitive/.tflint.hcl
@@ -1,0 +1,3 @@
+plugin "testing" {
+  enabled = true
+}

--- a/integrationtest/inspection/sensitive/main.tf
+++ b/integrationtest/inspection/sensitive/main.tf
@@ -1,0 +1,17 @@
+variable "sensitive" {
+  sensitive = true
+  default   = "t2.micro"
+}
+
+variable "non_sensitive" {
+  sensitive = false
+  default   = "t2.micro"
+}
+
+resource "aws_instance" "sensitive" {
+  instance_type = var.sensitive
+}
+
+resource "aws_instance" "non_sensitive" {
+  instance_type = var.non_sensitive
+}

--- a/integrationtest/inspection/sensitive/result.json
+++ b/integrationtest/inspection/sensitive/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is t2.micro",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 16,
+          "column": 19
+        },
+        "end": {
+          "line": 16,
+          "column": 36
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/tflint/runner_eval.go
+++ b/tflint/runner_eval.go
@@ -16,8 +16,18 @@ import (
 )
 
 // EvaluateExpr is a wrapper of terraform.BultinEvalContext.EvaluateExpr
-// In addition, it returns an error if expr cannot be evaluated, if it contains an unknown value,
-// or if it contains null. However, it allows null and unknown only for DynamicPseudoType.
+// However, unlike the original implementation, it returns an error instead of
+// returning the values below:
+//
+// - Unevaluable values (e.g. `module.<MODULE_NAME>`, `data.<DATA TYPE>.<NAME>`, `each.key`)
+// - Unknown values
+// - Null values
+//
+// An error is returned if these values are contained. This ensures that
+// the caller can get the value via `gocty.FromCtyValue` unless an error occurs.
+//
+// As an exception, only unknown and null values can be returned as values by specifying
+// `cty.DynamicPseudoType` for the type.
 func (r *Runner) EvaluateExpr(expr hcl.Expression, wantType cty.Type) (cty.Value, error) {
 	evaluable, err := isEvaluableExpr(expr)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1457
See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/174

When evaluating a variable with `sensitive = true`, TFLint fails with the following error:

```
Failed to check ruleset; Failed to check `aws_instance_previous_type` rule: value has marks, so it cannot be serialized
```

This happens because sensitive values are implemented as cty marked values. Marked values will cause an error when encoded in the message pack format to respond to plugins.

https://github.com/terraform-linters/tflint-plugin-sdk/blob/v0.11.0/plugin/plugin2host/server.go#L132
https://github.com/zclconf/go-cty/blob/v1.11.0/cty/msgpack/marshal.go#L45-L47

This behavior works very well with sensitive values and avoids unintentional disclosure unless explicitly unmarked.

In this PR, to prevent unintentional disclosure of sensitive values,  return an error and stop evaluation instead of unmarking sensitive values.
