### PR TITLE
Set up a security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ $ TFLINT_LOG=debug tflint
 
 See [Developer Guide](docs/developer-guide).
 
+## Security
+
+If you find a security vulnerability, please refer our [security policy](SECURITY.md).
+
 ## Stargazers over time
 
 [![Stargazers over time](https://starchart.cc/terraform-linters/tflint.svg)](https://starchart.cc/terraform-linters/tflint)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+TFLint always supports only the latest version and does not provide security updates for older versions.
+
+## Reporting a Vulnerability
+
+If you find a vulnerability, please do not report it in an issue or a discussion. You can discuss vulnerabilities internally with maintainers using [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).


### PR DESCRIPTION
Today, GitHub released [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository) 🎉 

We enable this feature in TFLint, set up a security policy, and tell users to use it to report vulnerabilities.