### PR TITLE
config: Add TFLint `required_version` settings

### DIFF
--- a/docs/user-guide/config.md
+++ b/docs/user-guide/config.md
@@ -10,6 +10,10 @@ You can change the behavior not only in CLI flags but also in config files. TFLi
 The config file is written in [HCL](https://github.com/hashicorp/hcl). An example is shown below:
 
 ```hcl
+tflint {
+  required_version = ">= 0.50"
+}
+
 config {
   format = "compact"
   plugin_dir = "~/.tflint.d/plugins"
@@ -43,6 +47,11 @@ The file path is resolved relative to the module directory when `--chdir` or `--
 ```sh
 tflint --recursive --config "$(pwd)/.tflint.hcl"
 ```
+
+### `required_version`
+
+Restrict the TFLint version used. This is almost the same as [Terraform's `required_version`](https://developer.hashicorp.com/terraform/language/settings#specifying-a-required-terraform-version).
+You can write version constraints in the same way.
 
 ### `format`
 


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/1217

This PR adds `required_version` attribute to TFLint's configuration in preparation for https://github.com/terraform-linters/tflint/issues/1953.

This is roughly equivalent to [Terraform's `required_version`](https://developer.hashicorp.com/terraform/language/settings#specifying-a-required-terraform-version), and similar constraints can be placed on TFLint's version:

```hcl
tflint {
  required_version = "> 0.51"
}
```

```console
$ tflint
Failed to load TFLint config; .tflint.hcl:2,22-30: Unsupported TFLint version; This config does not support the currently used TFLint version 0.50.3. Please update to another supported version or change the version requirement.:

Error: Unsupported TFLint version

  on .tflint.hcl line 2:
  (source code not available)

This config does not support the currently used TFLint version 0.50.3. Please update to another supported version or change the version requirement.
```

(During this work, I noticed that if there is an error in the configuration file, the diagnostics will not include the source code, but this will be fixed as a separate issue.)

This allows you to quickly provide problem feedback without exposing users to vague errors during future syntax changes.

If the `required_version` is not declared, the version error will not occur as before. This is an optional feature that may be useful if multiple developers may use different versions of TFLint.

You may have noticed that `required_version` is no longer an attribute in the `config` block, but a new `tflint` block has been introduced. This is in preparation for #1953, and I plan to gradually migrate attributes related to TFLint settings to the `tflint` block. I made this choice from the beginning because the `required_version` needs to be as compatible as possible.