### PR TITLE
Set bash pipefail mode in install_linux.sh to catch curl errors

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 get_machine_arch () {
     machine_arch=""


### PR DESCRIPTION
Command output is piped into subsequent commands three places in this script (two `curl`s and one `dpkg`) and in all of them the script exiting with error, as requested with the existing `set -e`, would be preferable to silently succeeding if the curl or `dpkg` command fails to produce the expected text output.  The `--fail` option passed to curl both times, explicitly requests this behavior, but without `-o pipefail` it does not work.