### PR TITLE
cmd: Add --no-module

### DIFF
--- a/cmd/option.go
+++ b/cmd/option.go
@@ -21,7 +21,8 @@ type Options struct {
 	EnablePlugins          []string `long:"enable-plugin" description:"Enable plugins from the command line" value-name:"PLUGIN_NAME"`
 	Varfiles               []string `long:"var-file" description:"Terraform variable file name" value-name:"FILE"`
 	Variables              []string `long:"var" description:"Set a Terraform variable" value-name:"'foo=bar'"`
-	Module                 *bool    `long:"module" description:"Inspect modules"`
+	Module                 *bool    `long:"module" description:"Enable module inspection"`
+	NoModule               *bool    `long:"no-module" description:"Disable module inspection"`
 	Chdir                  string   `long:"chdir" description:"Switch to a different working directory before executing the command" value-name:"DIR"`
 	Recursive              bool     `long:"recursive" description:"Run command in each directory recursively"`
 	Filter                 []string `long:"filter" description:"Filter issues by file names or globs" value-name:"FILE"`
@@ -51,19 +52,17 @@ func (opts *Options) toConfig() *tflint.Config {
 	}
 
 	var module, moduleSet bool
-	if opts.Module == nil {
-		module = false
-		moduleSet = false
-	} else {
+	if opts.Module != nil {
 		module = *opts.Module
+		moduleSet = true
+	}
+	if opts.NoModule != nil {
+		module = !*opts.NoModule
 		moduleSet = true
 	}
 
 	var force, forceSet bool
-	if opts.Force == nil {
-		force = false
-		forceSet = false
-	} else {
+	if opts.Force != nil {
 		force = *opts.Force
 		forceSet = true
 	}

--- a/cmd/option_test.go
+++ b/cmd/option_test.go
@@ -37,6 +37,21 @@ func Test_toConfig(t *testing.T) {
 			},
 		},
 		{
+			Name:    "--no-module",
+			Command: "./tflint --no-module",
+			Expected: &tflint.Config{
+				Module:            false,
+				ModuleSet:         true,
+				Force:             false,
+				IgnoreModules:     map[string]bool{},
+				Varfiles:          []string{},
+				Variables:         []string{},
+				DisabledByDefault: false,
+				Rules:             map[string]*tflint.RuleConfig{},
+				Plugins:           map[string]*tflint.PluginConfig{},
+			},
+		},
+		{
 			Name:    "--force",
 			Command: "./tflint --force",
 			Expected: &tflint.Config{


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1604

This PR adds `--no-module` CLI flag. This flag enables you to disable module inspection from CLI.