### PR TITLE
go: remove loop variable copying

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
   enable:
     - gci
     - gofmt
+    - copyloopvar
 issues:
   exclude-dirs:
     - terraform/

--- a/plugin/install_test.go
+++ b/plugin/install_test.go
@@ -70,8 +70,6 @@ func TestNewGitHubClient(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			client, err := newGitHubClient(context.Background(), tc.config)
 			if err != nil {


### PR DESCRIPTION
Removes unnecessary loop variable copying

https://go.dev/blog/loopvar-preview