### PR TITLE
Pin Go patch version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-linters/tflint
 
-go 1.22
+go 1.22.2
 
 require (
 	github.com/agext/levenshtein v1.2.3


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint/actions/runs/8924581586/job/24511211255?pr=1991
See https://github.com/golang/go/issues/62278

In Go 1.21+, it seems that the `go` directive in `go.mod` must specify the patch version.
I haven't been able to dig deeper into why it was working correctly so far, but it seems that at least the problem occurs when you use it with a module that specifies the patch version.