### PR TITLE
plugin: support GitHub Enterprise Server as plugin source

### DIFF
--- a/plugin/install.go
+++ b/plugin/install.go
@@ -16,6 +16,8 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const defaultSourceHost = "github.com"
+
 // InstallConfig is a config for plugin installation.
 // This is a wrapper for PluginConfig and manages naming conventions
 // and directory names for installation.
@@ -258,9 +260,8 @@ func newGitHubClient(ctx context.Context, config *InstallConfig) (*github.Client
 
 	hc.Transport = &requestLoggingTransport{hc.Transport}
 
-	client := github.NewClient(hc)
-	if config.SourceHost == client.BaseURL.Host {
-		return client, nil
+	if config.SourceHost == defaultSourceHost {
+		return github.NewClient(hc), nil
 	}
 
 	baseURL := fmt.Sprintf("https://%s/", config.SourceHost)

--- a/plugin/install_test.go
+++ b/plugin/install_test.go
@@ -17,6 +17,7 @@ func Test_Install(t *testing.T) {
 		Enabled:     true,
 		Version:     "0.4.0",
 		Source:      "github.com/terraform-linters/tflint-ruleset-aws",
+		SourceHost:  "github.com",
 		SourceOwner: "terraform-linters",
 		SourceRepo:  "tflint-ruleset-aws",
 	})

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -101,6 +101,7 @@ type PluginConfig struct {
 	Body hcl.Body `hcl:",remain"`
 
 	// Parsed source attributes
+	SourceHost  string
 	SourceOwner string
 	SourceRepo  string
 }
@@ -477,11 +478,10 @@ func (c *PluginConfig) validate() error {
 		parts := strings.Split(c.Source, "/")
 		// Expected `github.com/owner/repo` format
 		if len(parts) != 3 {
-			return fmt.Errorf("plugin `%s`: `source` is invalid. Must be in the format `github.com/owner/repo`", c.Name)
+			return fmt.Errorf("plugin `%s`: `source` is invalid. Must be a GitHub reference in the format `${host}/${owner}/${repo}`", c.Name)
 		}
-		if parts[0] != "github.com" {
-			return fmt.Errorf("plugin `%s`: `source` is invalid. Hostname must be `github.com`", c.Name)
-		}
+
+		c.SourceHost = parts[0]
 		c.SourceOwner = parts[1]
 		c.SourceRepo = parts[2]
 	}

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -107,6 +107,7 @@ plugin "baz" {
 						Version:     "0.1.0",
 						Source:      "github.com/foo/bar",
 						SigningKey:  "SIGNING_KEY",
+						SourceHost:  "github.com",
 						SourceOwner: "foo",
 						SourceRepo:  "bar",
 					},

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -277,24 +277,46 @@ plugin "foo" {
 }`,
 			},
 			errCheck: func(err error) bool {
-				return err == nil || err.Error() != "plugin `foo`: `source` is invalid. Must be in the format `github.com/owner/repo`"
+				return err == nil || err.Error() != "plugin `foo`: `source` is invalid. Must be a GitHub reference in the format `${host}/${owner}/${repo}`"
 			},
 		},
 		{
-			name: "plugin with invalid source host",
-			file: "plugin_with_invalid_source_host.hcl",
+			name: "plugin with GHES source host",
+			file: "plugin_with_ghes_source_host.hcl",
 			files: map[string]string{
-				"plugin_with_invalid_source_host.hcl": `
+				"plugin_with_ghes_source_host.hcl": `
 plugin "foo" {
 	enabled = true
 
 	version = "0.1.0"
-	source = "gitlab.com/foo/bar"
+	source = "github.example.com/foo/bar"
 }`,
 			},
-			errCheck: func(err error) bool {
-				return err == nil || err.Error() != "plugin `foo`: `source` is invalid. Hostname must be `github.com`"
+			want: &Config{
+				Module:            false,
+				Force:             false,
+				IgnoreModules:     map[string]bool{},
+				Varfiles:          []string{},
+				Variables:         []string{},
+				DisabledByDefault: false,
+				Rules:             map[string]*RuleConfig{},
+				Plugins: map[string]*PluginConfig{
+					"foo": {
+						Name:        "foo",
+						Enabled:     true,
+						Version:     "0.1.0",
+						Source:      "github.example.com/foo/bar",
+						SourceHost:  "github.example.com",
+						SourceOwner: "foo",
+						SourceRepo:  "bar",
+					},
+					"terraform": {
+						Name:    "terraform",
+						Enabled: true,
+					},
+				},
 			},
+			errCheck: neverHappend,
 		},
 	}
 


### PR DESCRIPTION
GitHub Enterprise Server is a private installation of GitHub. It provides a compatible API, but on a hostname other than `github.com`. This PR removes the requirement that plugin sources begin with `github.com` and assumes any other hostname is a GHES server hostname. If it's not, the client would likely receive a 404, which hopefully is enough "validation." But if needed, we could make a request an look for a header to explicitly fail with "this server is not GitHub."

I factored out the request logs into a logging transport to avoid the need to to reverse engineer URLs. Otherwise, `client.BaseURL.JoinPath` is the next best way to generate a URL relative to the client. 

Still thinking about how to test this. The only reasonable way would seem to be to run a mock server using `httptest` and then pass its URL, or at least the hostname part, as the SourceHost. I believe this is always `localhost` on a random port, which technically isn't expected in SourceHost, but should work in practice right now. However, given the amount of boilerplate involved in mocking out the responses from GitHub, we could potentially just merge this and let users try it, knowing that we at least have regression testing for `github.com`. 

Closes #1643