### PR TITLE
Ignore default preset by disabled_by_default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install:
 	go install
 
 e2e: prepare install
-	go test -timeout 5m ./integrationtest/inspection ./integrationtest/langserver ./integrationtest/init ./integrationtest/cli
+	go test -timeout 5m ./integrationtest/inspection ./integrationtest/langserver ./integrationtest/init ./integrationtest/cli ./integrationtest/bundled
 
 lint:
 	golangci-lint run ./...

--- a/integrationtest/bundled/bundled_test.go
+++ b/integrationtest/bundled/bundled_test.go
@@ -41,6 +41,11 @@ func TestIntegration(t *testing.T) {
 			command: "tflint --format json --force",
 			dir:     "with_config",
 		},
+		{
+			name:    "disabled_by_default",
+			command: "tflint --format json --force",
+			dir:     "disabled_by_default",
+		},
 	}
 
 	dir, _ := os.Getwd()

--- a/integrationtest/bundled/disabled_by_default/.tflint.hcl
+++ b/integrationtest/bundled/disabled_by_default/.tflint.hcl
@@ -1,0 +1,7 @@
+config {
+  disabled_by_default = true
+}
+
+rule "terraform_unused_declarations" {
+  enabled = true
+}

--- a/integrationtest/bundled/disabled_by_default/main.tf
+++ b/integrationtest/bundled/disabled_by_default/main.tf
@@ -1,0 +1,6 @@
+variable "unused" {}
+variable "used" {}
+
+resource "aws_instance" "main" {
+  instance_type = "${var.used}"
+}

--- a/integrationtest/bundled/disabled_by_default/result.json
+++ b/integrationtest/bundled/disabled_by_default/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "terraform_unused_declarations",
+        "severity": "warning",
+        "link": "https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.1.0/docs/rules/terraform_unused_declarations.md"
+      },
+      "message": "variable \"unused\" is declared but not used",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -301,6 +301,11 @@ func (c *Config) enableBundledPlugin() *Config {
 			Enabled: true,
 			Body:    f.Body,
 		}
+
+		// Implicit preset is ignored if you enable DisabledByDefault
+		if c.DisabledByDefault {
+			c.Plugins["terraform"].Body = nil
+		}
 	}
 	return c
 }


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint/issues/1513#issuecomment-1246414828

If the `terraform` plugin block is not declared in the config file, the "recommended" preset is applied implicitly. The `preset` config takes precedence over `disabled_by_default` declared in the config file, so counterintuitively, preset rules are not disabled.

This PR ignores the implicit default preset when `disabled_by_default` is enabled. This will prevent the preset from being applied.