### PR TITLE
plugin: Add support for GetOriginalwd API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/sourcegraph/jsonrpc2 v0.1.0
 	github.com/spf13/afero v1.9.3
-	github.com/terraform-linters/tflint-plugin-sdk v0.14.0
+	github.com/terraform-linters/tflint-plugin-sdk v0.14.1-0.20221221150051-7dee8c751c5b
 	github.com/terraform-linters/tflint-ruleset-terraform v0.2.1
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/terraform-linters/tflint-plugin-sdk v0.14.0 h1:OxrOQGYzcaGdStGid0Uk8MPLL/rAsINPBj/YZRU2jCw=
-github.com/terraform-linters/tflint-plugin-sdk v0.14.0/go.mod h1:XTwUT3Pj5Vp2Q+XkdNeNXg51MYGU/0X3ZxAxPOzHntg=
+github.com/terraform-linters/tflint-plugin-sdk v0.14.1-0.20221221150051-7dee8c751c5b h1:JRasYEhi7MNqbW7PjX9a3OhN/bAUCNekKmjoFXNLspE=
+github.com/terraform-linters/tflint-plugin-sdk v0.14.1-0.20221221150051-7dee8c751c5b/go.mod h1:XTwUT3Pj5Vp2Q+XkdNeNXg51MYGU/0X3ZxAxPOzHntg=
 github.com/terraform-linters/tflint-ruleset-terraform v0.2.1 h1:xCBhLmRyPc0rhAD1Ar5hi1ja4ZSzMP3XEH58GBRH2vI=
 github.com/terraform-linters/tflint-ruleset-terraform v0.2.1/go.mod h1:tHCcf0QjilDhjgkbx+meSV9BAYwd3bP3s/YczupbPQM=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=

--- a/plugin/server.go
+++ b/plugin/server.go
@@ -25,6 +25,11 @@ func NewGRPCServer(runner *tflint.Runner, rootRunner *tflint.Runner, files map[s
 	return &GRPCServer{runner: runner, rootRunner: rootRunner, files: files}
 }
 
+// GetOriginalwd returns the original working directory.
+func (s *GRPCServer) GetOriginalwd() string {
+	return s.runner.Ctx.Meta.OriginalWorkingDir
+}
+
 // GetModulePath returns the current module path.
 func (s *GRPCServer) GetModulePath() []string {
 	return s.runner.TFConfig.Path


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint-plugin-sdk/pull/224

This PR adds support for GetOriginalwd API added in https://github.com/terraform-linters/tflint-plugin-sdk/pull/224.