### PR TITLE
add test coverage for install script fail

### DIFF
--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -44,6 +44,21 @@ jobs:
         TFLINT_INSTALL_PATH: ${{ github.workspace }}/install-path
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: bash
+    - name: Non-existent version
+      id: fail
+      continue-on-error: true
+      run: |
+        ./install_linux.sh
+        tflint -v
+      env:
+        TFLINT_VERSION: vBROKEN
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Check failure
+      if: steps.fail.outcome != 'failure'
+      run: |
+        echo "::error::Expected previous step to fail, outcome was ${{ steps.fail.outcome }}"
+        exit 1
+
   container:
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Tests case where HTTP calls fail by passing a garbage version. There's some general messiness/legacy around error handling (a lot of checking of return values despite `bash -e`). This adds coverage before refactoring that all out.

See https://github.com/terraform-linters/tflint/discussions/1867