### PR TITLE
tflint: Allow commas with spaces in annotations

### DIFF
--- a/tflint/annotation.go
+++ b/tflint/annotation.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var annotationPattern = regexp.MustCompile(`tflint-ignore: (\S+)`)
+var annotationPattern = regexp.MustCompile(`tflint-ignore: ([^\n*/]+)`)
 
 // Annotation represents comments with special meaning in TFLint
 type Annotation struct {

--- a/tflint/annotation_test.go
+++ b/tflint/annotation_test.go
@@ -12,9 +12,9 @@ import (
 func Test_NewAnnotations(t *testing.T) {
 	src := `
 resource "aws_instance" "foo" {
-  /* tflint-ignore: aws_instance_invalid_type */
+  /* tflint-ignore: aws_instance_invalid_type, terraform_deprecated_syntax */
   instance_type = "t2.micro" // tflint-ignore: aws_instance_invalid_type
-  # tflint-ignore: aws_instance_invalid_type This is also comment
+  # tflint-ignore: aws_instance_invalid_type
   iam_instance_profile = "foo" # This is also comment
   // This is also comment
 }`
@@ -30,14 +30,14 @@ resource "aws_instance" "foo" {
 
 	expected := Annotations{
 		{
-			Content: "aws_instance_invalid_type",
+			Content: "aws_instance_invalid_type, terraform_deprecated_syntax ",
 			Token: hclsyntax.Token{
 				Type:  hclsyntax.TokenComment,
-				Bytes: []byte("/* tflint-ignore: aws_instance_invalid_type */"),
+				Bytes: []byte("/* tflint-ignore: aws_instance_invalid_type, terraform_deprecated_syntax */"),
 				Range: hcl.Range{
 					Filename: "resource.tf",
 					Start:    hcl.Pos{Line: 3, Column: 3},
-					End:      hcl.Pos{Line: 3, Column: 49},
+					End:      hcl.Pos{Line: 3, Column: 78},
 				},
 			},
 		},
@@ -57,7 +57,7 @@ resource "aws_instance" "foo" {
 			Content: "aws_instance_invalid_type",
 			Token: hclsyntax.Token{
 				Type:  hclsyntax.TokenComment,
-				Bytes: []byte("# tflint-ignore: aws_instance_invalid_type This is also comment\n"),
+				Bytes: []byte("# tflint-ignore: aws_instance_invalid_type\n"),
 				Range: hcl.Range{
 					Filename: "resource.tf",
 					Start:    hcl.Pos{Line: 5, Column: 3},


### PR DESCRIPTION
Closes https://github.com/terraform-linters/tflint/pull/1752

The `tflint-ignore` annotation did not allow commas with spaces, even though the documentation shows examples.

```hcl
// invalid
# tflint-ignore: aws_instance_invalid_type, terraform_deprecated_syntax

// valid
# tflint-ignore: aws_instance_invalid_type,terraform_deprecated_syntax
```

But this is not what was intended, so we'll change this to work with commas with spaces as well.

The only incompatibility with this change is when using spaces to include comments. The example below was previously available as an `aws_instance_invalid_type` annotation, but with this change, it becomes `aws_instance_invalid_type This is comment`.

```hcl
# tflint-ignore: aws_instance_invalid_type This is comment
```