### PR TITLE
Fix path.module when using --chdir/--recursive

### DIFF
--- a/integrationtest/inspection/chdir/dir/main.tf
+++ b/integrationtest/inspection/chdir/dir/main.tf
@@ -17,5 +17,5 @@ variable "from_auto_default" {
 module "aws_instance" {
   source = "./module"
 
-  instance_type = "${var.from_config}-${var.from_cli}-${var.from_auto}-${var.from_auto_default}-${file("dir.txt")}-${file("${path.cwd}/root.txt")}"
+  instance_type = "${var.from_config}-${var.from_cli}-${var.from_auto}-${var.from_auto_default}-${file("dir.txt")}-${file("${path.cwd}/root.txt")}-${file("${path.module}/module.txt")}-${file("${path.root}/module.txt")}"
 }

--- a/integrationtest/inspection/chdir/dir/module.txt
+++ b/integrationtest/inspection/chdir/dir/module.txt
@@ -1,0 +1,1 @@
+file_in_module

--- a/integrationtest/inspection/chdir/result.json
+++ b/integrationtest/inspection/chdir/result.json
@@ -6,7 +6,7 @@
         "severity": "error",
         "link": ""
       },
-      "message": "instance type is from_config-from_cli-from_auto-from_auto_default-file_in_dir-file_in_root",
+      "message": "instance type is from_config-from_cli-from_auto-from_auto_default-file_in_dir-file_in_root-file_in_module-file_in_module",
       "range": {
         "filename": "dir/main.tf",
         "start": {
@@ -15,7 +15,7 @@
         },
         "end": {
           "line": 20,
-          "column": 148
+          "column": 220
         }
       },
       "callers": [
@@ -27,7 +27,7 @@
           },
           "end": {
             "line": 20,
-            "column": 148
+            "column": 220
           }
         },
         {

--- a/integrationtest/inspection/chdir/result_windows.json
+++ b/integrationtest/inspection/chdir/result_windows.json
@@ -6,7 +6,7 @@
         "severity": "error",
         "link": ""
       },
-      "message": "instance type is from_config-from_cli-from_auto-from_auto_default-file_in_dir-file_in_root",
+      "message": "instance type is from_config-from_cli-from_auto-from_auto_default-file_in_dir-file_in_root-file_in_module-file_in_module",
       "range": {
         "filename": "dir\\main.tf",
         "start": {
@@ -15,7 +15,7 @@
         },
         "end": {
           "line": 20,
-          "column": 148
+          "column": 220
         }
       },
       "callers": [
@@ -27,7 +27,7 @@
           },
           "end": {
             "line": 20,
-            "column": 148
+            "column": 220
           }
         },
         {

--- a/terraform/loader_test.go
+++ b/terraform/loader_test.go
@@ -30,48 +30,48 @@ func TestLoadConfig_v0_15_0(t *testing.T) {
 		// module.instance
 		testChildModule(t, config, "instance", "ec2")
 		// module.consul
-		testChildModule(t, config, "consul", filepath.Join(".terraform", "modules", "consul"))
+		testChildModule(t, config, "consul", ".terraform/modules/consul")
 		// module.consul.module.consul_clients
 		testChildModule(
 			t,
 			config.Children["consul"],
 			"consul_clients",
-			filepath.Join(".terraform", "modules", "consul", "modules", "consul-cluster"),
+			".terraform/modules/consul/modules/consul-cluster",
 		)
 		// module.consul.module.consul_clients.module.iam_policies
 		testChildModule(
 			t,
 			config.Children["consul"].Children["consul_clients"],
 			"iam_policies",
-			filepath.Join(".terraform", "modules", "consul", "modules", "consul-iam-policies"),
+			".terraform/modules/consul/modules/consul-iam-policies",
 		)
 		// module.consul.module.consul_clients.module.security_group_rules
 		testChildModule(
 			t,
 			config.Children["consul"].Children["consul_clients"],
 			"security_group_rules",
-			filepath.Join(".terraform", "modules", "consul", "modules", "consul-security-group-rules"),
+			".terraform/modules/consul/modules/consul-security-group-rules",
 		)
 		// module.consul.module.consul_servers
 		testChildModule(
 			t,
 			config.Children["consul"],
 			"consul_servers",
-			filepath.Join(".terraform", "modules", "consul", "modules", "consul-cluster"),
+			".terraform/modules/consul/modules/consul-cluster",
 		)
 		// module.consul.module.consul_servers.module.iam_policies
 		testChildModule(
 			t,
 			config.Children["consul"].Children["consul_servers"],
 			"iam_policies",
-			filepath.Join(".terraform", "modules", "consul", "modules", "consul-iam-policies"),
+			".terraform/modules/consul/modules/consul-iam-policies",
 		)
 		// module.consul.module.consul_servers.module.security_group_rules
 		testChildModule(
 			t,
 			config.Children["consul"].Children["consul_servers"],
 			"security_group_rules",
-			filepath.Join(".terraform", "modules", "consul", "modules", "consul-security-group-rules"),
+			".terraform/modules/consul/modules/consul-security-group-rules",
 		)
 	})
 }
@@ -89,54 +89,54 @@ func TestLoadConfig_v0_15_0_withBaseDir(t *testing.T) {
 		}
 
 		// root
