### PR TITLE
tflint: Allow config file to be set via `TFLINT_CONFIG_FILE`

### DIFF
--- a/docs/user-guide/config.md
+++ b/docs/user-guide/config.md
@@ -1,11 +1,11 @@
 # Configuring TFLint
 
-You can change the behavior not only in CLI flags but also in config files. By default, TFLint looks up `.tflint.hcl` according to the following priority:
+You can change the behavior not only in CLI flags but also in config files. TFLint loads config files according to the following priority order:
 
-- Current directory (`./.tflint.hcl`)
-- Home directory (`~/.tflint.hcl`)
-
-However, if `--chdir` or `--recursive` is used, the config file will be loaded relative to the module (changed) directory.
+1. File passed by the `--config` option
+2. File set by the `TFLINT_CONFIG_FILE` environment variable
+3. Current directory (`./.tflint.hcl`)
+4. Home directory (`~/.tflint.hcl`)
 
 The config file is written in [HCL](https://github.com/hashicorp/hcl). An example is shown below:
 
@@ -38,13 +38,7 @@ rule "aws_instance_invalid_type" {
 }
 ```
 
-You can also use another file as a config file with the `--config` option:
-
-```
-$ tflint --config other_config.hcl
-```
-
-This is also resolved relative to the module directory when `--chdir` or `--recursive` is used. To use a configuration file from the process working directory when recursing, pass an absolute path:
+The file path is resolved relative to the module directory when `--chdir` or `--recursive` is used. To use a config file from the working directory when recursing, pass an absolute path:
 
 ```sh
 tflint --recursive --config "$(pwd)/.tflint.hcl"

--- a/docs/user-guide/environment_variables.md
+++ b/docs/user-guide/environment_variables.md
@@ -4,6 +4,8 @@ Below is a list of environment variables available in TFLint.
 
 - `TFLINT_LOG`
   - Print logs to stderr. See [Debugging](../../README.md#debugging).
+- `TFLINT_CONFIG_FILE`
+  - Configure the config file path. See [Configuring TFLint](./config.md).
 - `TFLINT_PLUGIN_DIR`
   - Configure the plugin directory. See [Configuring Plugins](./plugins.md).
 - `TF_VAR_name`


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1828

This PR introduces a new environment variable called  `TFLINT_CONFIG_FILE`. This is a similar concept to [`TF_CLI_CONFIG_FILE`](https://developer.hashicorp.com/terraform/cli/config/environment-variables#tf_cli_config_file). This allows you to specify a config file without explicitly specifying it with `--config` option.

```console
# Same as `tflint --config=config.hcl`
TFLINT_CONFIG_FILE=config.hcl tflint
```

The environment variable has lower priority than `--config` option, and if they are set at the same time, the latter will be used. Similar to `--config` option, an error occurs if the file set by the environment variable does not exist.