### PR TITLE
Print the working directory on error in recursive inspection

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -53,6 +53,10 @@ func (cli *CLI) inspect(opts Options) int {
 
 			moduleIssues, moduleChanges, err := cli.inspectModule(opts, ".", filterFiles)
 			if err != nil {
+				if len(workingDirs) > 1 {
+					// Print the current working directory in recursive inspection
+					return fmt.Errorf("%w working_dir=%s", err, wd)
+				}
 				return err
 			}
 			issues = append(issues, moduleIssues...)


### PR DESCRIPTION
After merging https://github.com/terraform-linters/tflint/pull/1918, errors are more likely to occur outside of the working directory as below.

```console
$ tflint --recursive
Failed to check ruleset; Failed to check `google_monitoring_alert_policy_invalid_combiner` rule: modules/monitoring/alert/variables.tf:155,1-42: Incorrect variable type; The resolved value of variable "gae_app_memory_usage_threshold" is not appropriate: list of object required.
```

This is an error that occurred in a called module and is difficult to fix because looking at `modules/monitoring/alert/variables.tf` doesn't tell you who called that module.

This PR adds the current working directory to the error output in recursive inspection to help troubleshoot such issues.

```console
$ tflint --recursive
Failed to check ruleset; Failed to check `google_monitoring_alert_policy_invalid_combiner` rule: modules/monitoring/alert/variables.tf:155,1-42: Incorrect variable type; The resolved value of variable "gae_app_memory_usage_threshold" is not appropriate: list of object required. working_dir=app1/staging
```