### PR TITLE
plugin: Handle eval errors on the plugin side

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/sourcegraph/jsonrpc2 v0.1.0
 	github.com/spf13/afero v1.9.3
-	github.com/terraform-linters/tflint-plugin-sdk v0.15.0
+	github.com/terraform-linters/tflint-plugin-sdk v0.15.1-0.20230225141907-dd804b3671af
 	github.com/terraform-linters/tflint-ruleset-terraform v0.2.2
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,8 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/terraform-linters/tflint-plugin-sdk v0.15.0 h1:bUJ9OskzT/I98XaJ5+rs7ymVPHiGT8oI4bG86LkopVY=
-github.com/terraform-linters/tflint-plugin-sdk v0.15.0/go.mod h1:enH5i7SHelcvC2AGZavEJzcrRF7nhAaOwTdaBjr/Zjo=
+github.com/terraform-linters/tflint-plugin-sdk v0.15.1-0.20230225141907-dd804b3671af h1:TAsqOUKu3DXg6ZmV3igB8ksKkHkaQrdSdZfCE3Ff7nc=
+github.com/terraform-linters/tflint-plugin-sdk v0.15.1-0.20230225141907-dd804b3671af/go.mod h1:g5UIXcskejxp38JWqvYqEb/HkvIX6X6luEdS60yimTw=
 github.com/terraform-linters/tflint-ruleset-terraform v0.2.2 h1:iTE09KkaZ0DE29xvp6IIM1/gmas9V0h8CER28SyBmQ8=
 github.com/terraform-linters/tflint-ruleset-terraform v0.2.2/go.mod h1:bCkvH8Vqzr16bWEE3e6Q3hvdZlmSAOR8i6G3M5y+M+k=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-plugin-sdk/pull/235

For historical reasons, errors from evaluating unknown or NULL values were handled on the server side rather than on the client side.
https://github.com/terraform-linters/tflint/blob/v0.45.0/plugin/server.go#L143-L167

But given that `EvaluateExpr` is an endpoint that returns a `cty.Value`, it's preferable to handle this error on the plugin side.

This PR changes to skip server-side error handling when the plugin's SDK is v0.16+. This is an internal change and has no end-user impact.