### PR TITLE
plugin: Drop support for plugin SDK v0.12

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -152,13 +152,6 @@ func (cli *CLI) inspectModule(opts Options, dir string, filterFiles []string) (t
 	if err != nil {
 		return tflint.Issues{}, fmt.Errorf("Failed to load TFLint config; %w", err)
 	}
-	// tflint-plugin-sdk v0.13+ doesn't need to disable rules config when enabling the only option.
-	// This is for the backward compatibility.
-	if len(opts.Only) > 0 {
-		for _, rule := range cli.config.Rules {
-			rule.Enabled = false
-		}
-	}
 	cli.config.Merge(opts.toConfig())
 
 	// Setup loader
@@ -195,8 +188,11 @@ func (cli *CLI) inspectModule(opts Options, dir string, filterFiles []string) (t
 				// SDKVersion endpoint is available in tflint-plugin-sdk v0.14+.
 				// Use nil if not available.
 			} else {
-				return tflint.Issues{}, fmt.Errorf("Failed to get TFLint version constraints to `%s` plugin; %w", name, err)
+				return tflint.Issues{}, fmt.Errorf(`Failed to get plugin "%s" SDK version; %w`, name, err)
 			}
+		}
+		if !plugin.SDKVersionConstraints.Check(sdkVersion) {
+			return tflint.Issues{}, fmt.Errorf(`Plugin "%s" SDK version (%s) is incompatible. Compatible versions: %s`, name, sdkVersion, plugin.SDKVersionConstraints)
 		}
 
 		for _, runner := range runners {

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -83,30 +83,18 @@ func (opts *Options) toConfig() *tflint.Config {
 	}
 
 	rules := map[string]*tflint.RuleConfig{}
-	if len(opts.Only) > 0 {
-		// tflint-plugin-sdk v0.13+ doesn't need rules config when enabling the only option.
-		// This is for the backward compatibility.
-		for _, rule := range opts.Only {
-			rules[rule] = &tflint.RuleConfig{
-				Name:    rule,
-				Enabled: true,
-				Body:    nil,
-			}
+	for _, rule := range append(opts.Only, opts.EnableRules...) {
+		rules[rule] = &tflint.RuleConfig{
+			Name:    rule,
+			Enabled: true,
+			Body:    nil,
 		}
-	} else {
-		for _, rule := range opts.EnableRules {
-			rules[rule] = &tflint.RuleConfig{
-				Name:    rule,
-				Enabled: true,
-				Body:    nil,
-			}
-		}
-		for _, rule := range opts.DisableRules {
-			rules[rule] = &tflint.RuleConfig{
-				Name:    rule,
-				Enabled: false,
-				Body:    nil,
-			}
+	}
+	for _, rule := range opts.DisableRules {
+		rules[rule] = &tflint.RuleConfig{
+			Name:    rule,
+			Enabled: false,
+			Body:    nil,
 		}
 	}
 

--- a/docs/developer-guide/api_compatibility.md
+++ b/docs/developer-guide/api_compatibility.md
@@ -3,12 +3,9 @@
 This is an internal documentation summarizing the currently supported SDK and TFLint versions and any compatibility caveats.
 
 Protocol version: 11  
-SDK version: v0.12.0+  
+SDK version: v0.13.0+
 TFLint version: v0.40.0+  
 
-- `Only` option is only supported by SDK v0.13.0+.
-  - https://github.com/terraform-linters/tflint/pull/1516
-  - https://github.com/terraform-linters/tflint-plugin-sdk/pull/198
 - Schema mode is only supported by SDK v0.14.0+ and TFLint v0.42.0+. v0.41 ignores this mode.
   - https://github.com/terraform-linters/tflint/pull/1530
   - https://github.com/terraform-linters/tflint-plugin-sdk/pull/201

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -65,8 +65,11 @@ func NewHandler(configPath string, cliConfig *tflint.Config) (jsonrpc2.Handler, 
 				// SDKVersion endpoint is available in tflint-plugin-sdk v0.14+.
 				// Use nil if not available.
 			} else {
-				return nil, nil, fmt.Errorf("Failed to get SDK version of `%s` plugin; %w", name, err)
+				return nil, nil, fmt.Errorf(`Failed to get plugin "%s" SDK version; %w`, name, err)
 			}
+		}
+		if !plugin.SDKVersionConstraints.Check(clientSDKVersions[name]) {
+			return nil, nil, fmt.Errorf(`Plugin "%s" SDK version (%s) is incompatible. Compatible versions: %s`, name, clientSDKVersions[name], plugin.SDKVersionConstraints)
 		}
 
 		rulesets = append(rulesets, ruleset)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-version"
 	"github.com/terraform-linters/tflint-plugin-sdk/plugin/host2plugin"
 )
 
@@ -11,6 +12,9 @@ var (
 	PluginRoot      = "~/.tflint.d/plugins"
 	localPluginRoot = "./.tflint.d/plugins"
 )
+
+// SDKVersionConstraints is the version constraint of the supported SDK version.
+var SDKVersionConstraints = version.MustConstraints(version.NewConstraint(">= 0.13.0"))
 
 // Plugin is an object handling plugins
 // Basically, it is a wrapper for go-plugin and provides an API to handle them collectively.


### PR DESCRIPTION
This PR drops support for plugins built with SDK v0.12.

SDK v0.12 is a version released over 6 months ago. It is in accordance with the future deprecation plan that versions that have passed more than 6 months since the release of the next version (v0.13) will be out of the scope of support. See https://github.com/terraform-linters/tflint/issues/1693 for details.

## TODO

- [ ] Add an integration test