### PR TITLE
release: Introduce Artifact Attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  attestations: write
 
 jobs:
   goreleaser:
@@ -32,3 +33,6 @@ jobs:
         args: release --rm-dist --release-notes tools/release/release-note.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: 'dist/checksums.txt'

--- a/README.md
+++ b/README.md
@@ -40,10 +40,21 @@ NOTE: The Chocolatey package is NOT directly maintained by the TFLint maintainer
 
 ### Verification
 
-Releases are signed by [Cosign](https://github.com/sigstore/cosign). `cosign verify-blob` ensures that the release was built with this repository's GitHub Actions.
+#### Cosign
 
-```
+[Cosign](https://github.com/sigstore/cosign) `verify-blob` command ensures that the release was built with GitHub Actions in this repository.
+
+```console
 cosign verify-blob --certificate=checksums.txt.pem --signature=checksums.txt.keyless.sig --certificate-identity-regexp="^https://github.com/terraform-linters/tflint" --certificate-oidc-issuer=https://token.actions.githubusercontent.com checksums.txt
+sha256sum --ignore-missing -c checksums.txt
+```
+
+#### GitHub CLI (Beta)
+
+[Artifact Attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) are available that can be verified using the GitHub CLI.
+
+```console
+gh attestation verify checksums.txt -R terraform-linters/tflint
 sha256sum --ignore-missing -c checksums.txt
 ```
 


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint/issues/1351

GitHub recently introduced Artifact Attestations.
https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/

This PR adds a step to build Artifact Attestations in the release workflow. It's currently in public beta, so it's not recommended for all users, but it's simpler than Cosign, so you might want to migrate to it in the future.

In the future, we hope that Artifact Attestations will also be used for plugin verification.