### PR TITLE
Add COSIGN_EXPERIMENTAL=1 flag to the verification example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sha256sum --ignore-missing -c checksums.txt
 Cosign
 
 ```
-cosign verify-blob --cert checksums.txt.pem --signature checksums.txt.keyless.sig --certificate-github-workflow-repository=terraform-linters/tflint checksums.txt
+COSIGN_EXPERIMENTAL=1 cosign verify-blob --certificate checksums.txt.pem --signature checksums.txt.keyless.sig --certificate-github-workflow-repository=terraform-linters/tflint checksums.txt
 sha256sum --ignore-missing -c checksums.txt
 ```
 


### PR DESCRIPTION
It seems that verify-blob with certificates (without chain) only works in experimental mode since some version.

If you disable experimental mode, you will get an error (Cosign v1.13.1):

```console
$ cosign verify-blob --certificate checksums.txt.pem --signature checksums.txt.keyless.sig --certificate-github-workflow-repository=terraform-linters/tflint checksums.txt
Error: verifying blob [checksums.txt]: certificate expired before signatures were entered in log: 2022-10-25T17:43:47Z is before 2022-11-14T14:28:18Z
main.go:62: error during command execution: verifying blob [checksums.txt]: certificate expired before signatures were entered in log: 2022-10-25T17:43:47Z is before 2022-11-14T14:28:18Z
```

Enabling experimental mode works fine.

```console
$ COSIGN_EXPERIMENTAL=1 cosign verify-blob --certificate checksums.txt.pem --signature checksums.txt.keyless.sig --certificate-github-workflow-repository=terraform-linters/tflint checksums.txt
tlog entry verified with uuid: 7e99747f805286e8148882307933c24cea2dfb6fbedf4de03fcdc57baf059e77 index: 5850177
Verified OK
```

This behavior seems to have changed with this commit https://github.com/sigstore/cosign/commit/80b79ed8b4d28ccbce3d279fd273606b5cddcc25
I'm not sure if this was intended, but at least this pull request documents it so I can assume it is.
https://github.com/sigstore/cosign/pull/2254

Follow this to update our documentation and tell you to enable experimental mode.