### PR TITLE
chores: Fix flaky CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,3 +29,5 @@ jobs:
         cache: true
     - name: Run e2e
       run: make e2e
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -51,7 +51,7 @@ jobs:
       uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        apk add bash curl unzip
+        apk add bash curl curl-dev unzip
     - name: Install latest version
       run: |
         ./install_linux.sh

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -27,6 +27,8 @@ jobs:
       run: |
         ./install_linux.sh
         tflint -v
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Install specific version
       env:
         TFLINT_VERSION: v0.15.0
@@ -40,6 +42,7 @@ jobs:
         "$TFLINT_INSTALL_PATH/tflint" -v
       env:
         TFLINT_INSTALL_PATH: ${{ github.workspace }}/install-path
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: bash
   container:
     runs-on: ubuntu-latest

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -35,9 +35,13 @@ echo "os=$os"
 echo -e "\n\n===================================================="
 
 get_latest_release() {
-  curl --fail -sS "https://api.github.com/repos/terraform-linters/tflint/releases/latest" | # Get latest release from GitHub api
-    grep '"tag_name":' |                                                                  # Get tag line
-    sed -E 's/.*"([^"]+)".*/\1/'                                                          # Pluck JSON value
+  headers=()
+  if [ -n "${GITHUB_TOKEN}" ]; then
+      headers=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  fi
+  curl --fail -sS "${headers[@]}" "https://api.github.com/repos/terraform-linters/tflint/releases/latest" | # Get latest release from GitHub api
+    grep '"tag_name":' |                                                                                    # Get tag line
+    sed -E 's/.*"([^"]+)".*/\1/'                                                                            # Pluck JSON value
 }
 
 download_path=$(mktemp -d -t tflint.XXXXXXXXXX)
@@ -46,6 +50,9 @@ download_executable="${download_path}/tflint"
 
 if [ -z "${TFLINT_VERSION}" ] || [ "${TFLINT_VERSION}" == "latest" ]; then
   echo "Looking up the latest version ..."
+  if [ -n "${GITHUB_TOKEN}" ]; then
+    echo "Requesting with GITHUB_TOKEN ..."
+  fi
   version=$(get_latest_release)
 else
   version=${TFLINT_VERSION}

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -35,7 +35,7 @@ echo "os=$os"
 echo -e "\n\n===================================================="
 
 get_latest_release() {
-  curl --silent "https://api.github.com/repos/terraform-linters/tflint/releases/latest" | # Get latest release from GitHub api
+  curl --fail -sS "https://api.github.com/repos/terraform-linters/tflint/releases/latest" | # Get latest release from GitHub api
     grep '"tag_name":' |                                                                  # Get tag line
     sed -E 's/.*"([^"]+)".*/\1/'                                                          # Pluck JSON value
 }
@@ -52,14 +52,8 @@ else
 fi
 
 echo "Downloading TFLint $version"
-curl --fail --silent -L -o "${download_zip}" "https://github.com/terraform-linters/tflint/releases/download/${version}/tflint_${os}.zip"
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "Failed to download tflint_${os}.zip"
-  exit $retVal
-else
-  echo "Downloaded successfully"
-fi
+curl --fail -sS -L -o "${download_zip}" "https://github.com/terraform-linters/tflint/releases/download/${version}/tflint_${os}.zip"
+echo "Downloaded successfully"
 
 echo -e "\n\n===================================================="
 echo "Unpacking ${download_zip} ..."


### PR DESCRIPTION
A few days ago GitHub Actions started failing frequently. Although the detailed cause is unknown, it seems that the frequency of hitting the API rate limit on GitHub Actions is increasing.

In this PR, we pass `GITHUB_TOKEN` to e2e/install workflows to avoid rate-limiting. If the `GITHUB_TOKEN` is set in the install script, it will send a request with the token.

Also, there was another problem with the install script on the `hashicorp/terraform` container image. The cause of this is unknown, but it seems to be an Alpine Linux issue due to a missing curl-dev dependency. Added curl-dev and fixed the issue.