### PR TITLE
Added snap installation option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Bash script (Linux):
 curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
 ```
 
+Snap (Ubuntu and other Linux distributions with snapd installed)
+
+```console
+sudo snap install tflint
+```
+NOTE: The [tflint](https://snapcraft.io/tflint) snap is NOT directly maintained by the TFLint maintainers. The latest version is always available by manual installation.
+
 Homebrew (macOS):
 
 ```console


### PR DESCRIPTION
I've been serving tflint using a snap for about 6 months, about 400 weekly users. I can continue that (I normally update within a few days after a new upstream release), but I'm also open to merge the snap build code into the main repo if you're interested of that.