### PR TITLE
Remove hard-coded versions from integration tests

### DIFF
--- a/integrationtest/inspection/incompatible-host/result.json
+++ b/integrationtest/inspection/incompatible-host/result.json
@@ -1,9 +1,0 @@
-{
-  "issues": [],
-  "errors": [
-    {
-      "message": "Failed to satisfy version constraints; tflint-ruleset-incompatiblehost requires >= 1.0, but TFLint version is 0.47.0",
-      "severity": "error"
-    }
-  ]
-}

--- a/integrationtest/inspection/incompatible-host/result.json.tmpl
+++ b/integrationtest/inspection/incompatible-host/result.json.tmpl
@@ -1,0 +1,9 @@
+{
+  "issues": [],
+  "errors": [
+    {
+      "message": "Failed to satisfy version constraints; tflint-ruleset-incompatiblehost requires >= 1.0, but TFLint version is {{.Version}}",
+      "severity": "error"
+    }
+  ]
+}


### PR DESCRIPTION
Remove hard-coded versions from integration tests for release automation.
The `result.json.tmpl` file will be able to dynamically inject metadata using the `text/template` package.