### PR TITLE
plugin: Fix panic when plugin path could not be loaded

### DIFF
--- a/plugin/discovery.go
+++ b/plugin/discovery.go
@@ -136,13 +136,15 @@ func findPluginPath(path string) (string, error) {
 
 func checkPluginExistance(path string) (string, error) {
 	info, err := os.Stat(path)
-	if os.IsNotExist(err) {
+	if err != nil {
+		return "", err
+	}
+	// directory is invalid as a plugin path
+	if info.IsDir() {
 		return "", os.ErrNotExist
-	} else if !os.IsNotExist(err) && !info.IsDir() {
-		return path, nil
 	}
 
-	return "", os.ErrNotExist
+	return path, nil
 }
 
 func pluginClientError(err error, config *tflint.PluginConfig) error {


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1646

The `checkPluginExistance` does not expect loading errors other than `os.ErrNotExist`. As a result, it will panic if the plugin cannot be loaded for some other reason, such as permission denied.