-		if config.Module.SourceDir != "v0.15.0_module" {
-			t.Fatalf("root module path: want=%s, got=%s", "v0.15.0_module", config.Module.SourceDir)
+		if config.Module.SourceDir != "." {
+			t.Fatalf("root module path: want=%s, got=%s", ".", config.Module.SourceDir)
 		}
 		// module.instance
-		testChildModule(t, config, "instance", filepath.Join("v0.15.0_module", "ec2"))
+		testChildModule(t, config, "instance", "ec2")
 		// module.consul
-		testChildModule(t, config, "consul", filepath.Join("v0.15.0_module", ".terraform", "modules", "consul"))
+		testChildModule(t, config, "consul", ".terraform/modules/consul")
 		// module.consul.module.consul_clients
 		testChildModule(
 			t,
 			config.Children["consul"],
 			"consul_clients",
-			filepath.Join("v0.15.0_module", ".terraform", "modules", "consul", "modules", "consul-cluster"),
+			".terraform/modules/consul/modules/consul-cluster",
 		)
 		// module.consul.module.consul_clients.module.iam_policies
 		testChildModule(
 			t,
 			config.Children["consul"].Children["consul_clients"],
 			"iam_policies",
-			filepath.Join("v0.15.0_module", ".terraform", "modules", "consul", "modules", "consul-iam-policies"),
+			".terraform/modules/consul/modules/consul-iam-policies",
 		)
 		// module.consul.module.consul_clients.module.security_group_rules
 		testChildModule(
 			t,
 			config.Children["consul"].Children["consul_clients"],
 			"security_group_rules",
-			filepath.Join("v0.15.0_module", ".terraform", "modules", "consul", "modules", "consul-security-group-rules"),
+			".terraform/modules/consul/modules/consul-security-group-rules",
 		)
 		// module.consul.module.consul_servers
 		testChildModule(
 			t,
 			config.Children["consul"],
 			"consul_servers",
-			filepath.Join("v0.15.0_module", ".terraform", "modules", "consul", "modules", "consul-cluster"),
+			".terraform/modules/consul/modules/consul-cluster",
 		)
 		// module.consul.module.consul_servers.module.iam_policies
 		testChildModule(
 			t,
 			config.Children["consul"].Children["consul_servers"],
 			"iam_policies",
-			filepath.Join("v0.15.0_module", ".terraform", "modules", "consul", "modules", "consul-iam-policies"),
+			".terraform/modules/consul/modules/consul-iam-policies",
 		)
 		// module.consul.module.consul_servers.module.security_group_rules
 		testChildModule(
 			t,
 			config.Children["consul"].Children["consul_servers"],
 			"security_group_rules",
-			filepath.Join("v0.15.0_module", ".terraform", "modules", "consul", "modules", "consul-security-group-rules"),
+			".terraform/modules/consul/modules/consul-security-group-rules",
 		)
 	})
 }

--- a/terraform/parser.go
+++ b/terraform/parser.go
@@ -56,7 +56,8 @@ func NewParser(fs afero.Fs) *Parser {
 // parsed using the HCL JSON syntax.
 //
 // If a baseDir is passed, the loaded files are assumed to be loaded from that
-// directory.
+// directory. However, SourceDir does not contain baseDir because it affects
+// `path.module` and `path.root` values.
 func (p *Parser) LoadConfigDir(baseDir, dir string) (*Module, hcl.Diagnostics) {
 	primaries, overrides, diags := p.configDirFiles(baseDir, dir)
 	if diags.HasErrors() {
@@ -95,7 +96,8 @@ func (p *Parser) LoadConfigDir(baseDir, dir string) (*Module, hcl.Diagnostics) {
 		return mod, diags
 	}
 
-	mod.SourceDir = filepath.Join(baseDir, dir)
+	// Do not contain baseDir because it affects `path.module` and `path.root` values.
+	mod.SourceDir = dir
 
 	buildDiags := mod.build()
 	diags = diags.Extend(buildDiags)

--- a/terraform/parser_test.go
+++ b/terraform/parser_test.go
@@ -91,7 +91,7 @@ func TestLoadConfigDir(t *testing.T) {
 			baseDir: "foo",
 			dir:     ".",
 			want: &Module{
-				SourceDir: "foo",
+				SourceDir: ".",
 				primaries: []*hcl.File{
 					{Body: hcltest.MockBody(&hcl.BodyContent{MissingItemRange: hcl.Range{Filename: filepath.Join("foo", "main.tf")}})},
 				},
@@ -151,7 +151,7 @@ func TestLoadConfigDir(t *testing.T) {
 			baseDir: "foo",
 			dir:     "bar",
 			want: &Module{
-				SourceDir: filepath.Join("foo", "bar"),
+				SourceDir: "bar",
 				primaries: []*hcl.File{
 					{Body: hcltest.MockBody(&hcl.BodyContent{MissingItemRange: hcl.Range{Filename: filepath.Join("foo", "bar", "main.tf")}})},
 				},


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1633

The `Parser.LoadConfigDir` will load a directory as if they were loaded from `baseDir`, regardless of the actual working directory. This is useful for getting relative paths from the original working directory, but `path.module` and `path.root` will give incorrect results if the module's `SourceDir` reflects the `baseDir`.

```console
$ cat dir/main.tf
locals {
  content = file("${path.module}/text.txt")
}
$ cat dir/text.txt
This is file content
$ tflint --chdir=dir
// path.module is "dir", so "dir/dir/text.txt" is loaded.
```

This PR fixes `SourceDir` so that it returns the correct results:

```console
$ tflint --chdir=dir
// path.module is ".", so "dir/text.txt" is loaded.
```

As a side note, I noticed that I can't specify the file argument well when using `--chdir`. This will be fixed in another PR:

```console
$ tflint --chdir=dir dir/main.tf
Cannot use --chdir and directory argument at the same time
$ tflint --chdir=dir main.tf
Failed to parse CLI arguments; Failed to load `main.tf`: File not found
```