### PR TITLE
Fix crash when evaluating nested sensitive values

### DIFF
--- a/integrationtest/inspection/expand/main.tf
+++ b/integrationtest/inspection/expand/main.tf
@@ -39,3 +39,12 @@ resource "aws_instance" "sensitive" {
 
   instance_type = "${count.index}.${var.sensitive}"
 }
+
+resource "aws_instance" "tags" {
+  count = 1
+
+  tags = {
+    count = count.index
+    sensitive = var.sensitive
+  }
+}

--- a/integrationtest/inspection/map-attribute/template.tf
+++ b/integrationtest/inspection/map-attribute/template.tf
@@ -1,3 +1,12 @@
 resource "aws_instance" "intance" {
   tags = { foo = "bar" }
 }
+
+variable "sensitive" {
+  sensitive = true
+  default   = "sensitive"
+}
+
+resource "aws_instance" "sensitive" {
+  tags = { foo = var.sensitive }
+}

--- a/plugin/server.go
+++ b/plugin/server.go
@@ -9,7 +9,6 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	sdk "github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/terraform-linters/tflint/terraform"
-	"github.com/terraform-linters/tflint/terraform/lang/marks"
 	"github.com/terraform-linters/tflint/tflint"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -123,7 +122,7 @@ func (s *GRPCServer) EvaluateExpr(expr hcl.Expression, opts sdk.EvaluateExprOpti
 		return val, diags
 	}
 
-	if val.HasMark(marks.Sensitive) {
+	if val.ContainsMarked() {
 		err := fmt.Errorf(
 			"sensitive value found in %s:%d%w",
 			expr.Range().Filename,

--- a/plugin/server_test.go
+++ b/plugin/server_test.go
@@ -492,6 +492,17 @@ variable "foo" {
 			},
 		},
 		{
+			Name: "sensitive value in object",
+			Args: func() (hcl.Expression, sdk.EvaluateExprOption) {
+				ty := cty.Object(map[string]cty.Type{"value": cty.String})
+				return hclExpr(`{ value = var.sensitive }`), sdk.EvaluateExprOption{WantType: &ty, ModuleCtx: sdk.SelfModuleCtxType}
+			},
+			Want: cty.NullVal(cty.NilType),
+			ErrCheck: func(err error) bool {
+				return err == nil || !errors.Is(err, sdk.ErrSensitive)
+			},
+		},
+		{
 			Name: "no default",
 			Args: func() (hcl.Expression, sdk.EvaluateExprOption) {
 				return hclExpr(`var.no_default`), sdk.EvaluateExprOption{WantType: &cty.String, ModuleCtx: sdk.SelfModuleCtxType}

--- a/terraform/expandable.go
+++ b/terraform/expandable.go
@@ -111,7 +111,7 @@ func (e *expandable) expandBlockByCount(ctx *Evaluator, block *hclext.Block) (hc
 				}
 				// If marked as sensitive, the cty.Value cannot be marshaled in MessagePack,
 				// so only bind it if it is unmarked.
-				if !val.IsMarked() {
+				if !val.ContainsMarked() {
 					// Even if there is no instance key later, the evaluated result is bound to
 					// the expression so that it can be referenced by EvaluateExpr.
 					attr.Expr = hclext.BindValue(val, attr.Expr)
@@ -191,7 +191,7 @@ func (e *expandable) expandBlockByForEach(ctx *Evaluator, block *hclext.Block) (
 				}
 				// If marked as sensitive, the cty.Value cannot be marshaled in MessagePack,
 				// so only bind it if it is unmarked.
-				if !val.IsMarked() {
+				if !val.ContainsMarked() {
 					// Even if there is no instance key later, the evaluated result is bound to
 					// the expression so that it can be referenced by EvaluateExpr.
 					attr.Expr = hclext.BindValue(val, attr.Expr)

--- a/terraform/lang/funcs/conversion.go
+++ b/terraform/lang/funcs/conversion.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 
 	"github.com/terraform-linters/tflint/terraform/lang/marks"
-	"github.com/terraform-linters/tflint/terraform/lang/types"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/convert"
 	"github.com/zclconf/go-cty/cty/function"
@@ -94,28 +93,4 @@ func MakeToFunc(wantTy cty.Type) function.Function {
 			return ret, nil
 		},
 	})
-}
-
-// TypeFunc returns an encapsulated value containing its argument's type. This
-// value is marked to allow us to limit the use of this function at the moment
-// to only a few supported use cases.
-var TypeFunc = function.New(&function.Spec{
-	Params: []function.Parameter{
-		{
-			Name:             "value",
-			Type:             cty.DynamicPseudoType,
-			AllowDynamicType: true,
-			AllowUnknown:     true,
-			AllowNull:        true,
-		},
-	},
-	Type: function.StaticReturnType(types.TypeType),
-	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
-		givenType := args[0].Type()
-		return cty.CapsuleVal(types.TypeType, &givenType).Mark(marks.TypeType), nil
-	},
-})
-
-func Type(input []cty.Value) (cty.Value, error) {
-	return TypeFunc.Call(input)
 }

--- a/terraform/lang/marks/marks.go
+++ b/terraform/lang/marks/marks.go
@@ -35,8 +35,3 @@ func Contains(val cty.Value, mark valueMark) bool {
 // Sensitive indicates that this value is marked as sensitive in the context of
 // Terraform.
 const Sensitive = valueMark("Sensitive")
-
-// TypeType is used to indicate that the value contains a representation of
-// another value's type. This is part of the implementation of the console-only
-// `type` function.
-const TypeType = valueMark("TypeType")


### PR DESCRIPTION
As a limitation of go-cty, marked values cannot be serialized.
https://github.com/zclconf/go-cty/blob/v1.11.1/cty/msgpack/marshal.go#L45-L47

There are `IsMarked`/`HasMark` and `ContainMarked` methods for determining whether a value is marked, but the former cannot determine nested sensitive values such as objects. So returning a nested sensitive value will cause an error like https://github.com/terraform-linters/tflint/issues/1457.

This PR fixes it to determine with `ContainMarked` when serializing the value.