### PR TITLE
Fix incorrect circular reference detection

### DIFF
--- a/terraform/evaluator_test.go
+++ b/terraform/evaluator_test.go
@@ -587,6 +587,18 @@ locals {
 			},
 		},
 		{
+			name: "nested multiple local values",
+			config: `
+locals {
+  foo = "foo"
+  bar = [local.foo, local.foo]
+}`,
+			expr:     expr(`local.bar`),
+			ty:       cty.List(cty.String),
+			want:     `cty.ListVal([]cty.Value{cty.StringVal("foo"), cty.StringVal("foo")})`,
+			errCheck: neverHappend,
+		},
+		{
 			name:     "count.index in non-counted context",
 			expr:     expr(`count.index`),
 			ty:       cty.Number,
@@ -666,7 +678,7 @@ locals {
 				ModulePath:     config.Path.UnkeyedInstanceShim(),
 				Config:         config,
 				VariableValues: variableValues,
-				CallGraph:      NewCallGraph(),
+				CallStack:      NewCallStack(),
 			}
 
 			got, diags := evaluator.EvaluateExpr(test.expr, test.ty, test.keyData)

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -53,7 +53,7 @@ func NewRunner(c *Config, ants map[string]Annotations, cfg *terraform.Config, va
 		ModulePath:     cfg.Path.UnkeyedInstanceShim(),
 		Config:         cfg.Root,
 		VariableValues: variableValues,
-		CallGraph:      terraform.NewCallGraph(),
+		CallStack:      terraform.NewCallStack(),
 	}
 
 	runner := &Runner{


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1565

Circular reference detection released in v0.42.0 is broken. The detection logic builds a call stack and determines that it is circular-referenced if the same address appears multiple times.

This call stack should literally be the stack. It should be popped after every push instead of clearing it at the end. The current detection logic detects erroneous circular references when the same local value appears multiple times in the middle.

```mermaid
graph LR
  local.foo ---> local.bar
  local.bar ---> local.baz
  local.bar ---> local.baz
```

This PR fixes the detection logic by using the stack correctly.