### PR TITLE
test: document git submodule requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 default: build
 
 prepare:
+	git submodule init
+	git submodule update
 	go run ./plugin/stub-generator
 
 test: prepare

--- a/docs/developer-guide/building.md
+++ b/docs/developer-guide/building.md
@@ -18,6 +18,13 @@ If you change code, make sure that the tests you add and existing tests will be 
 $ make test
 ```
 
+Some tests depending on Git submodules. Running `make test` will update these automatically, but if you run tests directly with `go test`, you need to update submodules manually:
+
+```sh
+git submodule init
+git submodule update
+```
+
 ## Run E2E tests
 
 You can check the actual CLI behavior by running the E2E tests. Since the E2E tests uses the installed `tflint` command, it is necessary to add the path into `$PATH` environment so that the binary built by `go install` can be referenced.

--- a/terraform/loader_test.go
+++ b/terraform/loader_test.go
@@ -609,7 +609,7 @@ func testChildModule(t *testing.T, config *Config, key string, wantPath string) 
 	t.Helper()
 
 	if _, exists := config.Children[key]; !exists {
-		t.Fatalf("`%s` module is not loaded: %#v", key, config.Children)
+		t.Fatalf("`%s` module is not loaded, are submodules downloaded?: %#v", key, config.Children)
 	}
 	modulePath := config.Children[key].Module.SourceDir
 	if modulePath != wantPath {


### PR DESCRIPTION
Documents the use of submodules for tests and automatically installs them via `make test`. 