### PR TITLE
formatter: Add source attribute in the checkstyle format

### DIFF
--- a/formatter/checkstyle.go
+++ b/formatter/checkstyle.go
@@ -8,12 +8,15 @@ import (
 )
 
 type checkstyleError struct {
-	Rule     string `xml:"rule,attr"`
+	Source   string `xml:"source,attr"`
 	Line     int    `xml:"line,attr"`
 	Column   int    `xml:"column,attr"`
 	Severity string `xml:"severity,attr"`
 	Message  string `xml:"message,attr"`
 	Link     string `xml:"link,attr"`
+
+	// Deprecated: Use `source` instead
+	Rule string `xml:"rule,attr"`
 }
 
 type checkstyleFile struct {
@@ -30,12 +33,14 @@ func (f *Formatter) checkstylePrint(issues tflint.Issues, appErr error, sources 
 	files := map[string]*checkstyleFile{}
 	for _, issue := range issues {
 		cherr := &checkstyleError{
-			Rule:     issue.Rule.Name(),
+			Source:   issue.Rule.Name(),
 			Line:     issue.Range.Start.Line,
 			Column:   issue.Range.Start.Column,
 			Severity: toSeverity(issue.Rule.Severity()),
 			Message:  issue.Message,
 			Link:     issue.Rule.Link(),
+
+			Rule: issue.Rule.Name(),
 		}
 
 		if file, exists := files[issue.Range.Filename]; exists {

--- a/formatter/checkstyle_test.go
+++ b/formatter/checkstyle_test.go
@@ -37,21 +37,23 @@ func Test_checkstylePrint(t *testing.T) {
 			Stdout: `<?xml version="1.0" encoding="UTF-8"?>
 <checkstyle>
   <file name="test.tf">
-    <error rule="test_rule" line="1" column="1" severity="error" message="test" link="https://github.com"></error>
+    <error source="test_rule" line="1" column="1" severity="error" message="test" link="https://github.com" rule="test_rule"></error>
   </file>
 </checkstyle>`,
 		},
 	}
 
 	for _, tc := range cases {
-		stdout := &bytes.Buffer{}
-		stderr := &bytes.Buffer{}
-		formatter := &Formatter{Stdout: stdout, Stderr: stderr}
+		t.Run(tc.Name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			formatter := &Formatter{Stdout: stdout, Stderr: stderr}
 
-		formatter.checkstylePrint(tc.Issues, tc.Error, map[string][]byte{})
+			formatter.checkstylePrint(tc.Issues, tc.Error, map[string][]byte{})
 
-		if stdout.String() != tc.Stdout {
-			t.Fatalf("Failed %s test: expected=%s, stdout=%s", tc.Name, tc.Stdout, stdout.String())
-		}
+			if stdout.String() != tc.Stdout {
+				t.Fatalf("expected=%s, stdout=%s", tc.Stdout, stdout.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/2056

Currently, the `checkstyle` output format uses the `rule` attribute as the rule name.

```console
$ tflint --format checkstyle
<checkstyle>
  <file name="test.tf">
    <error rule="test_rule" line="1" column="1" severity="error" message="test" link="https://github.com"></error>
  </file>
</checkstyle>
```

However, the original Checkstyle XML output format uses the `source` attribute as the issue identifier.
https://github.com/checkstyle/checkstyle/blob/a7042e5119e6df9b8f782751af6cae2ee54a215a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java#L205-L224

Several tools rely on the original format shown above, so TFLint adds the `source` attribute as well.

The `rule` attribute will remain for backwards compatibility, but will be removed in the future. Tools that rely on its value are encouraged to switch to the `source` attribute as soon as possible.