### PR TITLE
install: move `-e` out of shebang

### DIFF
--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -48,7 +48,7 @@ jobs:
       id: fail
       continue-on-error: true
       run: |
-        cat install_linux.sh | bash
+        bash < install_linux.sh
         tflint -v
       env:
         TFLINT_VERSION: vBROKEN

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -47,6 +47,8 @@ jobs:
     - name: Non-existent version
       id: fail
       continue-on-error: true
+      # Install instructions pipe the script from curl to bash
+      # Passing scripts via stdin can have differing behavior from passing as a file arg
       run: |
         bash < install_linux.sh
         tflint -v

--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -48,7 +48,7 @@ jobs:
       id: fail
       continue-on-error: true
       run: |
-        ./install_linux.sh
+        cat install_linux.sh | bash
         tflint -v
       env:
         TFLINT_VERSION: vBROKEN

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 get_machine_arch () {
     machine_arch=""


### PR DESCRIPTION
Ensure `install_linux.sh` still exists non-zero upon first error when the script is piped to bash (instead of run directly, which respects shebang).