### PR TITLE
Fix a race condition when evaluating on the root context

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,3 +33,18 @@ jobs:
       run: make e2e
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  race:
+    name: race
+    # go test -race is slow and only runs on ubuntu
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+    - name: Run e2e-race
+      run: make e2e-race

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,10 @@ install:
 	go install
 
 e2e: prepare install
-	go test -timeout 5m ./integrationtest/...
+	go test -timeout 5m $$(go list ./integrationtest/... | grep -v race)
+
+e2e-race: prepare
+	go test --race --timeout 5m ./integrationtest/race
 
 lint:
 	golangci-lint run ./...

--- a/integrationtest/race/eval_locals_on_root_ctx/.tflint.hcl
+++ b/integrationtest/race/eval_locals_on_root_ctx/.tflint.hcl
@@ -1,0 +1,3 @@
+plugin "testing" {
+  enabled = true
+}

--- a/integrationtest/race/eval_locals_on_root_ctx/main.tf
+++ b/integrationtest/race/eval_locals_on_root_ctx/main.tf
@@ -1,0 +1,17 @@
+locals {
+  dns_name = "www.example.com"
+}
+
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = local.dns_name
+  type    = "A"
+  ttl     = 300
+  records = [aws_eip.lb.public_ip]
+}
+
+module "route53_records" {
+  count = 10
+
+  source = "./module"
+}

--- a/integrationtest/race/eval_locals_on_root_ctx/module/main.tf
+++ b/integrationtest/race/eval_locals_on_root_ctx/module/main.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_record" "help" {
+  zone_id = aws_route53_zone.primary.zone_id
+  name    = "help.example.com"
+  type    = "A"
+  ttl     = 300
+  records = [aws_eip.lb.public_ip]
+}

--- a/integrationtest/race/eval_locals_on_root_ctx/result.json
+++ b/integrationtest/race/eval_locals_on_root_ctx/result.json
@@ -1,0 +1,25 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_route53_record_eval_on_root_ctx_example",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "record name (root): \"www.example.com\"",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 7,
+          "column": 13
+        },
+        "end": {
+          "line": 7,
+          "column": 27
+        }
+      },
+      "callers": []
+    }
+  ],
+  "errors": []
+}

