### PR TITLE
plugin: Add support for schema mode

### DIFF
--- a/integrationtest/inspection/inspection_test.go
+++ b/integrationtest/inspection/inspection_test.go
@@ -178,6 +178,11 @@ func TestIntegration(t *testing.T) {
 			Command: "tflint --format json",
 			Dir:     "sensitive",
 		},
+		{
+			Name:    "just attributes",
+			Command: "tflint --format json",
+			Dir:     "just-attributes",
+		},
 	}
 
 	// Disable the bundled plugin because the `os.Executable()` is go(1) in the tests

--- a/integrationtest/inspection/just-attributes/.tflint.hcl
+++ b/integrationtest/inspection/just-attributes/.tflint.hcl
@@ -1,0 +1,3 @@
+plugin "testing" {
+  enabled = true
+}

--- a/integrationtest/inspection/just-attributes/result.json
+++ b/integrationtest/inspection/just-attributes/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "locals_just_attributes_example",
+        "severity": "info",
+        "link": ""
+      },
+      "message": "found 3 local values",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/inspection/just-attributes/template.tf
+++ b/integrationtest/inspection/just-attributes/template.tf
@@ -1,0 +1,5 @@
+locals {
+  foo = "foo"
+  bar = "bar"
+  just_attributes = "just_attributes"
+}

--- a/plugin/stub-generator/sources/testing/main.go
+++ b/plugin/stub-generator/sources/testing/main.go
@@ -21,6 +21,7 @@ func main() {
 				rules.NewAwsRoute53RecordEvalOnRootCtxExampleRule(),
 				rules.NewAwsDBInstanceWithDefaultConfigExampleRule(),
 				rules.NewAwsCloudFormationStackErrorRule(),
+				rules.NewLocalsJustAttributesExampleRule(),
 			},
 		},
 	})

--- a/plugin/stub-generator/sources/testing/rules/locals_just_attributes_example_rule.go
+++ b/plugin/stub-generator/sources/testing/rules/locals_just_attributes_example_rule.go
@@ -1,0 +1,61 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// LocalsJustAttributesExampleRule checks whether ...
+type LocalsJustAttributesExampleRule struct {
+	tflint.DefaultRule
+}
+
+// LocalsJustAttributesExampleRule returns a new rule
+func NewLocalsJustAttributesExampleRule() *LocalsJustAttributesExampleRule {
+	return &LocalsJustAttributesExampleRule{}
+}
+
+// Name returns the rule name
+func (r *LocalsJustAttributesExampleRule) Name() string {
+	return "locals_just_attributes_example"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *LocalsJustAttributesExampleRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *LocalsJustAttributesExampleRule) Severity() tflint.Severity {
+	return tflint.NOTICE
+}
+
+// Link returns the rule reference link
+func (r *LocalsJustAttributesExampleRule) Link() string {
+	return ""
+}
+
+// Check checks whether ...
+func (r *LocalsJustAttributesExampleRule) Check(runner tflint.Runner) error {
+	body, err := runner.GetModuleContent(&hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{
+				Type: "locals",
+				Body: &hclext.BodySchema{Mode: hclext.SchemaJustAttributesMode},
+			},
+		},
+	}, nil)
+	if err != nil || len(body.Blocks) == 0 {
+		return err
+	}
+
+	locals := body.Blocks[0]
+
+	if _, exists := locals.Body.Attributes["just_attributes"]; !exists {
+		return nil
+	}
+
+	return runner.EmitIssue(r, fmt.Sprintf("found %d local values", len(locals.Body.Attributes)), locals.DefRange)
+}

--- a/terraform/module_test.go
+++ b/terraform/module_test.go
@@ -113,6 +113,38 @@ resource "aws_instance" "foo" {
 			},
 		},
 		{
+			name: "just attributes",
+			files: map[string]string{
+				"main.tf": `
+locals {
+  foo = "foo"
+  bar = "bar"
+}`,
+			},
+			schema: &hclext.BodySchema{
+				Blocks: []hclext.BlockSchema{
+					{
+						Type: "locals",
+						Body: &hclext.BodySchema{Mode: hclext.SchemaJustAttributesMode},
+					},
+				},
+			},
+			want: &hclext.BodyContent{
+				Blocks: hclext.Blocks{
+					{
+						Type: "locals",
+						Body: &hclext.BodyContent{
+							Attributes: hclext.Attributes{
+								"foo": &hclext.Attribute{Name: "foo", Range: hcl.Range{Filename: "main.tf"}},
+								"bar": &hclext.Attribute{Name: "bar", Range: hcl.Range{Filename: "main.tf"}},
+							},
+						},
+						DefRange: hcl.Range{Filename: "main.tf"},
+					},
+				},
+			},
+		},
+		{
 			name: "contains not created resource",
 			files: map[string]string{
 				"main.tf": `


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/201

This PR adds support for schema mode added by https://github.com/terraform-linters/tflint-plugin-sdk/pull/201. Actually, this support has already been merged in https://github.com/terraform-linters/tflint/pull/1525, so this PR adds tests to guarantee this support.