### PR TITLE
tflint: Allow config to be merged even with initial values

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -83,7 +83,9 @@ func (cli *CLI) inspect(opts Options, args []string) int {
 	if opts.Recursive {
 		// Respect "--format" and "--force" flags in recursive mode
 		cli.formatter.Format = opts.Format
-		force = opts.Force
+		if opts.Force != nil {
+			force = *opts.Force
+		}
 	} else {
 		cli.formatter.Format = cli.config.Format
 		force = cli.config.Force

--- a/cmd/option_test.go
+++ b/cmd/option_test.go
@@ -26,6 +26,7 @@ func Test_toConfig(t *testing.T) {
 			Command: "./tflint --module",
 			Expected: &tflint.Config{
 				Module:            true,
+				ModuleSet:         true,
 				Force:             false,
 				IgnoreModules:     map[string]bool{},
 				Varfiles:          []string{},
@@ -41,6 +42,7 @@ func Test_toConfig(t *testing.T) {
 			Expected: &tflint.Config{
 				Module:            false,
 				Force:             true,
+				ForceSet:          true,
 				IgnoreModules:     map[string]bool{},
 				Varfiles:          []string{},
 				Variables:         []string{},
@@ -173,13 +175,14 @@ func Test_toConfig(t *testing.T) {
 			Name:    "--only",
 			Command: "./tflint --only aws_instance_invalid_type",
 			Expected: &tflint.Config{
-				Module:            false,
-				Force:             false,
-				IgnoreModules:     map[string]bool{},
-				Varfiles:          []string{},
-				Variables:         []string{},
-				DisabledByDefault: true,
-				Only:              []string{"aws_instance_invalid_type"},
+				Module:               false,
+				Force:                false,
+				IgnoreModules:        map[string]bool{},
+				Varfiles:             []string{},
+				Variables:            []string{},
+				DisabledByDefault:    true,
+				DisabledByDefaultSet: true,
+				Only:                 []string{"aws_instance_invalid_type"},
 				Rules: map[string]*tflint.RuleConfig{
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
@@ -226,6 +229,7 @@ func Test_toConfig(t *testing.T) {
 				Variables:         []string{},
 				DisabledByDefault: false,
 				Format:            "compact",
+				FormatSet:         true,
 				Rules:             map[string]*tflint.RuleConfig{},
 				Plugins:           map[string]*tflint.PluginConfig{},
 			},

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -72,8 +72,10 @@ plugin "baz" {
 }`,
 			},
 			want: &Config{
-				Module: true,
-				Force:  true,
+				Module:    true,
+				ModuleSet: true,
+				Force:     true,
+				ForceSet:  true,
 				IgnoreModules: map[string]bool{
 					"github.com/terraform-linters/example-module": true,
 				},
@@ -81,7 +83,9 @@ plugin "baz" {
 				Variables:         []string{"foo=bar", "bar=['foo']"},
 				DisabledByDefault: false,
 				PluginDir:         "~/.tflint.d/plugins",
+				PluginDirSet:      true,
 				Format:            "compact",
+				FormatSet:         true,
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
@@ -136,13 +140,15 @@ config {
 }`,
 			},
 			want: &Config{
-				Module:            false,
-				Force:             true,
-				IgnoreModules:     map[string]bool{},
-				Varfiles:          []string{},
-				Variables:         []string{},
-				DisabledByDefault: true,
-				Rules:             map[string]*RuleConfig{},
+				Module:               false,
+				Force:                true,
+				ForceSet:             true,
+				IgnoreModules:        map[string]bool{},
+				Varfiles:             []string{},
+				Variables:            []string{},
+				DisabledByDefault:    true,
+				DisabledByDefaultSet: true,
+				Rules:                map[string]*RuleConfig{},
 				Plugins: map[string]*PluginConfig{
 					"terraform": {
 						Name:    "terraform",
@@ -329,8 +335,10 @@ func TestMerge(t *testing.T) {
 	}
 
 	config := &Config{
-		Module: true,
-		Force:  true,
+		Module:    true,
+		ModuleSet: true,
+		Force:     true,
+		ForceSet:  true,
 		IgnoreModules: map[string]bool{
 			"github.com/terraform-linters/example-1": true,
 			"github.com/terraform-linters/example-2": false,
@@ -339,7 +347,9 @@ func TestMerge(t *testing.T) {
 		Variables:         []string{"foo=bar"},
 		DisabledByDefault: false,
 		PluginDir:         "./.tflint.d/plugins",
+		PluginDirSet:      true,
 		Format:            "compact",
+		FormatSet:         true,
 		Rules: map[string]*RuleConfig{
 			"aws_instance_invalid_type": {
 				Name:    "aws_instance_invalid_type",
@@ -382,17 +392,21 @@ func TestMerge(t *testing.T) {
 		{
 			name: "override and merge",
 			base: &Config{
-				Module: true,
-				Force:  false,
+				Module:    true,
+				ModuleSet: true,
+				Force:     false,
 				IgnoreModules: map[string]bool{
 					"github.com/terraform-linters/example-1": true,
 					"github.com/terraform-linters/example-2": false,
 				},
-				Varfiles:          []string{"example1.tfvars", "example2.tfvars"},
-				Variables:         []string{"foo=bar"},
-				DisabledByDefault: false,
-				PluginDir:         "./.tflint.d/plugins",
-				Format:            "compact",
+				Varfiles:             []string{"example1.tfvars", "example2.tfvars"},
+				Variables:            []string{"foo=bar"},
+				DisabledByDefault:    true,
+				DisabledByDefaultSet: true,
+				PluginDir:            "./.tflint.d/plugins",
+				PluginDirSet:         true,
+				Format:               "compact",
+				FormatSet:            true,
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
@@ -417,17 +431,21 @@ func TestMerge(t *testing.T) {
 				},
 			},
 			other: &Config{
-				Module: false,
-				Force:  true,
+				Module:   false,
+				Force:    true,
+				ForceSet: true,
 				IgnoreModules: map[string]bool{
 					"github.com/terraform-linters/example-2": true,
 					"github.com/terraform-linters/example-3": false,
 				},
-				Varfiles:          []string{"example3.tfvars"},
-				Variables:         []string{"bar=baz"},
-				DisabledByDefault: false,
-				PluginDir:         "~/.tflint.d/plugins",
-				Format:            "json",
+				Varfiles:             []string{"example3.tfvars"},
+				Variables:            []string{"bar=baz"},
+				DisabledByDefault:    false,
+				DisabledByDefaultSet: true,
+				PluginDir:            "~/.tflint.d/plugins",
+				PluginDirSet:         true,
+				Format:               "json",
+				FormatSet:            true,
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_ami": {
 						Name:    "aws_instance_invalid_ami",
@@ -452,18 +470,23 @@ func TestMerge(t *testing.T) {
 				},
 			},
 			want: &Config{
-				Module: true,
-				Force:  true,
+				Module:    true,
+				ModuleSet: true,
+				Force:     true,
+				ForceSet:  true,
 				IgnoreModules: map[string]bool{
 					"github.com/terraform-linters/example-1": true,
 					"github.com/terraform-linters/example-2": true,
 					"github.com/terraform-linters/example-3": false,
 				},
-				Varfiles:          []string{"example1.tfvars", "example2.tfvars", "example3.tfvars"},
-				Variables:         []string{"foo=bar", "bar=baz"},
-				DisabledByDefault: false,
-				PluginDir:         "~/.tflint.d/plugins",
-				Format:            "json",
+				Varfiles:             []string{"example1.tfvars", "example2.tfvars", "example3.tfvars"},
+				Variables:            []string{"foo=bar", "bar=baz"},
+				DisabledByDefault:    false,
+				DisabledByDefaultSet: true,
+				PluginDir:            "~/.tflint.d/plugins",
+				PluginDirSet:         true,
+				Format:               "json",
+				FormatSet:            true,
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
@@ -500,8 +523,9 @@ func TestMerge(t *testing.T) {
 		{
 			name: "CLI --only argument and merge",
 			base: &Config{
-				Module: true,
-				Force:  false,
+				Module:    true,
+				ModuleSet: true,
+				Force:     false,
 				IgnoreModules: map[string]bool{
 					"github.com/terraform-linters/example-1": true,
 					"github.com/terraform-linters/example-2": false,
@@ -533,16 +557,18 @@ func TestMerge(t *testing.T) {
 				},
 			},
 			other: &Config{
-				Module: false,
-				Force:  true,
+				Module:   false,
+				Force:    true,
+				ForceSet: true,
 				IgnoreModules: map[string]bool{
 					"github.com/terraform-linters/example-2": true,
 					"github.com/terraform-linters/example-3": false,
 				},
-				Varfiles:          []string{"example3.tfvars"},
-				Variables:         []string{"bar=baz"},
-				DisabledByDefault: true,
-				Only:              []string{"aws_instance_invalid_type", "aws_instance_previous_type"},
+				Varfiles:             []string{"example3.tfvars"},
+				Variables:            []string{"bar=baz"},
+				DisabledByDefault:    true,
+				DisabledByDefaultSet: true,
+				Only:                 []string{"aws_instance_invalid_type", "aws_instance_previous_type"},
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",
@@ -567,17 +593,20 @@ func TestMerge(t *testing.T) {
 				},
 			},
 			want: &Config{
-				Module: true,
-				Force:  true,
+				Module:    true,
+				ModuleSet: true,
+				Force:     true,
+				ForceSet:  true,
 				IgnoreModules: map[string]bool{
 					"github.com/terraform-linters/example-1": true,
 					"github.com/terraform-linters/example-2": true,
 					"github.com/terraform-linters/example-3": false,
 				},
-				Varfiles:          []string{"example1.tfvars", "example2.tfvars", "example3.tfvars"},
-				Variables:         []string{"foo=bar", "bar=baz"},
-				DisabledByDefault: true,
-				Only:              []string{"aws_instance_invalid_type", "aws_instance_previous_type"},
+				Varfiles:             []string{"example1.tfvars", "example2.tfvars", "example3.tfvars"},
+				Variables:            []string{"foo=bar", "bar=baz"},
+				DisabledByDefault:    true,
+				DisabledByDefaultSet: true,
+				Only:                 []string{"aws_instance_invalid_type", "aws_instance_previous_type"},
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_type": {
 						Name:    "aws_instance_invalid_type",


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/issues/1604

The `tflint.Config` does not have a mechanism to distinguish between undefined and initial values, and whether or not it is overwritten was determined by whether it was different from the initial value.

https://github.com/terraform-linters/tflint/blob/16e02189fd8afb461a3941f11c2f4442f9e87602/tflint/config.go#L331-L333

However, this cannot override it to the initial value, and fails to achieve requirements like #1604.

This PR adds a flag to distinguish between undefined and initial values in `tflint.Config`. The `tfllint.Config` will only be overridden if the flag is set. With this change, the following five values can be overridden to the initial values:

- `module`
- `force`
- `disabled_by_default`
- `plugin_dir`
- `format`

However, since the initial values for these values cannot be set from the CLI, the current behavior does not change.