### PR TITLE
Ignore module issues that are not valid expressions

### DIFF
--- a/plugin/server.go
+++ b/plugin/server.go
@@ -188,6 +188,9 @@ func (s *GRPCServer) EvaluateExpr(expr hcl.Expression, opts sdk.EvaluateExprOpti
 }
 
 // EmitIssue stores an issue in the server based on passed rule, message, and location.
+// It attempts to detect whether the issue range represents an expression and emits it based on that context.
+// However, some ranges may be syntactically valid but not actually represent an expression.
+// In these cases, the "expression" is still provided as context and the client should ignore any errors when attempting to evaluate it.
 func (s *GRPCServer) EmitIssue(rule sdk.Rule, message string, location hcl.Range, fixable bool) (bool, error) {
 	// If the issue range represents an expression, it is emitted based on that context.
 	// This is required to emit issues in called modules.

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -319,14 +319,18 @@ func (r *Runner) listModuleVars(expr hcl.Expression) []*moduleVariable {
 	return ret
 }
 
+// listVarRefs returns the references in the expression.
+// If the expression is not a valid expression, it returns an empty map.
 func listVarRefs(expr hcl.Expression) map[string]addrs.InputVariable {
+	ret := map[string]addrs.InputVariable{}
 	refs, diags := lang.ReferencesInExpr(expr)
+
 	if diags.HasErrors() {
-		// Maybe this is bug
-		panic(diags)
+		// If we cannot determine the references in the expression, it is likely a valid HCL expression, but not a valid Terraform expression.
+		// The declaration range of a block with no labels is its name, which is syntactically valid as an HCL expression, but is not a valid Terraform reference.
+		return ret
 	}
 
-	ret := map[string]addrs.InputVariable{}
 	for _, ref := range refs {
 		if varRef, ok := ref.Subject.(addrs.InputVariable); ok {
 			ret[varRef.String()] = varRef

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -820,6 +820,11 @@ func Test_listVarRefs(t *testing.T) {
 				"var.tags": {Name: "tags"},
 			},
 		},
+		{
+			Name:     "invalid expression",
+			Expr:     "my_block",
+			Expected: map[string]addrs.InputVariable{},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
When filtering emitted issues from child modules, ignore any issue covering an expression that cannot be parsed for references. Fixes a panic described in #1968.

`EmitIssue` may be called for a range that is not actually a valid Terraform expression. But TFLint just [checks](https://github.com/terraform-linters/tflint/blob/5ed807d0d4ab05fc81d9b3c9db623d3ee937ba2e/plugin/server.go#L213) whether the range's source is a valid _HCL_ expression. Something like `my_block` is a valid HCL expression, but it's not a valid expression in Terraform when it's a child block of a `resource`. Some declaration ranges (e.g., blocks with labels) are not valid HCL expressions either, but unlabeled block declarations (name, without braces) are syntactically valid expressions.

So `listVarRefs` must handle invalid expressions. Or callers must be able to specify that they are emitting an issue on a non-expression range, which would likely require a breaking change somewhere.

Closes https://github.com/terraform-linters/tflint/issues/1968
Closes https://github.com/terraform-linters/tflint-ruleset-opa/issues/85