### PR TITLE
release: fix `$EDITOR` handling

### DIFF
--- a/tools/release/main.go
+++ b/tools/release/main.go
@@ -233,7 +233,16 @@ func editFileInteractive(path string) error {
 	if e := os.Getenv("EDITOR"); e != "" {
 		editor = e
 	}
-	return execCommand(os.Stdout, editor, path)
+	return execShellCommand(os.Stdout, fmt.Sprintf("%s %s", editor, path))
+}
+
+func execShellCommand(stdout io.Writer, command string) error {
+	shell := "sh"
+	if s := os.Getenv("SHELL"); s != "" {
+		shell = s
+	}
+
+	return execCommand(stdout, shell, "-c", command)
 }
 
 func execCommand(stdout io.Writer, name string, args ...string) error {


### PR DESCRIPTION
`$EDITOR` should be handled as a shell command and not passed directly to exec.

VS Code, for example, needs $EDITOR to be set to `code --wait --new-window` to get the desired behavior.