### PR TITLE
plugin: Drop support for plugin SDK v0.12/v0.13

### DIFF
--- a/cmd/option.go
+++ b/cmd/option.go
@@ -83,30 +83,18 @@ func (opts *Options) toConfig() *tflint.Config {
 	}
 
 	rules := map[string]*tflint.RuleConfig{}
-	if len(opts.Only) > 0 {
-		// tflint-plugin-sdk v0.13+ doesn't need rules config when enabling the only option.
-		// This is for the backward compatibility.
-		for _, rule := range opts.Only {
-			rules[rule] = &tflint.RuleConfig{
-				Name:    rule,
-				Enabled: true,
-				Body:    nil,
-			}
+	for _, rule := range append(opts.Only, opts.EnableRules...) {
+		rules[rule] = &tflint.RuleConfig{
+			Name:    rule,
+			Enabled: true,
+			Body:    nil,
 		}
-	} else {
-		for _, rule := range opts.EnableRules {
-			rules[rule] = &tflint.RuleConfig{
-				Name:    rule,
-				Enabled: true,
-				Body:    nil,
-			}
-		}
-		for _, rule := range opts.DisableRules {
-			rules[rule] = &tflint.RuleConfig{
-				Name:    rule,
-				Enabled: false,
-				Body:    nil,
-			}
+	}
+	for _, rule := range opts.DisableRules {
+		rules[rule] = &tflint.RuleConfig{
+			Name:    rule,
+			Enabled: false,
+			Body:    nil,
 		}
 	}
 

--- a/docs/developer-guide/api_compatibility.md
+++ b/docs/developer-guide/api_compatibility.md
@@ -3,24 +3,19 @@
 This is an internal documentation summarizing the currently supported SDK and TFLint versions and any compatibility caveats.
 
 Protocol version: 11  
-SDK version: v0.12.0+  
+SDK version: v0.14.0+
 TFLint version: v0.40.0+  
 
-- `Only` option is only supported by SDK v0.13.0+.
-  - https://github.com/terraform-linters/tflint/pull/1516
-  - https://github.com/terraform-linters/tflint-plugin-sdk/pull/198
-- Schema mode is only supported by SDK v0.14.0+ and TFLint v0.42.0+. v0.41 ignores this mode.
+- Schema mode is only supported by TFLint v0.42.0+. v0.41 ignores this mode.
   - https://github.com/terraform-linters/tflint/pull/1530
   - https://github.com/terraform-linters/tflint-plugin-sdk/pull/201
-- `VersionConstraint` is only supported by SDK v0.14.0+ and TFLint v0.42.0+. v0.41 ignores this constraint.
+- `VersionConstraint` is only supported by TFLint v0.42.0+. v0.41 ignores this constraint.
   - https://github.com/terraform-linters/tflint/pull/1535
   - https://github.com/terraform-linters/tflint-plugin-sdk/pull/202
-- `SDKVersion` is only supported by SDK v0.14.0+. v0.13 does not return a version.
-  - https://github.com/terraform-linters/tflint-plugin-sdk/pull/203
-- `each.*` and `count.*` are only supported by SDK v0.14.0+ and TFLint v0.42.0+.
+- `each.*` and `count.*` are only supported by TFLint v0.42.0+. v0.41 treats as unknown value.
   - https://github.com/terraform-linters/tflint/pull/1537
   - https://github.com/terraform-linters/tflint-plugin-sdk/pull/205
-- Expand mode is only supported by SDK v0.14.0+ and TFLint v0.42.0+.
+- Expand mode is only supported by TFLint v0.42.0+. v0.41 ignores this option.
   - https://github.com/terraform-linters/tflint/pull/1537
   - https://github.com/terraform-linters/tflint-plugin-sdk/pull/208
 - Client-side value handling is introduced in SDK v0.16.0 and TFLint v0.46.0. TFLint v0.45.0 returns an error instead of a value.

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -50,7 +50,7 @@ func NewHandler(configPath string, cliConfig *tflint.Config) (jsonrpc2.Handler, 
 		if err != nil {
 			if st, ok := status.FromError(err); ok && st.Code() == codes.Unimplemented {
 				// VersionConstraints endpoint is available in tflint-plugin-sdk v0.14+.
-				// Skip verification if not available.
+				return nil, nil, fmt.Errorf(`Plugin "%s" SDK version is incompatible. Compatible versions: %s`, name, plugin.SDKVersionConstraints)
 			} else {
 				return nil, nil, fmt.Errorf("Failed to get TFLint version constraints to `%s` plugin; %w", name, err)
 			}
@@ -63,10 +63,13 @@ func NewHandler(configPath string, cliConfig *tflint.Config) (jsonrpc2.Handler, 
 		if err != nil {
 			if st, ok := status.FromError(err); ok && st.Code() == codes.Unimplemented {
 				// SDKVersion endpoint is available in tflint-plugin-sdk v0.14+.
-				// Use nil if not available.
+				return nil, nil, fmt.Errorf(`Plugin "%s" SDK version is incompatible. Compatible versions: %s`, name, plugin.SDKVersionConstraints)
 			} else {
-				return nil, nil, fmt.Errorf("Failed to get SDK version of `%s` plugin; %w", name, err)
+				return nil, nil, fmt.Errorf(`Failed to get plugin "%s" SDK version; %w`, name, err)
 			}
+		}
+		if !plugin.SDKVersionConstraints.Check(clientSDKVersions[name]) {
+			return nil, nil, fmt.Errorf(`Plugin "%s" SDK version (%s) is incompatible. Compatible versions: %s`, name, clientSDKVersions[name], plugin.SDKVersionConstraints)
 		}
 
 		rulesets = append(rulesets, ruleset)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-version"
 	"github.com/terraform-linters/tflint-plugin-sdk/plugin/host2plugin"
 )
 
@@ -11,6 +12,9 @@ var (
 	PluginRoot      = "~/.tflint.d/plugins"
 	localPluginRoot = "./.tflint.d/plugins"
 )
+
+// SDKVersionConstraints is the version constraint of the supported SDK version.
+var SDKVersionConstraints = version.MustConstraints(version.NewConstraint(">= 0.14.0"))
 
 // Plugin is an object handling plugins
 // Basically, it is a wrapper for go-plugin and provides an API to handle them collectively.


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/1727

This PR drops support for plugins built with SDK v0.12/v0.13.

SDK v0.13 is a version released over 6 months ago. It is in accordance with the future deprecation plan that versions that have passed more than 6 months since the release of the next version (v0.14) will be out of the scope of support. See https://github.com/terraform-linters/tflint/issues/1693 for details.
