### PR TITLE
Fix panic when file read fails

### DIFF
--- a/terraform/parser.go
+++ b/terraform/parser.go
@@ -66,6 +66,9 @@ func (p *Parser) LoadConfigDir(dir string) (*Module, hcl.Diagnostics) {
 	for i, path := range primaries {
 		f, loadDiags := p.loadHCLFile(path)
 		diags = diags.Extend(loadDiags)
+		if loadDiags.HasErrors() {
+			continue
+		}
 
 		mod.primaries[i] = f
 		mod.Sources[path] = f.Bytes
@@ -74,6 +77,9 @@ func (p *Parser) LoadConfigDir(dir string) (*Module, hcl.Diagnostics) {
 	for i, path := range overrides {
 		f, loadDiags := p.loadHCLFile(path)
 		diags = diags.Extend(loadDiags)
+		if loadDiags.HasErrors() {
+			continue
+		}
 
 		mod.overrides[i] = f
 		mod.Sources[path] = f.Bytes


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/discussions/1596

Fix panic caused by nil pointer dereference when `*.tf` file fails to load.

However, this error should be rare. If the file doesn't exist, an error occurs before `loadHCLFile`, so it seems to only occur in exceptional circumstances, such as filesystem corruption.