### PR TITLE
workflows: remove `cache` config for setup-go action (as it tunred on by default)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
-        cache: true
     - name: Run test
       run: make test
       env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
-        cache: true
     - name: Run e2e
       run: make e2e
       env:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -14,7 +14,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
-        cache: true
     - run: go generate ./...
     - run: git add --intent-to-add .
     - run: git diff --exit-code

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -20,7 +20,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
-        cache: true
     - name: goreleaser check
       uses: goreleaser/goreleaser-action@v5
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
-        cache: true
     - name: Run linters
       uses: golangci/golangci-lint-action@v3.7.0
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
-        cache: true
     - name: Install Cosign
       uses: sigstore/cosign-installer@v3.4.0
     - name: Run GoReleaser


### PR DESCRIPTION
actually no need to specify `cache` attribute as it turned on by default

<img width="703" alt="image" src="https://github.com/terraform-linters/tflint/assets/1580956/8b15b641-5c0b-4114-9e78-9c363a01b2ee">

ref https://github.com/actions/setup-go?tab=readme-ov-file#caching-dependency-files-and-build-outputs