### PR TITLE
Add formula-path to follow formula path changes

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula:
           formula-name: tflint
+          formula-path: Formula/t/tflint.rb
           push-to: chenrui333/homebrew-core
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint/actions/runs/6065394790/job/16454840158
See https://github.com/mislav/bump-homebrew-formula-action/issues/58

GitHub Actions failed because the formula path changed in homebrew-core. This PR works around the issue by setting `formula-path`, as described in https://github.com/mislav/bump-homebrew-formula-action/issues/58.