### PR TITLE
Fix a bug where auto-fixed code could not be retrieved via GetFile API

### DIFF
--- a/integrationtest/autofix/autofix_test.go
+++ b/integrationtest/autofix/autofix_test.go
@@ -71,6 +71,11 @@ func TestIntegration(t *testing.T) {
 			Dir:     "chdir",
 		},
 		{
+			Name:    "--chdir with conflict",
+			Command: "./tflint --chdir=dir --format json --fix",
+			Dir:     "chdir_with_conflict",
+		},
+		{
 			Name:    "--filter",
 			Command: "./tflint --format json --fix --filter=main.tf",
 			Dir:     "filter",

--- a/integrationtest/autofix/chdir_with_conflict/dir/.tflint.hcl
+++ b/integrationtest/autofix/chdir_with_conflict/dir/.tflint.hcl
@@ -1,0 +1,3 @@
+plugin "testing" {
+  enabled = true
+}

--- a/integrationtest/autofix/chdir_with_conflict/dir/main.tf
+++ b/integrationtest/autofix/chdir_with_conflict/dir/main.tf
@@ -1,0 +1,4 @@
+// autofixed
+resource "aws_instance" "autofixed_foo" {
+  instance_type = "[AUTO_FIXED]"
+}

--- a/integrationtest/autofix/chdir_with_conflict/dir/main.tf.fixed
+++ b/integrationtest/autofix/chdir_with_conflict/dir/main.tf.fixed
@@ -1,0 +1,4 @@
+# autofixed
+resource "aws_instance" "autofixed_foo" {
+  instance_type = "t2.micro" # autofixed
+}

--- a/integrationtest/autofix/chdir_with_conflict/result.json
+++ b/integrationtest/autofix/chdir_with_conflict/result.json
@@ -1,0 +1,85 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "terraform_autofix_comment",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "Use \"# autofixed\" instead of \"// autofixed\"",
+      "range": {
+        "filename": "dir/main.tf",
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 2,
+          "column": 1
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is [AUTO_FIXED]",
+      "range": {
+        "filename": "dir/main.tf",
+        "start": {
+          "line": 3,
+          "column": 19
+        },
+        "end": {
+          "line": 3,
+          "column": 33
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_instance_autofix_conflict",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is [AUTO_FIXED]",
+      "range": {
+        "filename": "dir/main.tf",
+        "start": {
+          "line": 3,
+          "column": 19
+        },
+        "end": {
+          "line": 3,
+          "column": 33
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "terraform_autofix_comment",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "Use \"# autofixed\" instead of \"// autofixed\"",
+      "range": {
+        "filename": "dir/main.tf",
+        "start": {
+          "line": 3,
+          "column": 30
+        },
+        "end": {
+          "line": 4,
+          "column": 1
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/autofix/chdir_with_conflict/result_windows.json
+++ b/integrationtest/autofix/chdir_with_conflict/result_windows.json
@@ -1,0 +1,85 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "terraform_autofix_comment",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "Use \"# autofixed\" instead of \"// autofixed\"",
+      "range": {
+        "filename": "dir\\main.tf",
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 2,
+          "column": 1
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is [AUTO_FIXED]",
+      "range": {
+        "filename": "dir\\main.tf",
+        "start": {
+          "line": 3,
+          "column": 19
+        },
+        "end": {
+          "line": 3,
+          "column": 33
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_instance_autofix_conflict",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is [AUTO_FIXED]",
+      "range": {
+        "filename": "dir\\main.tf",
+        "start": {
+          "line": 3,
+          "column": 19
+        },
+        "end": {
+          "line": 3,
+          "column": 33
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "terraform_autofix_comment",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "Use \"# autofixed\" instead of \"// autofixed\"",
+      "range": {
+        "filename": "dir\\main.tf",
+        "start": {
+          "line": 3,
+          "column": 30
+        },
+        "end": {
+          "line": 4,
+          "column": 1
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/plugin/server.go
+++ b/plugin/server.go
@@ -77,6 +77,7 @@ func (s *GRPCServer) GetFile(name string) (*hcl.File, error) {
 		return file, nil
 	}
 	// If the file is not found in the current module, it may be in other modules (e.g. root module).
+	log.Printf(`[DEBUG] The file "%s" is not found in the current module. Fall back to global caches.`, name)
 	return s.files[name], nil
 }
 

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -215,9 +215,7 @@ func (r *Runner) File(path string) *hcl.File {
 func (r *Runner) Files() map[string]*hcl.File {
 	result := make(map[string]*hcl.File)
 	for name, file := range r.TFConfig.Module.Files {
-		if filepath.Dir(name) == filepath.Clean(r.TFConfig.Module.SourceDir) {
-			result[name] = file
-		}
+		result[name] = file
 	}
 	return result
 }

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -292,7 +292,6 @@ func Test_RunnerFiles(t *testing.T) {
 	runner := TestRunner(t, map[string]string{
 		"main.tf": "",
 	})
-	runner.TFConfig.Module.Files["child/main.tf"] = &hcl.File{}
 
 	expected := map[string]*hcl.File{
 		"main.tf": {


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1958

Autofix saves the fixed file in memory and writes them to the file system at the end. Therefore, if each rule always loads files from the file system, there is a problem that autofix that have been applied halfway cannot be properly reflected. To prevent this, TFLint's plugin server has the `GetFile` API that returns files based on auto-fixed code.

https://github.com/terraform-linters/tflint/blob/cc6168ccf8c14831c7bd6a09e16630a79120cec2/plugin/server.go#L73-L81

The auto-fixed code is applied in the runner by `runner.ApplyChanges`, so it can be retrieved in `runner.Files`.

However, there was a bug in `runner.Files` that prevented it from returning properly fixed files. As a result, it fell back to `GRPCServer.files` and returned the code before the fix, which caused HCL parsing errors due to unintended range parsing.

The details of the bug are incorrect filtering based on module directory. The `runner.Files` returns only the files that make up a Terraform module that match the module's source directory.

https://github.com/terraform-linters/tflint/blob/cc6168ccf8c14831c7bd6a09e16630a79120cec2/tflint/runner.go#L214-L223

In this case, the `SourceDir` will match in most cases, but if `--chdir` or `--recursive` is used, the `SourceDir` will be a relative path from the changed directory, while the `Files` path will be relative from the original directory. For example, when executed with `--chdir=subdir`, the `SourceDir` will be "./" and the File path will be "subdir/main.tf".

To fix this bug, I completely removed filtering by module directory. Originally, this was introduced to avoid returning all files parsed by the HCL parser https://github.com/terraform-linters/tflint/pull/762. However, in https://github.com/terraform-linters/tflint/pull/1428, `runner.files` was replaced with the Terraform module files instead of the parser sources, so this filtering is no longer effective.
https://github.com/terraform-linters/tflint/pull/1428/files#diff-1949a8b20814ca4596fa340c7409af6fb657da070446c633b42cfa095a10d2d9L447-R350