### PR TITLE
plugin: Allow plugins to set TFLint version constraints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/sourcegraph/jsonrpc2 v0.1.0
 	github.com/spf13/afero v1.9.2
-	github.com/terraform-linters/tflint-plugin-sdk v0.13.1-0.20221002072010-eed3c184986c
+	github.com/terraform-linters/tflint-plugin-sdk v0.13.1-0.20221007143453-76cc99146499
 	github.com/terraform-linters/tflint-ruleset-terraform v0.1.1
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.11.0
@@ -34,6 +34,7 @@ require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
 	golang.org/x/text v0.3.7
+	google.golang.org/grpc v1.49.0
 )
 
 require (
@@ -77,7 +78,6 @@ require (
 	google.golang.org/api v0.40.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210226172003-ab064af71705 // indirect
-	google.golang.org/grpc v1.49.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/terraform-linters/tflint-plugin-sdk v0.13.1-0.20221002072010-eed3c184986c h1:db9cn98nR42OxoirkmtWiL2B/hUAqJMKtbTdIuzNuek=
-github.com/terraform-linters/tflint-plugin-sdk v0.13.1-0.20221002072010-eed3c184986c/go.mod h1:BWxrWRnzU+wQddNnsY4HGDEVBNLhVzQZZU8tCoRYxVI=
+github.com/terraform-linters/tflint-plugin-sdk v0.13.1-0.20221007143453-76cc99146499 h1:4abfVUQM2L3teOoJE7asKqzkG/NLvX+F2xuWpqaTeG8=
+github.com/terraform-linters/tflint-plugin-sdk v0.13.1-0.20221007143453-76cc99146499/go.mod h1:oYEwDLOQrn3mIUQwiyXPBOnTqO1DcvRPnl/zOqHNu8A=
 github.com/terraform-linters/tflint-ruleset-terraform v0.1.1 h1:dAi25kUMZ3+c1aiQZlP+ifxXnRv+WNpSVSMBroUxeOI=
 github.com/terraform-linters/tflint-ruleset-terraform v0.1.1/go.mod h1:+iOphcKeOXXNPqjc3STxHvJ+4km5y8Zo+qqqPLgqFFw=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=

--- a/integrationtest/inspection/incompatible-host/.tflint.hcl
+++ b/integrationtest/inspection/incompatible-host/.tflint.hcl
@@ -1,0 +1,3 @@
+plugin "incompatiblehost" {
+  enabled = true
+}

--- a/integrationtest/inspection/incompatible-host/result.json
+++ b/integrationtest/inspection/incompatible-host/result.json
@@ -1,0 +1,9 @@
+{
+  "issues": [],
+  "errors": [
+    {
+      "message": "Failed to satisfy version constraints; tflint-ruleset-incompatiblehost requires >= 1.0, but TFLint version is 0.41.0",
+      "severity": "error"
+    }
+  ]
+}

--- a/integrationtest/inspection/inspection_test.go
+++ b/integrationtest/inspection/inspection_test.go
@@ -183,6 +183,11 @@ func TestIntegration(t *testing.T) {
 			Command: "tflint --format json",
 			Dir:     "just-attributes",
 		},
+		{
+			Name:    "incompatible host version",
+			Command: "tflint --format json",
+			Dir:     "incompatible-host",
+		},
 	}
 
 	// Disable the bundled plugin because the `os.Executable()` is go(1) in the tests

--- a/plugin/stub-generator/main.go
+++ b/plugin/stub-generator/main.go
@@ -36,6 +36,7 @@ func main() {
 	execCommand("mkdir", "-p", pluginDir)
 	execCommand("go", "build", "-o", pluginDir+"/tflint-ruleset-testing"+fileExt(), "./sources/testing/main.go")
 	execCommand("go", "build", "-o", pluginDir+"/tflint-ruleset-customrulesettesting"+fileExt(), "./sources/customrulesettesting/main.go")
+	execCommand("go", "build", "-o", pluginDir+"/tflint-ruleset-incompatiblehost"+fileExt(), "./sources/incompatiblehost/main.go")
 	execCommand("go", "build", "-o", "../../integrationtest/inspection/plugin/.tflint.d/plugins/tflint-ruleset-example"+fileExt(), "./sources/example/main.go")
 }
 

--- a/plugin/stub-generator/sources/incompatiblehost/main.go
+++ b/plugin/stub-generator/sources/incompatiblehost/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/terraform-linters/tflint-plugin-sdk/plugin"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		RuleSet: &tflint.BuiltinRuleSet{
+			Name:       "incompatiblehost",
+			Version:    "0.1.0",
+			Constraint: ">= 1.0",
+		},
+	})
+}

--- a/tflint/meta.go
+++ b/tflint/meta.go
@@ -1,9 +1,13 @@
 package tflint
 
-import "fmt"
+import (
+	"fmt"
+
+	version "github.com/hashicorp/go-version"
+)
 
 // Version is application version
-const Version string = "0.41.0"
+var Version *version.Version = version.Must(version.NewVersion("0.41.0"))
 
 // ReferenceLink returns the rule reference link
 func ReferenceLink(name string) string {


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/202

Add a step to get the version constraints set by plugins and check if the TFLint version satisfies it.

Note that version constraints are only available since tflint-plugin-sdk v0.14+. Since v0.12 and v0.13 are compatible in terms of protocol versions, these versions may return an unimplemented error. In this case, skip the check and continue inspection.