### PR TITLE
build: Use default cosign version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
         go-version-file: 'go.mod'
     - name: Install Cosign
       uses: sigstore/cosign-installer@v2.5.1
-      with:
-        cosign-release: 'v1.10.0'
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v3
       with:


### PR DESCRIPTION
The current default is v1.10.1
https://github.com/sigstore/cosign-installer/blob/v2.5.1/action.yml#L13