### PR TITLE
cmd: Reject all directory arguments with --chdir/--recursive

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -36,13 +36,13 @@ func (cli *CLI) inspect(opts Options, args []string) int {
 				return fmt.Errorf("Failed to parse CLI arguments; %w", err)
 			}
 
-			if opts.Chdir != "" && targetDir != "." {
+			if opts.Chdir != "" && (len(args) > 1 && (len(filterFiles) == 0 || targetDir != ".")) {
 				return fmt.Errorf("Cannot use --chdir and directory argument at the same time")
 			}
-			if opts.Recursive && (targetDir != "." || len(filterFiles) > 0) {
+			if opts.Recursive && len(args) > 1 {
 				return fmt.Errorf("Cannot use --recursive and arguments at the same time")
 			}
-			if len(opts.Filter) > 0 && (targetDir != "." || len(filterFiles) > 0) {
+			if len(opts.Filter) > 0 && len(args) > 1 {
 				return fmt.Errorf("Cannot use --filter and arguments at the same time")
 			}
 

--- a/integrationtest/cli/cli_test.go
+++ b/integrationtest/cli/cli_test.go
@@ -353,6 +353,13 @@ func TestIntegration(t *testing.T) {
 			stderr:  "Cannot use --chdir and directory argument at the same time",
 		},
 		{
+			name:    "--chdir and the current directory argument",
+			command: "./tflint --chdir=subdir .",
+			dir:     "chdir",
+			status:  cmd.ExitCodeError,
+			stderr:  "Cannot use --chdir and directory argument at the same time",
+		},
+		{
 			name:    "--chdir and file under the directory argument",
 			command: fmt.Sprintf("./tflint --chdir=subdir %s", filepath.Join("nested", "main.tf")),
 			dir:     "chdir",
@@ -376,6 +383,13 @@ func TestIntegration(t *testing.T) {
 		{
 			name:    "--recursive and directory argument",
 			command: "./tflint --recursive subdir",
+			dir:     "chdir",
+			status:  cmd.ExitCodeError,
+			stderr:  "Cannot use --recursive and arguments at the same time",
+		},
+		{
+			name:    "--recursive and the current directory argument",
+			command: "./tflint --recursive .",
 			dir:     "chdir",
 			status:  cmd.ExitCodeError,
 			stderr:  "Cannot use --recursive and arguments at the same time",


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/discussions/1650

This PR changes the arguments handling to reject all directory arguments (especially the current directory) with --chdir/--recursive. Previously, the current directory did not error when it should.

This is a preparation to warn when using all arguments in v0.46.