### PR TITLE
tflint: Add `tflint-ignore-file` annotation

### DIFF
--- a/docs/user-guide/annotations.md
+++ b/docs/user-guide/annotations.md
@@ -54,3 +54,28 @@ resource "aws_instance" "foo" {
   instance_type = "t10.2xlarge" 
 }
 ```
+
+To disable an entire file, you can also use the `tflint-ignore-file` annotation:
+
+```hcl
+# tflint-ignore-file: aws_instance_invalid_type
+
+resource "aws_instance" "foo" {
+  instance_type = "t1.2xlarge"
+}
+```
+
+This annotation is valid only at the top of the file. The following cannot be used and will result in an error:
+
+```hcl
+resource "aws_instance" "foo" {
+  # tflint-ignore-file: aws_instance_invalid_type
+  instance_type = "t1.2xlarge"
+}
+```
+
+```hcl
+resource "aws_instance" "foo" { # tflint-ignore-file: aws_instance_invalid_type
+  instance_type = "t1.2xlarge"
+}
+```

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -530,7 +530,7 @@ func Test_EmitIssue(t *testing.T) {
 			},
 			Annotations: map[string]Annotations{
 				"test.tf": {
-					{
+					&LineAnnotation{
 						Content: "test_rule",
 						Token: hclsyntax.Token{
 							Type: hclsyntax.TokenComment,
@@ -653,7 +653,7 @@ func Test_EmitIssue(t *testing.T) {
 			},
 			Annotations: map[string]Annotations{
 				"module.tf": {
-					{
+					&LineAnnotation{
 						Content: "test_rule",
 						Token: hclsyntax.Token{
 							Type: hclsyntax.TokenComment,


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1641

This PR introduces a new annotation syntax called `tflint-ignore-file`. The `tflint-ignore-file` annotation differs from the traditional `tflint-ignore` annotation in that it targets the entire file rather than a specific line. By declaring it at the top of a file as shown below, you can ignore all issues of the target rule that occur in that file.

```hcl
# tflint-ignore-file: aws_instance_invalid_type

resource "aws_instance" "foo" {
  instance_type = "t1.2xlarge"
}
```

If this annotation is declared anywhere other than at the top of the file, it will return an error.