### PR TITLE
tests: pass `$GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
         cache: true
     - name: Run test
       run: make test
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run build
       run: make build
     - name: Upload Artifact


### PR DESCRIPTION
Provides authentication when running tests in GitHub Action. Prevents flakes in plugin download tests due to rate limiting:

https://github.com/terraform-linters/tflint/actions/runs/3622249418/jobs/6106724062 (#1614)


```
--- FAIL: Test_Install (0.39s)
100
    install_test.go:26: Failed to install: Failed to download checksums.txt.sig: GET https://api.github.com/repos/terraform-linters/tflint-ruleset-aws/releases/assets/35784141: 403 API rate limit exceeded for 20.36.167.160. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 20m57s]
```