### PR TITLE
Add --filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ TFLint inspects files under the current directory by default. You can change the
 ```
 $ tflint --help
 Usage:
-  tflint [OPTIONS] [FILE or DIR...]
+  tflint --chdir=DIR/--recursive [OPTIONS]
 
 Application Options:
   -v, --version                                                 Print TFLint version
@@ -141,6 +141,7 @@ Application Options:
       --module                                                  Inspect modules
       --chdir=DIR                                               Switch to a different working directory before executing the command
       --recursive                                               Run command in each directory recursively
+      --filter=FILE                                             Filter reported issues by file name
       --force                                                   Return zero exit status even if issues found
       --color                                                   Enable colorized output
       --no-color                                                Disable colorized output

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Application Options:
       --module                                                  Inspect modules
       --chdir=DIR                                               Switch to a different working directory before executing the command
       --recursive                                               Run command in each directory recursively
-      --filter=FILE                                             Filter reported issues by file name
+      --filter=FILE                                             Filter issues by file names or globs.
       --force                                                   Return zero exit status even if issues found
       --color                                                   Enable colorized output
       --no-color                                                Disable colorized output

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -54,7 +54,7 @@ func NewCLI(outStream io.Writer, errStream io.Writer) (*CLI, error) {
 func (cli *CLI) Run(args []string) int {
 	var opts Options
 	parser := flags.NewParser(&opts, flags.HelpFlag)
-	parser.Usage = "[OPTIONS] [FILE or DIR...]"
+	parser.Usage = "--chdir=DIR/--recursive [OPTIONS]"
 	parser.UnknownOptionHandler = unknownOptionHandler
 	// Parse commandline flag
 	args, err := parser.ParseArgs(args)

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -42,6 +42,10 @@ func (cli *CLI) inspect(opts Options, args []string) int {
 			if opts.Recursive && (targetDir != "." || len(filterFiles) > 0) {
 				return fmt.Errorf("Cannot use --recursive and arguments at the same time")
 			}
+			if len(opts.Filter) > 0 && (targetDir != "." || len(filterFiles) > 0) {
+				return fmt.Errorf("Cannot use --filter and arguments at the same time")
+			}
+			filterFiles = append(filterFiles, opts.Filter...)
 
 			// Join with the working directory to create the fullpath
 			for i, file := range filterFiles {

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -45,7 +45,18 @@ func (cli *CLI) inspect(opts Options, args []string) int {
 			if len(opts.Filter) > 0 && (targetDir != "." || len(filterFiles) > 0) {
 				return fmt.Errorf("Cannot use --filter and arguments at the same time")
 			}
-			filterFiles = append(filterFiles, opts.Filter...)
+
+			for _, pattern := range opts.Filter {
+				files, err := filepath.Glob(pattern)
+				if err != nil {
+					return fmt.Errorf("Failed to parse --filter options; %w", err)
+				}
+				// Add the raw pattern to return an empty result if it doesn't match any files
+				if len(files) == 0 {
+					filterFiles = append(filterFiles, pattern)
+				}
+				filterFiles = append(filterFiles, files...)
+			}
 
 			// Join with the working directory to create the fullpath
 			for i, file := range filterFiles {

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -24,7 +24,7 @@ type Options struct {
 	Module             bool     `long:"module" description:"Inspect modules"`
 	Chdir              string   `long:"chdir" description:"Switch to a different working directory before executing the command" value-name:"DIR"`
 	Recursive          bool     `long:"recursive" description:"Run command in each directory recursively"`
-	Filter             []string `long:"filter" description:"Filter reported issues by file name" value-name:"FILE"`
+	Filter             []string `long:"filter" description:"Filter issues by file names or globs" value-name:"FILE"`
 	Force              bool     `long:"force" description:"Return zero exit status even if issues found"`
 	Color              bool     `long:"color" description:"Enable colorized output"`
 	NoColor            bool     `long:"no-color" description:"Disable colorized output"`

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -24,6 +24,7 @@ type Options struct {
 	Module             bool     `long:"module" description:"Inspect modules"`
 	Chdir              string   `long:"chdir" description:"Switch to a different working directory before executing the command" value-name:"DIR"`
 	Recursive          bool     `long:"recursive" description:"Run command in each directory recursively"`
+	Filter             []string `long:"filter" description:"Filter reported issues by file name" value-name:"FILE"`
 	Force              bool     `long:"force" description:"Return zero exit status even if issues found"`
 	Color              bool     `long:"color" description:"Enable colorized output"`
 	NoColor            bool     `long:"no-color" description:"Disable colorized output"`

--- a/integrationtest/cli/cli_test.go
+++ b/integrationtest/cli/cli_test.go
@@ -275,6 +275,21 @@ func TestIntegration(t *testing.T) {
 			stderr:  fmt.Sprintf("Failed to load `%s`: Multiple files in different directories are not allowed", filepath.Join("subdir", "main.tf")),
 		},
 		{
+			name:    "--filter",
+			command: "./tflint --filter=empty.tf",
+			dir:     "multiple_files",
+			status:  cmd.ExitCodeOK,
+			stdout:  "", // main.tf is ignored
+		},
+		{
+			name:    "--filter with multiple files",
+			command: "./tflint --filter=empty.tf --filter=main.tf",
+			dir:     "multiple_files",
+			status:  cmd.ExitCodeIssuesFound,
+			// main.tf is not ignored
+			stdout: fmt.Sprintf("%s (aws_instance_example_type)", color.New(color.Bold).Sprint("instance type is t2.micro")),
+		},
+		{
 			name:    "--chdir",
 			command: "./tflint --chdir=subdir",
 			dir:     "chdir",
@@ -303,6 +318,13 @@ func TestIntegration(t *testing.T) {
 			stderr:  "Cannot use --chdir and directory argument at the same time",
 		},
 		{
+			name:    "--chdir and --filter",
+			command: "./tflint --chdir=subdir --filter=main.tf",
+			dir:     "chdir",
+			status:  cmd.ExitCodeIssuesFound,
+			stdout:  fmt.Sprintf("%s (aws_instance_example_type)", color.New(color.Bold).Sprint("instance type is m5.2xlarge")),
+		},
+		{
 			name:    "--recursive and file argument",
 			command: "./tflint --recursive main.tf",
 			dir:     "chdir",
@@ -315,6 +337,13 @@ func TestIntegration(t *testing.T) {
 			dir:     "chdir",
 			status:  cmd.ExitCodeError,
 			stderr:  "Cannot use --recursive and arguments at the same time",
+		},
+		{
+			name:    "--recursive and --filter",
+			command: "./tflint --recursive --filter=main.tf",
+			dir:     "chdir",
+			status:  cmd.ExitCodeIssuesFound,
+			stdout:  fmt.Sprintf("%s (aws_instance_example_type)", color.New(color.Bold).Sprint("instance type is m5.2xlarge")),
 		},
 	}
 

--- a/integrationtest/cli/cli_test.go
+++ b/integrationtest/cli/cli_test.go
@@ -290,6 +290,20 @@ func TestIntegration(t *testing.T) {
 			stdout: fmt.Sprintf("%s (aws_instance_example_type)", color.New(color.Bold).Sprint("instance type is t2.micro")),
 		},
 		{
+			name:    "--filter with glob (files found)",
+			command: "./tflint --filter=*.tf",
+			dir:     "multiple_files",
+			status:  cmd.ExitCodeIssuesFound,
+			stdout:  fmt.Sprintf("%s (aws_instance_example_type)", color.New(color.Bold).Sprint("instance type is t2.micro")),
+		},
+		{
+			name:    "--filter with glob (files not found)",
+			command: "./tflint --filter=*_generated.tf",
+			dir:     "multiple_files",
+			status:  cmd.ExitCodeOK,
+			stdout:  "",
+		},
+		{
 			name:    "--chdir",
 			command: "./tflint --chdir=subdir",
 			dir:     "chdir",


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/1636

This PR introduces the `--filter` option as an alternative to file arguments. This is the same as the file argument, except that it doesn't check for the existence of the file:

```console
$ tflint main.tf
$ tflint --filter=main.tf
```

Introduction of this option deprecates all arguments. It can be replaced as follows:

```console
$ tflint --chdir=dir                  # replacement of "tflint dir"
$ tflint --filter=main.tf             # replacement of "tflint main.tf"
$ tflint --chdir=dir --filter=main.tf # replacement of "tflint dir/main.tf"
```

Arguments are still available, but will be removed in a future version, so early migration to `--chdir`/`--filter` is recommended.