### PR TITLE
feat: use go1.22

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
+        cache: true
     - name: goreleaser check
       uses: goreleaser/goreleaser-action@v5
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
+        cache: true
     - name: Run linters
       uses: golangci/golangci-lint-action@v3.7.0
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
+        cache: true
     - name: Install Cosign
       uses: sigstore/cosign-installer@v3.4.0
     - name: Run GoReleaser

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.21-alpine3.18 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine3.19 as builder
 
 ARG TARGETOS TARGETARCH
 

--- a/docs/developer-guide/building.md
+++ b/docs/developer-guide/building.md
@@ -1,6 +1,6 @@
 # Building TFLint
 
-Go 1.21 or higher is required to build TFLint from source code. Clone the source code and run the `make` command. Built binary will be placed in `dist` directory.
+Go 1.22 or higher is required to build TFLint from source code. Clone the source code and run the `make` command. Built binary will be placed in `dist` directory.
 
 ```console
 $ git clone https://github.com/terraform-linters/tflint.git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-linters/tflint
 
-go 1.21.1
+go 1.22
 
 require (
 	github.com/agext/levenshtein v1.2.3


### PR DESCRIPTION
- bump to use go1.22
- update base docker image
- update docs to specify go1.22
- enable caching everywhere `setup-go` is used