### PR TITLE
plugin: Add support for host-specific GitHub tokens

### DIFF
--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -74,6 +74,20 @@ To increase the rate limit, you can send an authenticated request by authenticat
 
 It's also a good idea to cache the plugin directory, as TFLint will only send requests if plugins aren't installed. The [setup-tflint action](https://github.com/terraform-linters/setup-tflint#usage) includes an example of caching in GitHub Actions.
 
+If you host your plugins on GitHub Enterprise Server (GHES), you may want to use tokens differently from GitHub.com. In this case, you can use a host-specific token like `GITHUB_TOKEN_example_com`. The hostname must be normalized with Punycode, and you can use "_" instead of "." and "__" instead of "-".
+
+```hcl
+# GITHUB_TOKEN will be used
+plugin "foo" {
+  source = "github.com/org/tflint-ruleset-foo"
+}
+
+# GITHUB_TOKEN_example_com will be used preferentially and will fall back to GITHUB_TOKEN if not set.
+plugin "bar" {
+  source = "example.com/org/tflint-ruleset-bar"
+}
+```
+
 ## Keeping plugins up to date
 
 We recommend using automatic updates to keep your plugin version up-to-date. [Renovate supports TFLint plugins](https://docs.renovatebot.com/modules/manager/tflint-plugin/) to easily set up automated update workflows.

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -74,7 +74,7 @@ To increase the rate limit, you can send an authenticated request by authenticat
 
 It's also a good idea to cache the plugin directory, as TFLint will only send requests if plugins aren't installed. The [setup-tflint action](https://github.com/terraform-linters/setup-tflint#usage) includes an example of caching in GitHub Actions.
 
-If you host your plugins on GitHub Enterprise Server (GHES), you may want to use tokens differently from GitHub.com. In this case, you can use a host-specific token like `GITHUB_TOKEN_example_com`. The hostname must be normalized with Punycode, and you can use "_" instead of "." and "__" instead of "-".
+If you host your plugins on GitHub Enterprise Server (GHES), you may need to use a different token than on GitHub.com. In this case, you can use a host-specific token like `GITHUB_TOKEN_example_com`. The hostname must be normalized with Punycode. Use "_" instead of "." and "__" instead of "-".
 
 ```hcl
 # GITHUB_TOKEN will be used

--- a/plugin/install_test.go
+++ b/plugin/install_test.go
@@ -84,3 +84,135 @@ func TestNewGitHubClient(t *testing.T) {
 		})
 	}
 }
+
+func TestGetGitHubToken(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *InstallConfig
+		envs   map[string]string
+		want   string
+	}{
+		{
+			name: "no token",
+			config: &InstallConfig{
+				PluginConfig: &tflint.PluginConfig{
+					SourceHost: "github.com",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "GITHUB_TOKEN",
+			config: &InstallConfig{
+				PluginConfig: &tflint.PluginConfig{
+					SourceHost: "github.com",
+				},
+			},
+			envs: map[string]string{
+				"GITHUB_TOKEN": "github_com_token",
+			},
+			want: "github_com_token",
+		},
+		{
+			name: "GITHUB_TOKEN_example_com",
+			config: &InstallConfig{
+				PluginConfig: &tflint.PluginConfig{
+					SourceHost: "example.com",
+				},
+			},
+			envs: map[string]string{
+				"GITHUB_TOKEN_example_com": "example_com_token",
+			},
+			want: "example_com_token",
+		},
+		{
+			name: "GITHUB_TOKEN and GITHUB_TOKEN_example_com",
+			config: &InstallConfig{
+				PluginConfig: &tflint.PluginConfig{
+					SourceHost: "example.com",
+				},
+			},
+			envs: map[string]string{
+				"GITHUB_TOKEN":             "github_com_token",
+				"GITHUB_TOKEN_example_com": "example_com_token",
+			},
+			want: "example_com_token",
+		},
+		{
+			name: "GITHUB_TOKEN_example_com and GITHUB_TOKEN_example_org",
+			config: &InstallConfig{
+				PluginConfig: &tflint.PluginConfig{
+					SourceHost: "example.com",
+				},
+			},
+			envs: map[string]string{
+				"GITHUB_TOKEN_example_com": "example_com_token",
+				"GITHUB_TOKEN_example_org": "example_org_token",
+			},
+			want: "example_com_token",
+		},
+		{
+			name: "GITHUB_TOKEN_{source_host} found, but source host is not matched",
+			config: &InstallConfig{
+				PluginConfig: &tflint.PluginConfig{
+					SourceHost: "example.org",
+				},
+			},
+			envs: map[string]string{
+				"GITHUB_TOKEN_example_com": "example_com_token",
+			},
+			want: "",
+		},
+		{
+			name: "GITHUB_TOKEN_{source_host} and GITHUB_TOKEN found, but source host is not matched",
+			config: &InstallConfig{
+				PluginConfig: &tflint.PluginConfig{
+					SourceHost: "example.org",
+				},
+			},
+			envs: map[string]string{
+				"GITHUB_TOKEN_example_com": "example_com_token",
+				"GITHUB_TOKEN":             "github_com_token",
+			},
+			want: "github_com_token",
+		},
+		{
+			name: "GITHUB_TOKEN_xn--lhr645fjve.jp",
+			config: &InstallConfig{
+				PluginConfig: &tflint.PluginConfig{
+					SourceHost: "総務省.jp",
+				},
+			},
+			envs: map[string]string{
+				"GITHUB_TOKEN_xn--lhr645fjve.jp": "mic_jp_token",
+			},
+			want: "mic_jp_token",
+		},
+		{
+			name: "GITHUB_TOKEN_xn____lhr645fjve_jp",
+			config: &InstallConfig{
+				PluginConfig: &tflint.PluginConfig{
+					SourceHost: "総務省.jp",
+				},
+			},
+			envs: map[string]string{
+				"GITHUB_TOKEN_xn____lhr645fjve_jp": "mic_jp_token",
+			},
+			want: "mic_jp_token",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("GITHUB_TOKEN", "")
+			for k, v := range test.envs {
+				t.Setenv(k, v)
+			}
+
+			got := test.config.getGitHubToken()
+			if got != test.want {
+				t.Errorf("got %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/2005

This PR adds support for host-specific GitHub tokens like `GITHUB_TOKEN_example_com`.

Previously, the `GITHUB_TOKEN` environment variable was supported during plugin installation for private repositories and to avoid rate limits. However, as explained in #2004 and #2005, when using GitHub.com and GHES together as plugin source hosts, there was a problem where different access tokens could not be used for each.

To solve this, we will introduce environment variables that are only used in GHES. For example, if a plugin is hosted on example.com, `GITHUB_TOKEN_example_com` will only be used when installing a plugin whose `source` is "example.com".

```hcl
# GITHUB_TOKEN will be used
plugin "foo" {
  source = "github.com/org/tflint-ruleset-foo"
}

# GITHUB_TOKEN_example_com will be used preferentially and will fall back to GITHUB_TOKEN if not set.
plugin "bar" {
  source = "example.com/org/tflint-ruleset-bar"
}
```

This allows you to install plugins from GitHub.com and GHES at the same time by setting `GITHUB_TOKEN` and `GITHUB_TOKEN_example_com`.

Please note that host names used as environment variables must be normalized in Punycode. You can also use "_" instead of "." and "__" instead of "-".