### PR TITLE
chore: improve installation script

### DIFF
--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -51,7 +51,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        apk add bash curl unzip
+        apk add bash curl unzip coreutils
     - name: Install latest version
       run: |
         ./install_linux.sh


### PR DESCRIPTION
Verify checksum via `sha256sum` by default but can be skipped when`SKIP_VERIFY_CHECKSUM` is set to `yes` or `y`.

This provides flexibility to verify the checksum while not enforced and failed if the sha256sum doesn't exist.