### PR TITLE
feat(annotations): Allow a comment at the end of a tflint-ignore annotation

### DIFF
--- a/docs/user-guide/annotations.md
+++ b/docs/user-guide/annotations.md
@@ -31,7 +31,26 @@ It is possible to add a reason for why a rule is ignored:
 
 ```hcl
 resource "aws_instance" "foo" {
-    # tflint-ignore: aws_instance_invalid_type # A good reason
-    instance_type = "t1.2xlarge"
+    # This instance type is new and TFLint doesn't know about it yet
+    # tflint-ignore: aws_instance_invalid_type
+    instance_type = "t10.2xlarge"
+}
+```
+
+Or, on the same line:
+
+```hcl
+resource "aws_instance" "foo" {
+  # tflint-ignore: aws_instance_invalid_type # too new for TFLint
+  instance_type = "t10.2xlarge" 
+}
+```
+
+One can also use `//`-style comments
+
+```hcl
+resource "aws_instance" "foo" {
+  // tflint-ignore: aws_instance_invalid_type // too new for TFLint
+  instance_type = "t10.2xlarge" 
 }
 ```

--- a/docs/user-guide/annotations.md
+++ b/docs/user-guide/annotations.md
@@ -27,7 +27,7 @@ resource "aws_instance" "foo" {
 }
 ```
 
-It is possible to add a reason for why a rule is ignored:
+It's a good idea to add a reason for why a rule is ignored, especially temporarily:
 
 ```hcl
 resource "aws_instance" "foo" {
@@ -46,7 +46,7 @@ resource "aws_instance" "foo" {
 }
 ```
 
-One can also use `//`-style comments
+The `//` comment style is also supported, but Terraform recommends `#`.
 
 ```hcl
 resource "aws_instance" "foo" {

--- a/docs/user-guide/annotations.md
+++ b/docs/user-guide/annotations.md
@@ -26,3 +26,12 @@ resource "aws_instance" "foo" {
     instance_type = "t1.2xlarge"
 }
 ```
+
+It is possible to add a reason for why a rule is ignored:
+
+```hcl
+resource "aws_instance" "foo" {
+    # tflint-ignore: aws_instance_invalid_type # A good reason
+    instance_type = "t1.2xlarge"
+}
+```

--- a/tflint/annotation.go
+++ b/tflint/annotation.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 )
 
-var annotationPattern = regexp.MustCompile(`tflint-ignore: ([^\n*/]+)`)
+var annotationPattern = regexp.MustCompile(`tflint-ignore: ([^\n*/#]+)`)
 
 // Annotation represents comments with special meaning in TFLint
 type Annotation struct {
@@ -40,7 +40,7 @@ func NewAnnotations(path string, file *hcl.File) (Annotations, hcl.Diagnostics) 
 			continue
 		}
 		ret = append(ret, Annotation{
-			Content: match[1],
+			Content: strings.TrimSpace(match[1]),
 			Token:   token,
 		})
 	}

--- a/tflint/annotation_test.go
+++ b/tflint/annotation_test.go
@@ -17,6 +17,9 @@ resource "aws_instance" "foo" {
   # tflint-ignore: aws_instance_invalid_type
   iam_instance_profile = "foo" # This is also comment
   // This is also comment
+  instance_type_reason = "t2.micro" // tflint-ignore: aws_instance_invalid_type // With reason
+  # tflint-ignore: aws_instance_invalid_type # With reason
+  iam_instance_profile_reason = "foo" # This is also comment
 }`
 
 	file, diags := hclsyntax.ParseConfig([]byte(src), "resource.tf", hcl.Pos{Byte: 0, Line: 1, Column: 1})
@@ -30,7 +33,7 @@ resource "aws_instance" "foo" {
 
 	expected := Annotations{
 		{
-			Content: "aws_instance_invalid_type, terraform_deprecated_syntax ",
+			Content: "aws_instance_invalid_type, terraform_deprecated_syntax",
 			Token: hclsyntax.Token{
 				Type:  hclsyntax.TokenComment,
 				Bytes: []byte("/* tflint-ignore: aws_instance_invalid_type, terraform_deprecated_syntax */"),
@@ -62,6 +65,30 @@ resource "aws_instance" "foo" {
 					Filename: "resource.tf",
 					Start:    hcl.Pos{Line: 5, Column: 3},
 					End:      hcl.Pos{Line: 6, Column: 1},
+				},
+			},
+		},
+		{
+			Content: "aws_instance_invalid_type",
+			Token: hclsyntax.Token{
+				Type:  hclsyntax.TokenComment,
+				Bytes: []byte("// tflint-ignore: aws_instance_invalid_type // With reason\n"),
+				Range: hcl.Range{
+					Filename: "resource.tf",
+					Start:    hcl.Pos{Line: 8, Column: 37},
+					End:      hcl.Pos{Line: 9, Column: 1},
+				},
+			},
+		},
+		{
+			Content: "aws_instance_invalid_type",
+			Token: hclsyntax.Token{
+				Type:  hclsyntax.TokenComment,
+				Bytes: []byte("# tflint-ignore: aws_instance_invalid_type # With reason\n"),
+				Range: hcl.Range{
+					Filename: "resource.tf",
+					Start:    hcl.Pos{Line: 9, Column: 3},
+					End:      hcl.Pos{Line: 10, Column: 1},
 				},
 			},
 		},


### PR DESCRIPTION
So that it is possible to add a reason why we ignore a rule.

Inspiration from [`nolintlint` linter](https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint/README.md).