### PR TITLE
Exit with an error if the explicitly passed `.tflint.hcl` does not exist

### DIFF
--- a/cmd/option.go
+++ b/cmd/option.go
@@ -14,7 +14,7 @@ type Options struct {
 	Init                   bool     `long:"init" description:"Install plugins"`
 	Langserver             bool     `long:"langserver" description:"Start language server"`
 	Format                 string   `short:"f" long:"format" description:"Output format" choice:"default" choice:"json" choice:"checkstyle" choice:"junit" choice:"compact" choice:"sarif"`
-	Config                 string   `short:"c" long:"config" description:"Config file name" value-name:"FILE" default:".tflint.hcl"`
+	Config                 string   `short:"c" long:"config" description:"Config file name (default: .tflint.hcl)" value-name:"FILE"`
 	IgnoreModules          []string `long:"ignore-module" description:"Ignore module sources" value-name:"SOURCE"`
 	EnableRules            []string `long:"enable-rule" description:"Enable rules from the command line" value-name:"RULE_NAME"`
 	DisableRules           []string `long:"disable-rule" description:"Disable rules from the command line" value-name:"RULE_NAME"`

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -139,7 +139,7 @@ func EmptyConfig() *Config {
 // plugin block is not explicitly declared.
 func LoadConfig(fs afero.Afero, file string) (*Config, error) {
 	// Load the file passed by the --config option
-	if file != defaultConfigFile {
+	if file != "" {
 		log.Printf("[INFO] Load config: %s", file)
 		f, err := fs.Open(file)
 		if err != nil {
@@ -168,8 +168,8 @@ func LoadConfig(fs afero.Afero, file string) (*Config, error) {
 	}
 
 	// Load the default config file
-	log.Printf("[INFO] Load config: %s", file)
-	if f, err := fs.Open(file); err == nil {
+	log.Printf("[INFO] Load config: %s", defaultConfigFile)
+	if f, err := fs.Open(defaultConfigFile); err == nil {
 		cfg, err := loadConfig(f)
 		if err != nil {
 			return nil, err

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -134,7 +134,7 @@ plugin "baz" {
 		},
 		{
 			name: "TFLINT_CONFIG_FILE",
-			file: ".tflint.hcl",
+			file: "",
 			files: map[string]string{
 				"env.hcl": `
 config {
@@ -166,7 +166,7 @@ config {
 		},
 		{
 			name: "default home config",
-			file: ".tflint.hcl",
+			file: "",
 			files: map[string]string{
 				"/root/.tflint.hcl": `
 config {
@@ -195,7 +195,7 @@ config {
 		},
 		{
 			name:     "no config",
-			file:     ".tflint.hcl",
+			file:     "",
 			want:     EmptyConfig().enableBundledPlugin(),
 			errCheck: neverHappend,
 		},
@@ -234,7 +234,7 @@ plugin "terraform" {
 		},
 		{
 			name: "file not found with TFLINT_CONFIG_FILE",
-			file: ".tflint.hcl",
+			file: "",
 			envs: map[string]string{
 				"TFLINT_CONFIG_FILE": "not_found.hcl",
 			},


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1926

Previously, the default configuration file name (`.tflint.hcl`) was treated specially and did not return an error even if explicitly passed the file does not exist.

```console
$ tflint --config .tflint.hcl
// no errors
$ tflint --config config.hcl
Failed to load TFLint config; failed to load file: open config.hcl: no such file or directory
```

This is inconsistent, so this change will always return an error.

```console
$ tflint --config .tflint.hcl
Failed to load TFLint config; failed to load file: open .tflint.hcl: no such file or directory
```