--- a/integrationtest/race/race_test.go
+++ b/integrationtest/race/race_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/terraform-linters/tflint/cmd"
+	"github.com/terraform-linters/tflint/formatter"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func TestMain(m *testing.M) {
+	log.SetOutput(io.Discard)
+	os.Exit(m.Run())
+}
+
+type meta struct {
+	Version string
+}
+
+func TestIntegration(t *testing.T) {
+	cases := []struct {
+		Name    string
+		Command string
+		Dir     string
+	}{
+		{
+			// @see https://github.com/terraform-linters/tflint/issues/2094
+			Name:    "eval locals on the root context in parallel runners",
+			Command: "tflint --format json",
+			Dir:     "eval_locals_on_root_ctx",
+		},
+	}
+
+	// Disable the bundled plugin because the `os.Executable()` is go(1) in the tests
+	tflint.DisableBundledPlugin = true
+	defer func() {
+		tflint.DisableBundledPlugin = false
+	}()
+
+	dir, _ := os.Getwd()
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testDir := filepath.Join(dir, tc.Dir)
+
+			defer func() {
+				if err := os.Chdir(dir); err != nil {
+					t.Fatal(err)
+				}
+			}()
+			if err := os.Chdir(testDir); err != nil {
+				t.Fatal(err)
+			}
+
+			outStream, errStream := new(bytes.Buffer), new(bytes.Buffer)
+			cli, err := cmd.NewCLI(outStream, errStream)
+			if err != nil {
+				t.Fatal(err)
+			}
+			args := strings.Split(tc.Command, " ")
+
+			cli.Run(args)
+
+			rawWant, err := readResultFile(testDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var want *formatter.JSONOutput
+			if err := json.Unmarshal(rawWant, &want); err != nil {
+				t.Fatal(err)
+			}
+
+			var got *formatter.JSONOutput
+			if err := json.Unmarshal(outStream.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}
+
+func readResultFile(dir string) ([]byte, error) {
+	resultFile := "result.json"
+	if runtime.GOOS == "windows" {
+		if _, err := os.Stat(filepath.Join(dir, "result_windows.json")); !os.IsNotExist(err) {
+			resultFile = "result_windows.json"
+		}
+	}
+	if _, err := os.Stat(fmt.Sprintf("%s.tmpl", resultFile)); !os.IsNotExist(err) {
+		resultFile = fmt.Sprintf("%s.tmpl", resultFile)
+	}
+
+	if !strings.HasSuffix(resultFile, ".tmpl") {
+		return os.ReadFile(filepath.Join(dir, resultFile))
+	}
+
+	want := new(bytes.Buffer)
+	tmpl := template.Must(template.ParseFiles(filepath.Join(dir, resultFile)))
+	if err := tmpl.Execute(want, meta{Version: tflint.Version.String()}); err != nil {
+		return nil, err
+	}
+	return want.Bytes(), nil
+}

--- a/terraform/evaluator_test.go
+++ b/terraform/evaluator_test.go
@@ -788,7 +788,6 @@ locals {
 				ModulePath:     config.Path.UnkeyedInstanceShim(),
 				Config:         config,
 				VariableValues: variableValues,
-				CallStack:      NewCallStack(),
 			}
 			if evaluator.Meta == nil {
 				evaluator.Meta = &ContextMeta{Env: Workspace()}
@@ -2181,7 +2180,6 @@ resource "aws_instance" "main" {
 				ModulePath:     config.Path.UnkeyedInstanceShim(),
 				Config:         config,
 				VariableValues: variableValues,
-				CallStack:      NewCallStack(),
 			}
 
 			expanded, diags := evaluator.ExpandBlock(file.Body, test.schema)

--- a/terraform/lang/scope.go
+++ b/terraform/lang/scope.go
@@ -1,8 +1,10 @@
 package lang
 
 import (
+	"strings"
 	"sync"
 
+	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty/function"
 
 	"github.com/terraform-linters/tflint/terraform/addrs"
@@ -29,6 +31,62 @@ type Scope struct {
 	// then differ during apply.
 	PureOnly bool
 
+	// CallStack is a stack for recording local value references to detect
+	// circular references.
+	CallStack *CallStack
+
 	funcs     map[string]function.Function
 	funcsLock sync.Mutex
+}
+
+type CallStack struct {
+	addrs map[string]addrs.Reference
+	stack []string
+}
+
+func NewCallStack() *CallStack {
+	return &CallStack{
+		addrs: make(map[string]addrs.Reference),
+		stack: make([]string, 0),
+	}
+}
+
+func (g *CallStack) Push(addr addrs.Reference) hcl.Diagnostics {
+	g.stack = append(g.stack, addr.Subject.String())
+
+	if _, exists := g.addrs[addr.Subject.String()]; exists {
+		return hcl.Diagnostics{
+			{
+				Severity: hcl.DiagError,
+				Summary:  "circular reference found",
+				Detail:   g.String(),
+				Subject:  addr.SourceRange.Ptr(),
+			},
+		}
+	}
+	g.addrs[addr.Subject.String()] = addr
+	return hcl.Diagnostics{}
+}
+
+func (g *CallStack) Pop() {
+	if g.Empty() {
+		panic("cannot pop from empty stack")
+	}
+
+	addr := g.stack[len(g.stack)-1]
+	g.stack = g.stack[:len(g.stack)-1]
+	delete(g.addrs, addr)
+}
+
+func (g *CallStack) String() string {
+	return strings.Join(g.stack, " -> ")
+}
+
+func (g *CallStack) Empty() bool {
+	return len(g.stack) == 0
+}
+
+func (g *CallStack) Clear() {
+	g.addrs = make(map[string]addrs.Reference)
+	g.stack = make([]string, 0)
 }

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -57,7 +57,6 @@ func NewRunner(originalWorkingDir string, c *Config, ants map[string]Annotations
 		ModulePath:     cfg.Path.UnkeyedInstanceShim(),
 		Config:         cfg.Root,
 		VariableValues: variableValues,
-		CallStack:      terraform.NewCallStack(),
 	}
 
 	runner := &Runner{


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/2094

https://github.com/terraform-linters/tflint/pull/1944 parallelized the inspection of child modules, but did not take into account side effects that the child modules could cause on the root module. These are unsafe because the root module is shared by each child module (goroutine).

https://github.com/terraform-linters/tflint/blob/90494f35337ed3e024349e1ca6c88356045c96ee/cmd/inspect.go#L162-L174

The side effect reported in #2094 was the call stack. TFLint detects loops while building the call stack to prevent infinite loops when evaluating local values ​​with circular references. This call stack was shared per Runner (Evaluator).

https://github.com/terraform-linters/tflint/blob/a7ebc9b6592b599b628bcb9d3b0cc82047cd5f2a/terraform/evaluator.go#L76-L82

This means that the call stack with side effects is shared between goroutines.

To prevent this, we moved the call stack into a scope instead of the evaluator. The scope is initialized per evaluation and therefore is not shared between goroutines. As a result, the race condition is fixed.

https://github.com/terraform-linters/tflint/blob/a7ebc9b6592b599b628bcb9d3b0cc82047cd5f2a/terraform/evaluator.go#L84-L90

To prevent such bugs, we added a test case to run with `go test --race`. In general, this tends to slow down compilation speed, so we only run some tests with `--race`, and we expect to increase the number of tests if similar bugs are found.