### PR TITLE
Fix panic for module calls without source

### DIFF
--- a/terraform/loader.go
+++ b/terraform/loader.go
@@ -96,6 +96,10 @@ func (l *Loader) LoadConfig(dir string, callModuleType CallModuleType) (*Config,
 func (l *Loader) moduleWalkerFunc(walkLocal, walkRemote bool) ModuleWalkerFunc {
 	return func(req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) {
 		switch source := req.SourceAddr.(type) {
+		case nil:
+			// Case for no source attribute. This is usually invalid, but is ignored to prevent panic.
+			return nil, nil, nil
+
 		case addrs.ModuleSourceLocal:
 			if !walkLocal {
 				return nil, nil, nil

--- a/terraform/test-fixtures/v0.15.0_module/module.tf
+++ b/terraform/test-fixtures/v0.15.0_module/module.tf
@@ -7,3 +7,5 @@ module "consul" {
    source = "hashicorp/consul/aws"
    version = "0.9.0"
 }
+
+module "no_source" {}


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint-ruleset-opa/pull/80

TFLint v0.50 now automatically calls local modules, so calling a module without a `source` attribute now causes a panic:

```console
$ cat main.tf
module "no_source" {}

$ tflint
Panic: unexpected module source type: <nil>
 -> 0: main.main.func1: /main.go(25)
 -> 1: runtime.gopanic: /panic.go(914)
 -> 2: github.com/terraform-linters/tflint/terraform.(*Loader).LoadConfig.(*Loader).moduleWalkerFunc.func4: /loader.go(143)
 -> 3: github.com/terraform-linters/tflint/terraform.ModuleWalkerFunc.LoadModule: /config.go(167)
 -> 4: github.com/terraform-linters/tflint/terraform.buildChildModules: /config.go(106)
 -> 5: github.com/terraform-linters/tflint/terraform.BuildConfig: /config.go(63)
 -> 6: github.com/terraform-linters/tflint/terraform.(*Loader).LoadConfig: /loader.go(89)
 -> 7: github.com/terraform-linters/tflint/cmd.(*CLI).setupRunners: /inspect.go(234)
 -> 8: github.com/terraform-linters/tflint/cmd.(*CLI).inspectModule: /inspect.go(131)
 -> 9: github.com/terraform-linters/tflint/cmd.(*CLI).inspect.func1: /inspect.go(54)
 -> 10: github.com/terraform-linters/tflint/cmd.(*CLI).withinChangedDir: /cli.go(187)
 -> 11: github.com/terraform-linters/tflint/cmd.(*CLI).inspect: /inspect.go(35)
 -> 12: github.com/terraform-linters/tflint/cmd.(*CLI).Run: /cli.go(106)
 -> 13: main.main: /main.go(38)
 -> 14: runtime.main: /proc.go(267)
 -> 15: runtime.goexit: /asm_amd64.s(1650)

TFLint crashed... :(
Please attach an output log, describe the situation and version that occurred and post an issue to https://github.com/terraform-linters/tflint/issues
```

Normally, calling a module without source is invalid, but it is undesirable to cause a panic. This PR changes the module walker to simply ignore such module calls, which prevents the panic.