### PR TITLE
fix(install_linux): Update unzip arguments

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -64,7 +64,7 @@ echo "Downloaded successfully"
 
 echo -e "\n\n===================================================="
 echo "Unpacking ${download_zip} ..."
-unzip -u "${download_zip}" -d "${download_path}"
+unzip -o "${download_zip}" -d "${download_path}"
 if [[ $os == "windows"* ]]; then
   dest="${TFLINT_INSTALL_PATH:-/bin}/"
   echo "Installing ${download_executable} to ${dest} ..."


### PR DESCRIPTION
Use `-o` (overwrite) instead of `-u` (update).

Behaviourally, there shouldn't be any difference from this change.

This improves compatibility with BusyBox unzip, which only supports `-o`.