### PR TITLE
Deprecate tflint-bundle image

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,7 @@ sha256sum --ignore-missing -c checksums.txt
 
 ### Docker
 
-Instead of installing directly, you can use the Docker images:
-
-| Name | Description |
-| ---- | ----------- |
-| [ghcr.io/terraform-linters/tflint](https://github.com/terraform-linters/tflint/pkgs/container/tflint) | Basic image |
-| [ghcr.io/terraform-linters/tflint-bundle](https://github.com/terraform-linters/tflint-bundle/pkgs/container/tflint-bundle) | A Docker image with TFLint and ruleset plugins |
-
-Example:
+Instead of installing directly, you can use the Docker image:
 
 ```console
 docker run --rm -v $(pwd):/data -t ghcr.io/terraform-linters/tflint


### PR DESCRIPTION
The tflint-bundle image was provided as a workaround when deprecating bundled plugins https://github.com/terraform-linters/tflint/pull/1164

Now, 2 years later, tflint-bundle hardly plays an important role anymore. You can use Renovate for automatic updates of plugins. The most recommended workflow is to set the plugin versions in `.tflint.hcl` and update it automatically.

As a first step, This PR removes tflint-bundle image in README. The tflint-bundle will be available for a while, but will gradually stop being updated.