### PR TITLE
Bump tflint-plugin-sdk to v0.18.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d
 	github.com/sourcegraph/jsonrpc2 v0.2.0
 	github.com/spf13/afero v1.9.5
-	github.com/terraform-linters/tflint-plugin-sdk v0.17.0
+	github.com/terraform-linters/tflint-plugin-sdk v0.18.0
 	github.com/terraform-linters/tflint-ruleset-terraform v0.4.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zclconf/go-cty v1.13.2
@@ -33,7 +33,7 @@ require (
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	golang.org/x/oauth2 v0.10.0
 	golang.org/x/text v0.11.0
-	google.golang.org/grpc v1.56.2
+	google.golang.org/grpc v1.57.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -462,8 +462,8 @@ github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1F
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/terraform-linters/tflint-plugin-sdk v0.17.0 h1:epg9rqt6zaj7C3qaNqRMlqscOqX0S1UKiTk+UHGvi1Q=
-github.com/terraform-linters/tflint-plugin-sdk v0.17.0/go.mod h1:XrMaY79YpbU4J4cZgo6o4F31ZiMO2ccETXISniTOCsA=
+github.com/terraform-linters/tflint-plugin-sdk v0.18.0 h1:XqQS6/RfUU6J3ySDTdN5c/KvNu6sOYdGqtTo4zgRPXE=
+github.com/terraform-linters/tflint-plugin-sdk v0.18.0/go.mod h1:OvyC1d9NyIFxNZQeKM7vSGrRWq0cuq27zAQUMpJH5h8=
 github.com/terraform-linters/tflint-ruleset-terraform v0.4.0 h1:HOkKth3zhtpEo4J0f122ln6xAo1RKnroDYzP+gnZWbM=
 github.com/terraform-linters/tflint-ruleset-terraform v0.4.0/go.mod h1:rcgg6YCJIvU2zL2aJlYE9s1u0HirSunjJg7Gu/mqUNY=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
@@ -1000,8 +1000,8 @@ google.golang.org/grpc v1.48.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACu
 google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc v1.50.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc v1.50.1/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
-google.golang.org/grpc v1.56.2 h1:fVRFRnXvU+x6C4IlHZewvJOVHoOv1TUuQyoRsYnB4bI=
-google.golang.org/grpc v1.56.2/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
+google.golang.org/grpc v1.57.0 h1:kfzNeI/klCGD2YPMUlaGNT3pxvYfga7smW3Vth8Zsiw=
+google.golang.org/grpc v1.57.0/go.mod h1:Sd+9RMTACXwmub0zcNY2c4arhtrbBYD1AUHI/dt16Mo=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/plugin/discovery.go
+++ b/plugin/discovery.go
@@ -22,7 +22,7 @@ import (
 // is specified will launch the bundled plugin instead of returning an error.
 func Discovery(config *tflint.Config) (*Plugin, error) {
 	clients := map[string]*plugin.Client{}
-	rulesets := map[string]*host2plugin.GRPCClient{}
+	rulesets := map[string]*host2plugin.Client{}
 
 	for _, pluginCfg := range config.Plugins {
 		installCfg := NewInstallConfig(config, pluginCfg)
@@ -64,7 +64,7 @@ func Discovery(config *tflint.Config) (*Plugin, error) {
 			if err != nil {
 				return nil, err
 			}
-			ruleset := raw.(*host2plugin.GRPCClient)
+			ruleset := raw.(*host2plugin.Client)
 
 			clients[pluginCfg.Name] = client
 			rulesets[pluginCfg.Name] = ruleset

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -19,7 +19,7 @@ var SDKVersionConstraints = version.MustConstraints(version.NewConstraint(">= 0.
 // Plugin is an object handling plugins
 // Basically, it is a wrapper for go-plugin and provides an API to handle them collectively.
 type Plugin struct {
-	RuleSets map[string]*host2plugin.GRPCClient
+	RuleSets map[string]*host2plugin.Client
 
 	clients map[string]*plugin.Client
 }

--- a/plugin/server.go
+++ b/plugin/server.go
@@ -63,8 +63,7 @@ func (s *GRPCServer) GetModuleContent(bodyS *hclext.BodySchema, opts sdk.GetModu
 		}
 	}
 
-	//nolint:staticcheck
-	if opts.IncludeNotCreated || opts.ExpandMode == sdk.ExpandModeNone {
+	if opts.ExpandMode == sdk.ExpandModeNone {
 		ctx = nil
 	}
 

--- a/plugin/server_test.go
+++ b/plugin/server_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/spf13/afero"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
-	"github.com/terraform-linters/tflint-plugin-sdk/plugin/host2plugin"
+	"github.com/terraform-linters/tflint-plugin-sdk/plugin"
 	"github.com/terraform-linters/tflint-plugin-sdk/terraform/lang/marks"
 	sdk "github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/terraform-linters/tflint/tflint"
 	"github.com/zclconf/go-cty/cty"
 )
 
-var SDKVersion = version.Must(version.NewVersion(host2plugin.SDKVersion))
+var SDKVersion = version.Must(version.NewVersion(plugin.SDKVersion))
 
 func TestGetModuleContent(t *testing.T) {
 	runner := tflint.TestRunner(t, map[string]string{"main.tf": `
@@ -116,53 +116,6 @@ resource "aws_instance" "bar" {
 						Body: &hclext.BodyContent{
 							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type"}},
 							Blocks:     hclext.Blocks{},
-						},
-					},
-				},
-			},
-		},
-		{
-			Name: "include not created",
-			Args: func() (*hclext.BodySchema, sdk.GetModuleContentOption) {
-				return &hclext.BodySchema{
-					Blocks: []hclext.BlockSchema{
-						{
-							Type:       "resource",
-							LabelNames: []string{"type", "name"},
-							Body: &hclext.BodySchema{
-								Attributes: []hclext.AttributeSchema{{Name: "instance_type"}},
-								Blocks:     []hclext.BlockSchema{{Type: "ebs_block_device"}},
-							},
-						},
-					},
-				}, sdk.GetModuleContentOption{ModuleCtx: sdk.SelfModuleCtxType, IncludeNotCreated: true, Hint: sdk.GetModuleContentHint{ResourceType: "aws_instance"}}
-			},
-			Want: &hclext.BodyContent{
-				Blocks: hclext.Blocks{
-					{
-						Type:   "resource",
-						Labels: []string{"aws_instance", "baz"},
-						Body: &hclext.BodyContent{
-							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type"}},
-							Blocks: hclext.Blocks{
-								{
-									Type: "ebs_block_device",
-									Body: &hclext.BodyContent{Attributes: hclext.Attributes{}, Blocks: hclext.Blocks{}},
-								},
-							},
-						},
-					},
-					{
-						Type:   "resource",
-						Labels: []string{"aws_instance", "foo"},
-						Body: &hclext.BodyContent{
-							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type"}},
-							Blocks: hclext.Blocks{
-								{
-									Type: "ebs_block_device",
-									Body: &hclext.BodyContent{Attributes: hclext.Attributes{}, Blocks: hclext.Blocks{}},
-								},
-							},
 						},
 					},
 				},


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-plugin-sdk/releases/tag/v0.18.0

This change causes the deprecated `IncludeNotCreated` option to be ignored.