### PR TITLE
cmd: Deprecate CLI arguments

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -91,14 +91,26 @@ func (cli *CLI) Run(args []string) int {
 
 	switch {
 	case opts.Version:
+		if len(args) > 1 {
+			fmt.Fprintln(cli.errStream, `WARNING: Arguments are not used in version mode and will error in a future version. Use --chdir instead.`)
+		}
 		return cli.printVersion(opts)
 	case opts.Init:
+		if len(args) > 1 {
+			fmt.Fprintln(cli.errStream, `WARNING: Arguments are not used in init mode and will error in a future version. Use --chdir instead.`)
+		}
 		return cli.init(opts)
 	case opts.Langserver:
+		if len(args) > 1 {
+			fmt.Fprintln(cli.errStream, `WARNING: Arguments are not used in language server mode and will error in a future version.`)
+		}
 		return cli.startLanguageServer(opts)
 	case opts.ActAsBundledPlugin:
 		return cli.actAsBundledPlugin()
 	default:
+		if len(args) > 1 {
+			fmt.Fprintln(cli.errStream, `WARNING: "tflint FILE/DIR" is deprecated and will error in a future version. Use --chdir or --filter instead.`)
+		}
 		return cli.inspect(opts, args)
 	}
 }

--- a/integrationtest/cli/cli_test.go
+++ b/integrationtest/cli/cli_test.go
@@ -244,6 +244,7 @@ func TestIntegration(t *testing.T) {
 			dir:     "multiple_files",
 			status:  cmd.ExitCodeOK,
 			stdout:  "", // main.tf is ignored
+			stderr:  `WARNING: "tflint FILE/DIR" is deprecated and will error in a future version. Use --chdir or --filter instead.`,
 		},
 		{
 			name:    "file not found",
@@ -266,6 +267,7 @@ func TestIntegration(t *testing.T) {
 			status:  cmd.ExitCodeIssuesFound,
 			// main.tf is not ignored
 			stdout: fmt.Sprintf("%s (aws_instance_example_type)", color.New(color.Bold).Sprint("instance type is t2.micro")),
+			stderr: `WARNING: "tflint FILE/DIR" is deprecated and will error in a future version. Use --chdir or --filter instead.`,
 		},
 		{
 			name:    "directory argument",
@@ -273,6 +275,7 @@ func TestIntegration(t *testing.T) {
 			dir:     "multiple_files",
 			status:  cmd.ExitCodeIssuesFound,
 			stdout:  fmt.Sprintf("%s (aws_instance_example_type)", color.New(color.Bold).Sprint("instance type is m5.2xlarge")),
+			stderr:  `WARNING: "tflint FILE/DIR" is deprecated and will error in a future version. Use --chdir or --filter instead.`,
 		},
 		{
 			name:    "file under the directory",
@@ -280,6 +283,7 @@ func TestIntegration(t *testing.T) {
 			dir:     "multiple_files",
 			status:  cmd.ExitCodeIssuesFound,
 			stdout:  fmt.Sprintf("%s (aws_instance_example_type)", color.New(color.Bold).Sprint("instance type is m5.2xlarge")),
+			stderr:  `WARNING: "tflint FILE/DIR" is deprecated and will error in a future version. Use --chdir or --filter instead.`,
 		},
 		{
 			name:    "multiple directories",
@@ -344,6 +348,7 @@ func TestIntegration(t *testing.T) {
 			dir:     "chdir",
 			status:  cmd.ExitCodeIssuesFound,
 			stdout:  fmt.Sprintf("%s (aws_instance_example_type)", color.New(color.Bold).Sprint("instance type is m5.2xlarge")),
+			stderr:  `WARNING: "tflint FILE/DIR" is deprecated and will error in a future version. Use --chdir or --filter instead.`,
 		},
 		{
 			name:    "--chdir and directory argument",


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/1612 https://github.com/terraform-linters/tflint/pull/1638

Previously, TFLint accepted files and directories as arguments.

```console
$ tflint main.tf
// print only main.tf issues from the directory

$ tflint modules/production
// inspect modules/production directory
```

This is a natural interface as a linter. However, as a Terraform language static analyzer, there are some issues.

First, the Terraform language must evaluate modules (directories), so it cannot evaluate a single file. This is clear if you imagine the example of evaluating an expression like `var.foo` in the presence of `variables.tf` and `main.tf` respectively.

Second, in the Terraform language, the current directory is included in the semantics. Imagine an example like `file("./policy.json")`. From this you can see that `tflint modules/production` and `cd modules/production; tflint` give different results.

Terraform has dropped support for arguments and introduced the `-chdir` flag to address the second issue. https://github.com/hashicorp/terraform/pull/26087. TFLint focuses on Terraform language compatibility, so we try to make the interface as uniform and unambiguous as possible.

Recently, TFLint introduced the `--chdir` and `--filter` flags. It can replace the arguments as follows:

```console
$ tflint --filter=main.tf
// replacement of "tflint main.tf"

$ tflint --chdir=modules/production
// replacement of "tflint modules/production"

$ tflint --chdir=modules/production --filter=main.tf
// replacement of "tflint modules/production/main.tf"
```

(As a side note, for the same reasons as Terraform, it is recommended that these options be placed at the beginning of all flags and joined with `=`)

This PR changes it to print a warning to stderr like the following if the arguments are still in use:

```console
$ tflint main.tf
WARNING: "tflint FILE/DIR" is deprecated and will error in a future version. Use --chdir or --filter instead.

$ tflint --version modules/production
WARNING: Arguments are not used in version mode and will error in a future version. Use --chdir instead.

$ tflint --langserver modules/production
WARNING: Arguments are not used in language server mode and will error in a future version.

$ tflint --init modules/production
WARNING: Arguments are not used in init mode and will error in a future version. Use --chdir instead.
```

We are planning to drop support for arguments in v0.47. It will work as before in v0.46, but we recommend migrating early.
