### PR TITLE
Avoid escaping newlines

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -45,7 +45,7 @@ func (cli *CLI) init(opts Options) int {
 
 				_, err := plugin.FindPluginPath(installCfg)
 				if os.IsNotExist(err) {
-					fmt.Fprintf(cli.outStream, `Installing "%s" plugin...\n`, pluginCfg.Name)
+					fmt.Fprintf(cli.outStream, "Installing \"%s\" plugin...\n", pluginCfg.Name)
 
 					sigchecker := plugin.NewSignatureChecker(installCfg)
 					if !sigchecker.HasSigningKey() {
@@ -57,7 +57,7 @@ func (cli *CLI) init(opts Options) int {
 						return fmt.Errorf("Failed to install a plugin; %w", err)
 					}
 
-					fmt.Fprintf(cli.outStream, `Installed "%s" (source: %s, version: %s)\n`, pluginCfg.Name, pluginCfg.Source, pluginCfg.Version)
+					fmt.Fprintf(cli.outStream, "Installed \"%s\" (source: %s, version: %s)\n", pluginCfg.Name, pluginCfg.Source, pluginCfg.Version)
 					continue
 				}
 
@@ -65,7 +65,7 @@ func (cli *CLI) init(opts Options) int {
 					return fmt.Errorf("Failed to find a plugin; %w", err)
 				}
 
-				fmt.Fprintf(cli.outStream, `Plugin "%s" is already installed\n`, pluginCfg.Name)
+				fmt.Fprintf(cli.outStream, "Plugin \"%s\" is already installed\n", pluginCfg.Name)
 			}
 
 			if opts.Recursive && !found {


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint/pull/1934

This PR fixes an issue where newlines were not rendered properly as a result of turning double quotes into backticks.