### PR TITLE
Fix go directive to include patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-linters/tflint
 
-go 1.21
+go 1.21.1
 
 require (
 	github.com/agext/levenshtein v1.2.3


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/1823
See also https://github.com/dependabot/dependabot-core/issues/7895

Starting with Go 1.21, `go` directives must include patch version. `1.21` was incorrect and Dependabot was failing to parse the go.mod file.

This PR fixes the directive to `1.21.1`.