### PR TITLE
Add support for recursive init and print versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ Application Options:
       --var-file=FILE                                           Terraform variable file name
       --var='foo=bar'                                           Set a Terraform variable
       --module                                                  Inspect modules
-      --chdir=DIR                                               Switch to a different working directory before running inspection
+      --chdir=DIR                                               Switch to a different working directory before executing the command
+      --recursive                                               Run command in each directory recursively
       --force                                                   Return zero exit status even if issues found
-      --recursive                                               Inspect directories recursively
       --color                                                   Enable colorized output
       --no-color                                                Disable colorized output
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,54 +11,73 @@ import (
 )
 
 func (cli *CLI) init(opts Options) int {
-	if opts.Chdir != "" {
-		fmt.Fprintf(cli.errStream, "Cannot use --chdir with --init\n")
-		return ExitCodeError
-	}
-	if opts.Recursive {
-		fmt.Fprintf(cli.errStream, "Cannot use --recursive with --init\n")
-		return ExitCodeError
-	}
-
-	cfg, err := tflint.LoadConfig(afero.Afero{Fs: afero.NewOsFs()}, opts.Config)
+	workingDirs, err := findWorkingDirs(opts)
 	if err != nil {
-		cli.formatter.Print(tflint.Issues{}, fmt.Errorf("Failed to load TFLint config; %w", err), map[string][]byte{})
+		cli.formatter.Print(tflint.Issues{}, fmt.Errorf("Failed to find workspaces; %w", err), map[string][]byte{})
 		return ExitCodeError
 	}
 
-	for _, pluginCfg := range cfg.Plugins {
-		installCfg := plugin.NewInstallConfig(cfg, pluginCfg)
+	if opts.Recursive {
+		fmt.Fprint(cli.outStream, "Installing plugins on each working directory...\n\n")
+	}
 
-		// If version or source is not set, you need to install it manually
-		if installCfg.ManuallyInstalled() {
-			continue
-		}
-
-		_, err := plugin.FindPluginPath(installCfg)
-		if os.IsNotExist(err) {
-			fmt.Fprintf(cli.outStream, "Installing `%s` plugin...\n", pluginCfg.Name)
-
-			sigchecker := plugin.NewSignatureChecker(installCfg)
-			if !sigchecker.HasSigningKey() {
-				_, _ = color.New(color.FgYellow).Fprintln(cli.outStream, "No signing key configured. Set `signing_key` to verify that the release is signed by the plugin developer")
+	for _, wd := range workingDirs {
+		err := cli.withinChangedDir(wd, func() error {
+			if opts.Recursive {
+				fmt.Fprint(cli.outStream, "====================================================\n")
+				fmt.Fprintf(cli.outStream, "working directory: %s\n\n", wd)
 			}
 
-			_, err = installCfg.Install()
+			cfg, err := tflint.LoadConfig(afero.Afero{Fs: afero.NewOsFs()}, opts.Config)
 			if err != nil {
-				cli.formatter.Print(tflint.Issues{}, fmt.Errorf("Failed to install a plugin; %w", err), map[string][]byte{})
-				return ExitCodeError
+				return fmt.Errorf("Failed to load TFLint config; %w", err)
 			}
 
-			fmt.Fprintf(cli.outStream, "Installed `%s` (source: %s, version: %s)\n", pluginCfg.Name, pluginCfg.Source, pluginCfg.Version)
-			continue
-		}
+			found := false
+			for _, pluginCfg := range cfg.Plugins {
+				installCfg := plugin.NewInstallConfig(cfg, pluginCfg)
 
+				// If version or source is not set, you need to install it manually
+				if installCfg.ManuallyInstalled() {
+					continue
+				}
+				found = true
+
+				_, err := plugin.FindPluginPath(installCfg)
+				if os.IsNotExist(err) {
+					fmt.Fprintf(cli.outStream, "Installing `%s` plugin...\n", pluginCfg.Name)
+
+					sigchecker := plugin.NewSignatureChecker(installCfg)
+					if !sigchecker.HasSigningKey() {
+						_, _ = color.New(color.FgYellow).Fprintln(cli.outStream, "No signing key configured. Set `signing_key` to verify that the release is signed by the plugin developer")
+					}
+
+					_, err = installCfg.Install()
+					if err != nil {
+						return fmt.Errorf("Failed to install a plugin; %w", err)
+					}
+
+					fmt.Fprintf(cli.outStream, "Installed `%s` (source: %s, version: %s)\n", pluginCfg.Name, pluginCfg.Source, pluginCfg.Version)
+					continue
+				}
+
+				if err != nil {
+					return fmt.Errorf("Failed to find a plugin; %w", err)
+				}
+
+				fmt.Fprintf(cli.outStream, "Plugin `%s` is already installed\n", pluginCfg.Name)
+			}
+
+			if opts.Recursive && !found {
+				fmt.Fprint(cli.outStream, "No plugins to install\n")
+			}
+
+			return nil
+		})
 		if err != nil {
-			cli.formatter.Print(tflint.Issues{}, fmt.Errorf("Failed to find a plugin; %w", err), map[string][]byte{})
+			cli.formatter.Print(tflint.Issues{}, err, map[string][]byte{})
 			return ExitCodeError
 		}
-
-		fmt.Fprintf(cli.outStream, "Plugin `%s` is already installed\n", pluginCfg.Name)
 	}
 
 	return ExitCodeOK

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -22,8 +22,8 @@ type Options struct {
 	Varfiles           []string `long:"var-file" description:"Terraform variable file name" value-name:"FILE"`
 	Variables          []string `long:"var" description:"Set a Terraform variable" value-name:"'foo=bar'"`
 	Module             bool     `long:"module" description:"Inspect modules"`
-	Chdir              string   `long:"chdir" description:"Switch to a different working directory before running inspection" value-name:"DIR"`
-	Recursive          bool     `long:"recursive" description:"Inspect directories recursively"`
+	Chdir              string   `long:"chdir" description:"Switch to a different working directory before executing the command" value-name:"DIR"`
+	Recursive          bool     `long:"recursive" description:"Run command in each directory recursively"`
 	Force              bool     `long:"force" description:"Return zero exit status even if issues found"`
 	Color              bool     `long:"color" description:"Enable colorized output"`
 	NoColor            bool     `long:"no-color" description:"Disable colorized output"`

--- a/cmd/test-fixtures/arguments/README
+++ b/cmd/test-fixtures/arguments/README
@@ -1,1 +1,0 @@
-Hello World

--- a/cmd/test-fixtures/arguments/example/test.tf
+++ b/cmd/test-fixtures/arguments/example/test.tf
@@ -1,8 +1,0 @@
-resource "aws_instance" "backend" {
-  ami           = "ami-b73b63a0"
-  instance_type = "t1.2xlarge"
-
-  tags {
-    Name = "HelloWorld"
-  }
-}

--- a/cmd/test-fixtures/arguments/template.tf
+++ b/cmd/test-fixtures/arguments/template.tf
@@ -1,8 +1,0 @@
-resource "aws_instance" "backend" {
-  ami           = "ami-b73b63a0"
-  instance_type = "t1.2xlarge"
-
-  tags {
-    Name = "HelloWorld"
-  }
-}

--- a/cmd/test-fixtures/arguments/test.tf
+++ b/cmd/test-fixtures/arguments/test.tf
@@ -1,8 +1,0 @@
-resource "aws_instance" "web" {
-  ami           = "ami-b73b63a0"
-  instance_type = "t1.2xlarge"
-
-  tags {
-    Name = "HelloWorld"
-  }
-}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,37 +10,60 @@ import (
 )
 
 func (cli *CLI) printVersion(opts Options) int {
-	if opts.Chdir != "" {
-		fmt.Fprintf(cli.errStream, "Cannot use --chdir with --version\n")
-		return ExitCodeError
-	}
-	if opts.Recursive {
-		fmt.Fprintf(cli.errStream, "Cannot use --recursive with --version\n")
-		return ExitCodeError
-	}
-
 	fmt.Fprintf(cli.outStream, "TFLint version %s\n", tflint.Version)
 
+	workingDirs, err := findWorkingDirs(opts)
+	if err != nil {
+		cli.formatter.Print(tflint.Issues{}, fmt.Errorf("Failed to find workspaces; %w", err), map[string][]byte{})
+		return ExitCodeError
+	}
+
+	if opts.Recursive {
+		fmt.Fprint(cli.outStream, "\n")
+	}
+
+	for _, wd := range workingDirs {
+		err := cli.withinChangedDir(wd, func() error {
+			if opts.Recursive {
+				fmt.Fprint(cli.outStream, "====================================================\n")
+				fmt.Fprintf(cli.outStream, "working directory: %s\n\n", wd)
+			}
+
+			versions := getPluginVersions(opts)
+
+			for _, version := range versions {
+				fmt.Fprint(cli.outStream, version)
+			}
+			if len(versions) == 0 && opts.Recursive {
+				fmt.Fprint(cli.outStream, "No plugins\n")
+			}
+			return nil
+		})
+		if err != nil {
+			cli.formatter.Print(tflint.Issues{}, err, map[string][]byte{})
+		}
+	}
+
+	return ExitCodeOK
+}
+
+func getPluginVersions(opts Options) []string {
 	// Load configuration files to print plugin versions
 	cfg, err := tflint.LoadConfig(afero.Afero{Fs: afero.NewOsFs()}, opts.Config)
 	if err != nil {
 		log.Printf("[ERROR] Failed to load TFLint config: %s", err)
-		return ExitCodeOK
-	}
-	if len(opts.Only) > 0 {
-		for _, rule := range cfg.Rules {
-			rule.Enabled = false
-		}
+		return []string{}
 	}
 	cfg.Merge(opts.toConfig())
 
 	rulesetPlugin, err := plugin.Discovery(cfg)
 	if err != nil {
 		log.Printf("[ERROR] Failed to initialize plugins: %s", err)
-		return ExitCodeOK
+		return []string{}
 	}
 	defer rulesetPlugin.Clean()
 
+	versions := []string{}
 	for _, ruleset := range rulesetPlugin.RuleSets {
 		name, err := ruleset.RuleSetName()
 		if err != nil {
@@ -53,8 +76,8 @@ func (cli *CLI) printVersion(opts Options) int {
 			continue
 		}
 
-		fmt.Fprintf(cli.outStream, "+ ruleset.%s (%s)\n", name, version)
+		versions = append(versions, fmt.Sprintf("+ ruleset.%s (%s)\n", name, version))
 	}
 
-	return ExitCodeOK
+	return versions
 }

--- a/docs/user-guide/working-directory.md
+++ b/docs/user-guide/working-directory.md
@@ -25,3 +25,11 @@ $ tflint --recursive
 ```
 
 It takes no arguments in recursive mode. Passing a directory or file name will result in an error.
+
+These flags are also valid for `--init` and `--version`. Recursive init is required when installing required plugins all at once:
+
+```console
+$ tflint --recursive --init
+$ tflint --recursive --version
+$ tflint --recursive
+```

--- a/integrationtest/init/basic/.tflint.hcl
+++ b/integrationtest/init/basic/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "aws" {
   enabled = true
 
-  version = "0.5.0"
+  version = "0.21.1"
   source = "github.com/terraform-linters/tflint-ruleset-aws"
 }

--- a/integrationtest/init/init_test.go
+++ b/integrationtest/init/init_test.go
@@ -26,14 +26,14 @@ func TestIntegration(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	if err := os.Chdir(dir); err != nil {
-		t.Fatal(err)
-	}
-
 	pluginDir := t.TempDir()
 	os.Setenv("TFLINT_PLUGIN_DIR", pluginDir)
 	defer os.Setenv("TFLINT_PLUGIN_DIR", "")
 
+	// Init on the current directory
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
 	outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
 	cli, err := cmd.NewCLI(outStream, errStream)
 	if err != nil {
@@ -49,12 +49,74 @@ func TestIntegration(t *testing.T) {
 	if !strings.Contains(outStream.String(), "Installing `aws` plugin...") {
 		t.Fatalf("Expected to contain an installation log, but did not: stdout=%s, stderr=%s", outStream, errStream)
 	}
-	if !strings.Contains(outStream.String(), "Installed `aws` (source: github.com/terraform-linters/tflint-ruleset-aws, version: 0.5.0)") {
+	if !strings.Contains(outStream.String(), "Installed `aws` (source: github.com/terraform-linters/tflint-ruleset-aws, version: 0.21.1)") {
 		t.Fatalf("Expected to contain an installed log, but did not: stdout=%s, stderr=%s", outStream, errStream)
 	}
 
 	cli.Run([]string{"./tflint", "--init"})
 	if !strings.Contains(outStream.String(), "Plugin `aws` is already installed") {
 		t.Fatalf("Expected to contain an already installed log, but did not: stdout=%s, stderr=%s", outStream, errStream)
+	}
+
+	cli.Run([]string{"./tflint", "--version"})
+	if !strings.Contains(outStream.String(), "+ ruleset.aws (0.21.1)") {
+		t.Fatalf("Expected to contain an plugin version log, but did not: stdout=%s, stderr=%s", outStream, errStream)
+	}
+
+	// Init with --chdir
+	if err := os.Chdir(current); err != nil {
+		t.Fatal(err)
+	}
+	outStream, errStream = new(bytes.Buffer), new(bytes.Buffer)
+	cli, err = cmd.NewCLI(outStream, errStream)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli.Run([]string{"./tflint", "--chdir", "basic", "--init"})
+	if !strings.Contains(outStream.String(), "Plugin `aws` is already installed") {
+		t.Fatalf("Expected to contain an already installed log, but did not: stdout=%s, stderr=%s", outStream, errStream)
+	}
+
+	cli.Run([]string{"./tflint", "--chdir", "basic", "--version"})
+	if !strings.Contains(outStream.String(), "+ ruleset.aws (0.21.1)") {
+		t.Fatalf("Expected to contain an plugin version log, but did not: stdout=%s, stderr=%s", outStream, errStream)
+	}
+
+	// Init with --recursive
+	if err := os.Chdir(current); err != nil {
+		t.Fatal(err)
+	}
+	outStream, errStream = new(bytes.Buffer), new(bytes.Buffer)
+	cli, err = cmd.NewCLI(outStream, errStream)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli.Run([]string{"./tflint", "--recursive", "--init"})
+	if !strings.Contains(outStream.String(), "working directory: .") {
+		t.Fatalf("Expected to contain working dir log, but did not: stdout=%s, stderr=%s", outStream, errStream)
+	}
+	if !strings.Contains(outStream.String(), "No plugins to install") {
+		t.Fatalf("Expected to contain no plugins log, but did not: stdout=%s, stderr=%s", outStream, errStream)
+	}
+	if !strings.Contains(outStream.String(), "working directory: basic") {
+		t.Fatalf("Expected to contain working dir log, but did not: stdout=%s, stderr=%s", outStream, errStream)
+	}
+	if !strings.Contains(outStream.String(), "Plugin `aws` is already installed") {
+		t.Fatalf("Expected to contain an already installed log, but did not: stdout=%s, stderr=%s", outStream, errStream)
+	}
+
+	outStream, errStream = new(bytes.Buffer), new(bytes.Buffer)
+	cli, err = cmd.NewCLI(outStream, errStream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cli.Run([]string{"./tflint", "--recursive", "--version"})
+	if !strings.Contains(outStream.String(), "working directory: basic") {
+		t.Fatalf("Expected to contain working dir log, but did not: stdout=%s, stderr=%s", outStream, errStream)
+	}
+	if !strings.Contains(outStream.String(), "+ ruleset.aws (0.21.1)") {
+		t.Fatalf("Expected to contain an plugin version log, but did not: stdout=%s, stderr=%s", outStream, errStream)
 	}
 }


### PR DESCRIPTION
Follow up of https://github.com/terraform-linters/tflint/pull/1622

This PR changes `--init` and `--version` to support the `--recursive` option. As a result `--chdir` is also supported:

```console
$ tflint --recursive --init
Installing plugins on each working directory...

====================================================
working directory: .

Plugin `aws` is already installed
====================================================
working directory: sub1

No plugins to install
====================================================
working directory: sub2

No plugins to install
====================================================
working directory: sub3

No plugins to install
====================================================
working directory: sub3/sub

No plugins to install

$ tflint --recursive --version
TFLint version 0.43.0

====================================================
working directory: .

+ ruleset.aws (0.21.1)
+ ruleset.terraform (0.2.1-bundled)
====================================================
working directory: sub1

+ ruleset.terraform (0.2.1-bundled)
====================================================
working directory: sub2

+ ruleset.terraform (0.2.1-bundled)
====================================================
working directory: sub3

+ ruleset.terraform (0.2.1-bundled)
====================================================
working directory: sub3/sub

+ ruleset.terraform (0.2.1-bundled)
```

This is a missing piece for the recursive inspection introduced in https://github.com/terraform-linters/tflint/pull/1622. The recursive inspection will load each directory's config, so you'll need to `tflint --init` in each directory. The `tflint --recursive --init` solves this.