### PR TITLE
terraform: Fix `provider::terraform::*` function names

### DIFF
--- a/integrationtest/inspection/functions/main.tf
+++ b/integrationtest/inspection/functions/main.tf
@@ -11,5 +11,5 @@ resource "aws_instance" "provider" {
 }
 
 resource "aws_instance" "builtin_provider" {
-  instance_type = provider::terraform::tfvarsencode({ a = 1 })
+  instance_type = provider::terraform::encode_tfvars({ a = 1 })
 }

--- a/integrationtest/inspection/functions/result.json
+++ b/integrationtest/inspection/functions/result.json
@@ -55,7 +55,7 @@
         },
         "end": {
           "line": 14,
-          "column": 63
+          "column": 64
         }
       },
       "callers": []

--- a/terraform/evaluator_test.go
+++ b/terraform/evaluator_test.go
@@ -158,7 +158,7 @@ variable "string_var" {
 		},
 		{
 			name:     "built-in provider-defined functions",
-			expr:     expr(`provider::terraform::tfvarsdecode("a = 1")`),
+			expr:     expr(`provider::terraform::decode_tfvars("a = 1")`),
 			ty:       cty.Object(map[string]cty.Type{"a": cty.Number}),
 			want:     `cty.ObjectVal(map[string]cty.Value{"a":cty.NumberIntVal(1)})`,
 			errCheck: neverHappend,

--- a/terraform/lang/funcs/terraform/functions.go
+++ b/terraform/lang/funcs/terraform/functions.go
@@ -15,7 +15,7 @@ import (
 	"github.com/zclconf/go-cty/cty/function"
 )
 
-var TFVarsEncodeFunc = function.New(&function.Spec{
+var EncodeTfvarsFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
 		{
 			Name:             "value",
@@ -88,7 +88,7 @@ var TFVarsEncodeFunc = function.New(&function.Spec{
 	},
 })
 
-var TFVarsDecodeFunc = function.New(&function.Spec{
+var DecodeTfvarsFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
 		{
 			Name:      "src",
@@ -131,7 +131,7 @@ var TFVarsDecodeFunc = function.New(&function.Spec{
 		// stuff HCL diagnostics into plain string error messages. This produces
 		// a non-ideal result but is still better than hiding the HCL-provided
 		// diagnosis altogether.
-		f, hclDiags := hclsyntax.ParseConfig(src, "<tfvarsdecode argument>", hcl.InitialPos)
+		f, hclDiags := hclsyntax.ParseConfig(src, "<decode_tfvars argument>", hcl.InitialPos)
 		if hclDiags.HasErrors() {
 			return cty.NilVal, fmt.Errorf("invalid tfvars syntax: %s", hclDiags.Error())
 		}
@@ -155,7 +155,7 @@ var TFVarsDecodeFunc = function.New(&function.Spec{
 	},
 })
 
-var ExprEncodeFunc = function.New(&function.Spec{
+var EncodeExprFunc = function.New(&function.Spec{
 	Params: []function.Parameter{
 		{
 			Name:             "value",

--- a/terraform/lang/funcs/terraform/functions_test.go
+++ b/terraform/lang/funcs/terraform/functions_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func TestTFVarsEncode(t *testing.T) {
+func TestEncodeTfvars(t *testing.T) {
 	tests := []struct {
 		Input   cty.Value
 		Want    cty.Value
@@ -128,7 +128,7 @@ two   = 2
 
 	for _, test := range tests {
 		t.Run(test.Input.GoString(), func(t *testing.T) {
-			got, err := TFVarsEncodeFunc.Call([]cty.Value{test.Input})
+			got, err := EncodeTfvarsFunc.Call([]cty.Value{test.Input})
 			if test.WantErr != "" {
 				if err == nil {
 					t.Fatalf("unexpected success for %#v; want error\ngot: %#v", test.Input, got)
@@ -148,7 +148,7 @@ two   = 2
 	}
 }
 
-func TestTFVarsDecode(t *testing.T) {
+func TestDecodeTfvars(t *testing.T) {
 	tests := []struct {
 		Input   cty.Value
 		Want    cty.Value
@@ -179,25 +179,25 @@ number = 2`),
 			// This is actually not a very good diagnosis for this error,
 			// since we're expecting HCL arguments rather than HCL blocks,
 			// but that's something we'd need to address in HCL.
-			WantErr: `invalid tfvars syntax: <tfvarsdecode argument>:1,17-17: Invalid block definition; Either a quoted string block label or an opening brace ("{") is expected here.`,
+			WantErr: `invalid tfvars syntax: <decode_tfvars argument>:1,17-17: Invalid block definition; Either a quoted string block label or an opening brace ("{") is expected here.`,
 		},
 		{
 			Input:   cty.StringVal(`foo = not valid syntax`),
-			WantErr: `invalid tfvars syntax: <tfvarsdecode argument>:1,11-16: Missing newline after argument; An argument definition must end with a newline.`,
+			WantErr: `invalid tfvars syntax: <decode_tfvars argument>:1,11-16: Missing newline after argument; An argument definition must end with a newline.`,
 		},
 		{
 			Input:   cty.StringVal(`foo = var.whatever`),
-			WantErr: `invalid expression for variable "foo": <tfvarsdecode argument>:1,7-10: Variables not allowed; Variables may not be used here.`,
+			WantErr: `invalid expression for variable "foo": <decode_tfvars argument>:1,7-10: Variables not allowed; Variables may not be used here.`,
 		},
 		{
 			Input:   cty.StringVal(`foo = whatever()`),
-			WantErr: `invalid expression for variable "foo": <tfvarsdecode argument>:1,7-17: Function calls not allowed; Functions may not be called here.`,
+			WantErr: `invalid expression for variable "foo": <decode_tfvars argument>:1,7-17: Function calls not allowed; Functions may not be called here.`,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.Input.GoString(), func(t *testing.T) {
-			got, err := TFVarsDecodeFunc.Call([]cty.Value{test.Input})
+			got, err := DecodeTfvarsFunc.Call([]cty.Value{test.Input})
 			if test.WantErr != "" {
 				if err == nil {
 					t.Fatalf("unexpected success for %#v; want error\ngot: %#v", test.Input, got)
@@ -217,7 +217,7 @@ number = 2`),
 	}
 }
 
-func TestExprEncode(t *testing.T) {
+func TestEncodeExpr(t *testing.T) {
 	tests := []struct {
 		Input   cty.Value
 		Want    cty.Value
@@ -361,7 +361,7 @@ func TestExprEncode(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Input.GoString(), func(t *testing.T) {
-			got, err := ExprEncodeFunc.Call([]cty.Value{test.Input})
+			got, err := EncodeExprFunc.Call([]cty.Value{test.Input})
 			if test.WantErr != "" {
 				if err == nil {
 					t.Fatalf("unexpected success for %#v; want error\ngot: %#v", test.Input, got)

--- a/terraform/lang/functions.go
+++ b/terraform/lang/functions.go
@@ -178,9 +178,9 @@ func (s *Scope) Functions() map[string]function.Function {
 
 		// Built-in Terraform provider-defined functions are typically obtained dynamically,
 		// but given that they are built-ins, they are provided just like regular functions.
-		s.funcs["provider::terraform::tfvarsencode"] = terraform.TFVarsEncodeFunc
-		s.funcs["provider::terraform::tfvarsdecode"] = terraform.TFVarsDecodeFunc
-		s.funcs["provider::terraform::exprencode"] = terraform.ExprEncodeFunc
+		s.funcs["provider::terraform::encode_tfvars"] = terraform.EncodeTfvarsFunc
+		s.funcs["provider::terraform::decode_tfvars"] = terraform.DecodeTfvarsFunc
+		s.funcs["provider::terraform::encode_expr"] = terraform.EncodeExprFunc
 	}
 	s.funcsLock.Unlock()
 


### PR DESCRIPTION
See also https://github.com/terraform-linters/tflint/pull/2030

I had overlooked https://github.com/hashicorp/terraform/pull/34830, so the names in development were being used as Terraform-specific function names. As a result, in TFLint v0.51 terraform-specific functions always return unknown values.

This PR fixes the function names so that the terraform-specific functions return the known values.

- https://developer.hashicorp.com/terraform/language/functions/terraform-encode_tfvars
- https://developer.hashicorp.com/terraform/language/functions/terraform-decode_tfvars
- https://developer.hashicorp.com/terraform/language/functions/terraform-encode_expr