### PR TITLE
Update Terraform compatibility notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TFLint
 [![Build Status](https://github.com/terraform-linters/tflint/workflows/build/badge.svg?branch=master)](https://github.com/terraform-linters/tflint/actions)
 [![GitHub release](https://img.shields.io/github/release/terraform-linters/tflint.svg)](https://github.com/terraform-linters/tflint/releases/latest)
-[![Terraform Compatibility](https://img.shields.io/badge/terraform-%3E%3D%200.12-blue)](docs/user-guide/compatibility.md)
+[![Terraform Compatibility](https://img.shields.io/badge/terraform-%3E%3D%201.0-blue)](docs/user-guide/compatibility.md)
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-blue.svg)](LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/terraform-linters/tflint)](https://goreportcard.com/report/github.com/terraform-linters/tflint)
 [![Homebrew](https://img.shields.io/badge/dynamic/json.svg?url=https://formulae.brew.sh/api/formula/tflint.json&query=$.versions.stable&label=homebrew)](https://formulae.brew.sh/formula/tflint)
@@ -157,9 +157,6 @@ Note that if you want to recursively inspect local modules, you need to run them
 
 ### Do I need to install Terraform for TFLint to work?
 No. TFLint works as a single binary because Terraform is embedded as a library. Note that this means that the version of Terraform used is determined for each TFLint version. See also [Compatibility with Terraform](docs/user-guide/compatibility.md).
-
-### TFLint reports a loading error in my code, but this is valid in Terraform. Why?
-First, check the version of Terraform and TFLint you are using. TFLint loads files differently than the installed Terraform, so an error can occur if the version of Terraform supported by TFLint is different from the installed Terraform.
 
 ## Debugging
 

--- a/docs/user-guide/compatibility.md
+++ b/docs/user-guide/compatibility.md
@@ -1,14 +1,12 @@
 # Compatibility with Terraform
 
-TFLint bundles Terraform internal packages as a library. This allows the Terraform language to be parsed correctly even if Terraform is not installed at runtime.
+TFLint interprets the [Terraform language](https://www.terraform.io/language) with its own parser which is a fork of the Terraform's native one. This allows it to be parsed correctly even if Terraform is not installed at runtime.
 
-On the other hand, language semantics depend on the behavior of a particular bundled version. For example, a configuration parsed by Terraform v1.0 may be parsed by v1.1 language parser. The currently bundled version is v1.2.1.
-
-The best practice is to match the Terraform version bundled with TFLint to the version you actually use. However, the Terraform language guarantees some backward compatibility, so different versions may not cause immediate problems. However, keep in mind that false positives/negatives can occur depending on this assumption.
+The parser supports Terraform v1.x syntax and semantics. The language compatibility on Terraform v1.x is defined by [Compatibility Promises](https://www.terraform.io/language/v1-compatibility-promises). TFLint follows this promise. New features are only supported in newer TFLint versions, and bug and experimental features compatibility are not guaranteed.
 
 ## Input Variables
 
-Like Terraform, it supports the `--var`,` --var-file` options, environment variables (`TF_VAR_*`), and automatically loading variable definitions (`terraform.tfvars` and `*.auto.tfvars`) files. See [Input Variables](https://www.terraform.io/docs/language/values/variables.html).
+Like Terraform, TFLint supports the `--var`,` --var-file` options, environment variables (`TF_VAR_*`), and automatically loading variable definitions (`terraform.tfvars` and `*.auto.tfvars`) files. See [Input Variables](https://www.terraform.io/language/values/variables).
 
 Input variables are evaluated correctly, just like Terraform:
 
@@ -22,9 +20,11 @@ resource "aws_instance" "foo" {
 }
 ```
 
+Sensitive variables are ignored without being evaluated. This is to avoid unintended disclosure.
+
 ## Named Values
 
-[Named values](https://www.terraform.io/docs/configuration/expressions/references.html) are supported partially. The following named values are available:
+[Named values](https://www.terraform.io/language/expressions/references) are supported partially. The following named values are available:
 
 - `var.<NAME>`
 - `path.module`
@@ -32,7 +32,7 @@ resource "aws_instance" "foo" {
 - `path.cwd`
 - `terraform.workspace`
 
-Expressions that reference named values not included above (e.g. `locals.*`, `count.*`, `each.*`, etc.) are excluded from the inspection.
+Expressions containing unsupported named values (e.g. `local.*`, `count.index`, `each.key`) are simply ignored when evaluated.
 
 ```hcl
 locals {
@@ -46,12 +46,12 @@ resource "aws_instance" "foo" {
 
 ## Built-in Functions
 
-[Built-in Functions](https://www.terraform.io/docs/configuration/functions.html) are fully supported.
+[Built-in Functions](https://www.terraform.io/language/functions) are fully supported.
 
 ## Environment Variables
 
 The following environment variables are supported:
 
-- [TF_VAR_name](https://www.terraform.io/docs/commands/environment-variables.html#tf_var_name)
-- [TF_DATA_DIR](https://www.terraform.io/docs/commands/environment-variables.html#tf_data_dir)
-- [TF_WORKSPACE](https://www.terraform.io/docs/commands/environment-variables.html#tf_workspace)
+- [TF_VAR_name](https://www.terraform.io/cli/config/environment-variables#tf_var_name)
+- [TF_DATA_DIR](https://www.terraform.io/cli/config/environment-variables#tf_data_dir)
+- [TF_WORKSPACE](https://www.terraform.io/cli/config/environment-variables#tf_workspace)


### PR DESCRIPTION
TFLint now uses a fork instead of a specific version of Terraform internal packages. This PR updates the compatibility guide according to this fact.