### PR TITLE
Switch from x/crypto/openpgp to ProtonMail/go-crypto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/terraform-linters/tflint
 go 1.21
 
 require (
+	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8
 	github.com/agext/levenshtein v1.2.3
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/bmatcuk/doublestar v1.1.5
@@ -43,7 +44,6 @@ require (
 	cloud.google.com/go/iam v0.13.0 // indirect
 	cloud.google.com/go/storage v1.29.0 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
-	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.122 // indirect

--- a/plugin/signature.go
+++ b/plugin/signature.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	//nolint:staticcheck
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
 // SignatureChecker checks the signature of GitHub releases.
@@ -52,7 +52,7 @@ func (c *SignatureChecker) Verify(target, signature io.Reader) error {
 		return err
 	}
 
-	_, err = openpgp.CheckDetachedSignature(keyring, target, signature)
+	_, err = openpgp.CheckDetachedSignature(keyring, target, signature, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1768

Merging this PR will cause all built-in key verifications to fail, so further investigation is required to mitigate user impact.