### PR TITLE
cmd: Allow `--chdir` and `--recursive` to be used together

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -144,15 +144,14 @@ func unknownOptionHandler(option string, arg flags.SplitArgument, args []string)
 }
 
 func findWorkingDirs(opts Options) ([]string, error) {
-	if opts.Recursive && opts.Chdir != "" {
-		return []string{}, errors.New("cannot use --recursive and --chdir at the same time")
+	baseDir := opts.Chdir
+	if baseDir == "" {
+		baseDir = "."
 	}
-
 	workingDirs := []string{}
 
 	if opts.Recursive {
-		// NOTE: The target directory is always the current directory in recursive mode
-		err := filepath.WalkDir(".", func(path string, d os.DirEntry, err error) error {
+		err := filepath.WalkDir(baseDir, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
@@ -171,11 +170,7 @@ func findWorkingDirs(opts Options) ([]string, error) {
 			return []string{}, err
 		}
 	} else {
-		if opts.Chdir == "" {
-			workingDirs = []string{"."}
-		} else {
-			workingDirs = []string{opts.Chdir}
-		}
+		workingDirs = []string{baseDir}
 	}
 
 	return workingDirs, nil

--- a/integrationtest/recursive/chdir/result.json
+++ b/integrationtest/recursive/chdir/result.json
@@ -1,0 +1,45 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is t2.micro",
+      "range": {
+        "filename": "subdir1/main.tf",
+        "start": {
+          "line": 2,
+          "column": 19
+        },
+        "end": {
+          "line": 2,
+          "column": 29
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is t2.micro",
+      "range": {
+        "filename": "subdir1/subdir3/main.tf",
+        "start": {
+          "line": 2,
+          "column": 19
+        },
+        "end": {
+          "line": 2,
+          "column": 29
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/recursive/chdir/result_windows.json
+++ b/integrationtest/recursive/chdir/result_windows.json
@@ -1,0 +1,45 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is t2.micro",
+      "range": {
+        "filename": "subdir1\\main.tf",
+        "start": {
+          "line": 2,
+          "column": 19
+        },
+        "end": {
+          "line": 2,
+          "column": 29
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
+        "name": "aws_instance_example_type",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "instance type is t2.micro",
+      "range": {
+        "filename": "subdir1\\subdir3\\main.tf",
+        "start": {
+          "line": 2,
+          "column": 19
+        },
+        "end": {
+          "line": 2,
+          "column": 29
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/recursive/chdir/subdir1/.tflint.hcl
+++ b/integrationtest/recursive/chdir/subdir1/.tflint.hcl
@@ -1,0 +1,7 @@
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "testing" {
+  enabled = true
+}

--- a/integrationtest/recursive/chdir/subdir1/main.tf
+++ b/integrationtest/recursive/chdir/subdir1/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+  instance_type = "t2.micro"
+}

--- a/integrationtest/recursive/chdir/subdir1/subdir3/.tflint.hcl
+++ b/integrationtest/recursive/chdir/subdir1/subdir3/.tflint.hcl
@@ -1,0 +1,7 @@
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "testing" {
+  enabled = true
+}

--- a/integrationtest/recursive/chdir/subdir1/subdir3/main.tf
+++ b/integrationtest/recursive/chdir/subdir1/subdir3/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+  instance_type = "t2.micro"
+}

--- a/integrationtest/recursive/chdir/subdir2/.tflint.hcl
+++ b/integrationtest/recursive/chdir/subdir2/.tflint.hcl
@@ -1,0 +1,7 @@
+plugin "terraform" {
+  enabled = false
+}
+
+plugin "testing" {
+  enabled = true
+}

--- a/integrationtest/recursive/chdir/subdir2/main.tf
+++ b/integrationtest/recursive/chdir/subdir2/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+  instance_type = "t2.micro"
+}

--- a/integrationtest/recursive/recursive_test.go
+++ b/integrationtest/recursive/recursive_test.go
@@ -40,6 +40,11 @@ func TestIntegration(t *testing.T) {
 			error:       true,
 			ignoreOrder: true,
 		},
+		{
+			name:    "recursive + chdir",
+			command: "tflint --chdir=subdir1 --recursive --format json --force",
+			dir:     "chdir",
+		},
 	}
 
 	dir, _ := os.Getwd()


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/2051

Previously, `--chdir` and `--recursive` could not be used together.

```console
$ tflint --chdir=infra --recursive
Failed to find workspaces; cannot use --recursive and --chdir at the same time
```

This is because the `--recursive` was originally designed as `--chdir` for multi-directory https://github.com/terraform-linters/tflint/pull/1612 https://github.com/terraform-linters/tflint/pull/1622
Given this background, using them together was out of scope. Also, it is not obvious whether `--recursive` or `--chdir` takes precedence, which can lead to strange behavior when `--recursive` takes precedence.

However, given that `terraform -chdir=infra fmt --recursive` is a valid command, it is natural to expect similar behavior. In `terraform fmt`, `-chdir` takes precedence and recurses into the directory after the move. TFLint follows this behavior.