### PR TITLE
test: use darwin_arm64 compatible aws plugin

### DIFF
--- a/plugin/install_test.go
+++ b/plugin/install_test.go
@@ -16,7 +16,7 @@ func Test_Install(t *testing.T) {
 	config := NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{
 		Name:        "aws",
 		Enabled:     true,
-		Version:     "0.4.0",
+		Version:     "0.29.0",
 		Source:      "github.com/terraform-linters/tflint-ruleset-aws",
 		SourceHost:  "github.com",
 		SourceOwner: "terraform-linters",


### PR DESCRIPTION
Missed in #1972 because Actions still uses Intel by default and doesn't offer larger runners without a paid org:

https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-macos-larger-runners

Otherwise, `make test` fails on modern Macs:

```
--- FAIL: Test_Install (1.31s)
    install_test.go:28: Failed to install: Failed to download tflint-ruleset-aws_darwin_arm64.zip: file not found in the GitHub release. Does the release contain the file with the correct name ?
```