### PR TITLE
Add warnings to --module/--no-module and `module` attribute

### DIFF
--- a/cmd/option.go
+++ b/cmd/option.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/terraform-linters/tflint/terraform"
@@ -59,10 +61,12 @@ func (opts *Options) toConfig() *tflint.Config {
 	callModuleTypeSet := false
 	// --call-module-type takes precedence over --module/--no-module. This is for backward compatibility.
 	if opts.Module != nil {
+		fmt.Fprintln(os.Stderr, "WARNING: --module is deprecated. Use --call-module-type=all instead.")
 		callModuleType = terraform.CallAllModule
 		callModuleTypeSet = true
 	}
 	if opts.NoModule != nil {
+		fmt.Fprintln(os.Stderr, "WARNING: --no-module is deprecated. Use --call-module-type=none instead.")
 		callModuleType = terraform.CallNoModule
 		callModuleTypeSet = true
 	}

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -241,6 +241,7 @@ func loadConfig(file afero.File) (*Config, error) {
 				// "module" attribute is deprecated. Use "call_module_type" instead.
 				// This is for backward compatibility.
 				case "module":
+					fmt.Fprintf(os.Stderr, "WARNING: \"module\" attribute in %s is deprecated. Use \"call_module_type\" instead.\n", file.Name())
 					if config.CallModuleTypeSet {
 						// If "call_module_type" is set, ignore "module" attribute
 						continue


### PR DESCRIPTION
Follow up of https://github.com/terraform-linters/tflint/pull/1918

The `--call-module-type` flag and the `call_module_type` attribute introduced in TFLint v0.50 have deprecated the `--module`/`--no-module` and the `module` attribute. To encourage migration to these, this PR adds warnings to stderr for the use of deprecated flags or attributes.

```console
$ tflint --module
WARNING: --module is deprecated. Use --call-module-type=all instead.

$ tflint --no-module
WARNING: --no-module is deprecated. Use --call-module-type=none instead.

$ tflint
WARNING: "module" attribute in .tflint.hcl is deprecated. Use "call_module_type" instead.
```