### PR TITLE
Make assignments to undeclared variables an error

### DIFF
--- a/terraform/input_value_test.go
+++ b/terraform/input_value_test.go
@@ -172,21 +172,11 @@ func TestParseVariableValues(t *testing.T) {
 			declared: map[string]*Variable{},
 			vars: []string{
 				"foo=bar",
-				"bar=[\"foo\"]",
-				"baz={ foo=\"bar\" }",
 			},
-			want: InputValues{
-				"foo": &InputValue{
-					Value: cty.StringVal("bar"),
-				},
-				"bar": &InputValue{
-					Value: cty.StringVal("[\"foo\"]"),
-				},
-				"baz": &InputValue{
-					Value: cty.StringVal("{ foo=\"bar\" }"),
-				},
+			want: InputValues{},
+			errCheck: func(diags hcl.Diagnostics) bool {
+				return diags.Error() != `<value for var.foo>:1,1-1: Value for undeclared variable; A variable named "foo" was assigned, but the root module does not declare a variable of that name.`
 			},
-			errCheck: neverHappend,
 		},
 		{
 			name: "declared",
@@ -219,7 +209,7 @@ func TestParseVariableValues(t *testing.T) {
 			vars:     []string{"foo"},
 			want:     InputValues{},
 			errCheck: func(diags hcl.Diagnostics) bool {
-				return diags.Error() != `<nil>: invalid variable value format; "foo" is invalid. Variables must be "key=value" format`
+				return diags.Error() != `<input-value>:1,1-1: invalid variable value format; "foo" is invalid. Variables must be "key=value" format`
 			},
 		},
 		{


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1877
See also https://github.com/hashicorp/terraform/blob/v1.5.7/internal/backend/unparsed_value.go

Previously assignments to undeclared variables was not an error, but this PR makes it an error:

```console
// Before
$ tflint --var foo=1
// No errors
```

```console
// After
$ tflint --var foo=1
Failed to parse variables; <value for var.foo>:1,1-1: Value for undeclared variable; A variable named "foo" was assigned, but the root module does not declare a variable of that name.:

Error: Value for undeclared variable

  on <value for var.foo> line 1:
  (source code not available)

A variable named "foo" was assigned, but the root module does not declare a variable of that name.
```

In most cases, the previous behavior will lead you to overlook misconfigurations, so this change will help you find problems sooner.

Note that the environment variables `TF_VAR_*` are not subject to this check. This is the same behavior as Terraform.