### PR TITLE
sarif: add tool version, exclude empty range/position, slash paths

### DIFF
--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -3,6 +3,7 @@ package formatter
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/owenrumney/go-sarif/sarif"
@@ -41,7 +42,7 @@ func (f *Formatter) sarifPrint(issues tflint.Issues, appErr error) {
 		var location *sarif.PhysicalLocation
 		if issue.Range.Filename != "" {
 			location = sarif.NewPhysicalLocation().
-				WithArtifactLocation(sarif.NewSimpleArtifactLocation(issue.Range.Filename))
+				WithArtifactLocation(sarif.NewSimpleArtifactLocation(filepath.ToSlash(issue.Range.Filename)))
 
 			if !issue.Range.Empty() {
 				location.WithRegion(
@@ -73,7 +74,7 @@ func (f *Formatter) sarifPrint(issues tflint.Issues, appErr error) {
 		if errors.As(appErr, &diags) {
 			for _, diag := range diags {
 				location := sarif.NewPhysicalLocation().
-					WithArtifactLocation(sarif.NewSimpleArtifactLocation(diag.Subject.Filename)).
+					WithArtifactLocation(sarif.NewSimpleArtifactLocation(filepath.ToSlash(diag.Subject.Filename))).
 					WithRegion(
 						sarif.NewRegion().
 							WithByteOffset(diag.Subject.Start.Byte).

--- a/formatter/sarif_test.go
+++ b/formatter/sarif_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -95,6 +96,78 @@ func Test_sarifPrint(t *testing.T) {
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "test.tf"
+                },
+                "region": {
+                  "startLine": 1,
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 4
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": "tflint-errors",
+          "version": "0.45.0",
+          "informationUri": "https://github.com/terraform-linters/tflint"
+        }
+      },
+      "results": []
+    }
+  ]
+}`,
+		},
+		{
+			Name: "issues in directories",
+			Issues: tflint.Issues{
+				{
+					Rule:    &testRule{},
+					Message: "test",
+					Range: hcl.Range{
+						Filename: filepath.Join("test", "main.tf"),
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+			},
+			Stdout: `{
+  "version": "2.1.0",
+  "$schema": "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "tflint",
+          "version": "0.45.0",
+          "informationUri": "https://github.com/terraform-linters/tflint",
+          "rules": [
+            {
+              "id": "test_rule",
+              "shortDescription": {
+                "text": ""
+              },
+              "helpUri": "https://github.com"
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "test_rule",
+          "level": "error",
+          "message": {
+            "text": "test"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "test/main.tf"
                 },
                 "region": {
                   "startLine": 1,

--- a/formatter/sarif_test.go
+++ b/formatter/sarif_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint/tflint"
 	"github.com/xeipuuv/gojsonschema"
@@ -29,6 +30,7 @@ func Test_sarifPrint(t *testing.T) {
       "tool": {
         "driver": {
           "name": "tflint",
+          "version": "0.45.0",
           "informationUri": "https://github.com/terraform-linters/tflint"
         }
       },
@@ -38,6 +40,7 @@ func Test_sarifPrint(t *testing.T) {
       "tool": {
         "driver": {
           "name": "tflint-errors",
+          "version": "0.45.0",
           "informationUri": "https://github.com/terraform-linters/tflint"
         }
       },
@@ -67,6 +70,7 @@ func Test_sarifPrint(t *testing.T) {
       "tool": {
         "driver": {
           "name": "tflint",
+          "version": "0.45.0",
           "informationUri": "https://github.com/terraform-linters/tflint",
           "rules": [
             {
@@ -108,6 +112,7 @@ func Test_sarifPrint(t *testing.T) {
       "tool": {
         "driver": {
           "name": "tflint-errors",
+          "version": "0.45.0",
           "informationUri": "https://github.com/terraform-linters/tflint"
         }
       },
@@ -117,15 +122,13 @@ func Test_sarifPrint(t *testing.T) {
 }`,
 		},
 		{
-			Name: "Issues with SARIF-invalid position are output correctly",
+			Name: "Issues with missing source positions",
 			Issues: tflint.Issues{
 				{
 					Rule:    &testRule{},
 					Message: "test",
 					Range: hcl.Range{
 						Filename: "test.tf",
-						Start:    hcl.Pos{Line: 1, Column: 1},
-						End:      hcl.Pos{Line: 0, Column: 0},
 					},
 				},
 			},
@@ -138,6 +141,7 @@ func Test_sarifPrint(t *testing.T) {
       "tool": {
         "driver": {
           "name": "tflint",
+          "version": "0.45.0",
           "informationUri": "https://github.com/terraform-linters/tflint",
           "rules": [
             {
@@ -162,12 +166,6 @@ func Test_sarifPrint(t *testing.T) {
               "physicalLocation": {
                 "artifactLocation": {
                   "uri": "test.tf"
-                },
-                "region": {
-                  "startLine": 1,
-                  "startColumn": 1,
-                  "endLine": 1,
-                  "endColumn": 1
                 }
               }
             }
@@ -179,6 +177,7 @@ func Test_sarifPrint(t *testing.T) {
       "tool": {
         "driver": {
           "name": "tflint-errors",
+          "version": "0.45.0",
           "informationUri": "https://github.com/terraform-linters/tflint"
         }
       },
@@ -220,6 +219,7 @@ func Test_sarifPrint(t *testing.T) {
       "tool": {
         "driver": {
           "name": "tflint",
+          "version": "0.45.0",
           "informationUri": "https://github.com/terraform-linters/tflint"
         }
       },
@@ -229,6 +229,7 @@ func Test_sarifPrint(t *testing.T) {
       "tool": {
         "driver": {
           "name": "tflint-errors",
+          "version": "0.45.0",
           "informationUri": "https://github.com/terraform-linters/tflint"
         }
       },
@@ -272,8 +273,8 @@ func Test_sarifPrint(t *testing.T) {
 
 			formatter.Print(tc.Issues, tc.Error, map[string][]byte{})
 
-			if stdout.String() != tc.Stdout {
-				t.Fatalf("Failed %s test: expected=%s, stdout=%s", tc.Name, tc.Stdout, stdout.String())
+			if diff := cmp.Diff(tc.Stdout, stdout.String()); diff != "" {
+				t.Fatalf("Failed %s test: %s", tc.Name, diff)
 			}
 
 			schemaLoader := gojsonschema.NewReferenceLoader("http://json.schemastore.org/sarif-2.1.0")


### PR DESCRIPTION
Adds the TFLint version to the SARIF output. 

Avoids adding location information that is not known. Rules may emit violations about configuration that _wasn't_ present, meaning the `hcl.Range` may be a zero value, with no filename or position. Previously, a silly hack was in place that set the end line to 1 if it was zero.

Forces all paths to be POSIX-style with forward slashes, instead of `\` on Windows.

Closes #1657