### PR TITLE
Override exactly according to the Terraform spec

### DIFF
--- a/integrationtest/inspection/override/.tflint.hcl
+++ b/integrationtest/inspection/override/.tflint.hcl
@@ -1,3 +1,7 @@
 plugin "testing" {
   enabled = true
 }
+
+rule "terraform_required_providers" {
+  enabled = true
+}

--- a/integrationtest/inspection/override/result.json
+++ b/integrationtest/inspection/override/result.json
@@ -2,6 +2,26 @@
   "issues": [
     {
       "rule": {
+        "name": "terraform_required_providers",
+        "severity": "error",
+        "link": ""
+      },
+      "message": "required_providers: aws=2,azurerm=1,google=3,oracle=2",
+      "range": {
+        "filename": "template.tf",
+        "start": {
+          "line": 11,
+          "column": 3
+        },
+        "end": {
+          "line": 11,
+          "column": 21
+        }
+      },
+      "callers": []
+    },
+    {
+      "rule": {
         "name": "aws_instance_example_type",
         "severity": "error",
         "link": ""

--- a/integrationtest/inspection/override/template.tf
+++ b/integrationtest/inspection/override/template.tf
@@ -2,3 +2,15 @@ resource "aws_instance" "web" {
   ami           = "ami-12345678"
   instance_type = "t2.micro" // Override by `template_override.tf`
 }
+
+terraform {
+  backend "s3" {}
+}
+
+terraform {
+  required_providers {
+    aws     = "1" // Override by `template_override.tf`
+    google  = "1" // Override by `version_override.tf`
+    azurerm = "1"
+  }
+}

--- a/integrationtest/inspection/override/template_override.tf
+++ b/integrationtest/inspection/override/template_override.tf
@@ -3,3 +3,11 @@ resource "aws_instance" "web" {
   instance_type        = "m5.2xlarge" // aws_instance_example_type
   iam_instance_profile = "web-server"
 }
+
+terraform {
+  required_providers {
+    aws     = "2"
+    google  = "2"
+    oracle  = "2"
+  }
+}

--- a/integrationtest/inspection/override/version_override.tf
+++ b/integrationtest/inspection/override/version_override.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_providers {
+    google = "3"
+  }
+}

--- a/plugin/stub-generator/sources/testing/main.go
+++ b/plugin/stub-generator/sources/testing/main.go
@@ -27,6 +27,7 @@ func main() {
 				rules.NewTerraformAutofixRemoveLocalRule(), // should be former than terraform_autofix_comment because this rule changes the line number
 				rules.NewTerraformAutofixCommentRule(),
 				rules.NewAwsInstanceAutofixConflictRule(), // should be later than terraform_autofix_comment because this rule adds an issue for terraform_autofix_comment
+				rules.NewTerraformRequiredProvidersRule(),
 			},
 		},
 	})

--- a/plugin/stub-generator/sources/testing/rules/terraform_required_providers.go
+++ b/plugin/stub-generator/sources/testing/rules/terraform_required_providers.go
@@ -1,0 +1,87 @@
+package rules
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// TerraformRequiredProviders checks whether ...
+type TerraformRequiredProviders struct {
+	tflint.DefaultRule
+}
+
+// NewTerraformRequiredProvidersRule returns a new rule
+func NewTerraformRequiredProvidersRule() *TerraformRequiredProviders {
+	return &TerraformRequiredProviders{}
+}
+
+// Name returns the rule name
+func (r *TerraformRequiredProviders) Name() string {
+	return "terraform_required_providers"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *TerraformRequiredProviders) Enabled() bool {
+	return false
+}
+
+// Severity returns the rule severity
+func (r *TerraformRequiredProviders) Severity() tflint.Severity {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *TerraformRequiredProviders) Link() string {
+	return ""
+}
+
+// Check checks whether ...
+func (r *TerraformRequiredProviders) Check(runner tflint.Runner) error {
+	module, err := runner.GetModuleContent(&hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{
+				Type: "terraform",
+				Body: &hclext.BodySchema{
+					Blocks: []hclext.BlockSchema{
+						{
+							Type: "required_providers",
+							Body: &hclext.BodySchema{Mode: hclext.SchemaJustAttributesMode},
+						},
+					},
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, terraform := range module.Blocks {
+		for _, requiredProvider := range terraform.Body.Blocks {
+			ret := []string{}
+			for name, attr := range requiredProvider.Body.Attributes {
+				v, diags := attr.Expr.Value(nil)
+				if diags.HasErrors() {
+					return diags
+				}
+				ret = append(ret, fmt.Sprintf("%s=%s", name, v.AsString()))
+			}
+			sort.Strings(ret)
+
+			err := runner.EmitIssue(
+				r,
+				fmt.Sprintf("required_providers: %s", strings.Join(ret, ",")),
+				requiredProvider.DefRange,
+			)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/terraform/module.go
+++ b/terraform/module.go
@@ -169,40 +169,128 @@ func (m *Module) PartialContent(schema *hclext.BodySchema, ctx *Evaluator) (*hcl
 // Note that this function returns the overwritten primary blocks
 // but has side effects on the primary blocks.
 func overrideBlocks(primaries, overrides hclext.Blocks) hclext.Blocks {
-	dict := map[string]*hclext.Block{}
+	dict := map[string]hclext.Blocks{}
 	for _, primary := range primaries {
-		// A top-level block in an override file merges with a block in a normal configuration file
-		// that has the same block header.
-		// The block header is the block type and any quoted labels that follow it.
-		key := fmt.Sprintf("%s[%s]", primary.Type, strings.Join(primary.Labels, ","))
-		dict[key] = primary
+		switch primary.Type {
+		case "terraform":
+			// The "terraform" blocks are allowed to be declared multiple times.
+			dict[primary.Type] = append(dict[primary.Type], primary)
+
+		default:
+			// A top-level block in an override file merges with a block in a normal configuration file
+			// that has the same block header.
+			// The block header is the block type and any quoted labels that follow it.
+			key := fmt.Sprintf("%s[%s]", primary.Type, strings.Join(primary.Labels, ","))
+			dict[key] = hclext.Blocks{primary}
+		}
 	}
 
+	newPrimaries := hclext.Blocks{}
 	for _, override := range overrides {
-		key := fmt.Sprintf("%s[%s]", override.Type, strings.Join(override.Labels, ","))
-		if primary, exists := dict[key]; exists {
-			// Within a top-level block, an attribute argument within an override block
-			// replaces any argument of the same name in the original block.
-			for name, attr := range override.Body.Attributes {
-				primary.Body.Attributes[name] = attr
-			}
+		switch override.Type {
+		case "terraform":
+			// Any required_providers that were not used for overrides will be added,
+			// so we will track whether they were used for overrides or not.
+			overrideRequiredProviders := override.Body.Blocks.ByType()["required_providers"]
 
-			// Within a top-level block, any nested blocks within an override block replace
-			// all blocks of the same type in the original block.
-			// Any block types that do not appear in the override block remain from the original block.
-			for _, overrideBlock := range override.Body.Blocks {
-				overriddenBlocks := hclext.Blocks{}
-				for _, primaryBlock := range primary.Body.Blocks {
-					if primaryBlock.Type != overrideBlock.Type {
-						overriddenBlocks = append(overriddenBlocks, primaryBlock)
+			for _, primary := range dict[override.Type] {
+				// In both the required_version and required_providers settings,
+				// each override constraint entirely replaces the constraints for
+				// the same component in the original block.
+				for name, attr := range override.Body.Attributes {
+					primary.Body.Attributes[name] = attr
+				}
+
+				for _, overrideInnerBlock := range override.Body.Blocks {
+					switch overrideInnerBlock.Type {
+					case "required_providers":
+						// If the required_providers argument is set, its value is merged on an element-by-element basis
+						for _, primaryInnerBlock := range primary.Body.Blocks {
+							if primaryInnerBlock.Type == "required_providers" {
+								for name, attr := range overrideInnerBlock.Body.Attributes {
+									if _, exists := primaryInnerBlock.Body.Attributes[name]; exists {
+										primaryInnerBlock.Body.Attributes[name] = attr
+										// Remove the required provider that was used to override.
+										for _, requiredProvider := range overrideRequiredProviders {
+											delete(requiredProvider.Body.Attributes, name)
+										}
+									}
+								}
+							}
+						}
+
+					case "cloud", "backend":
+						// The presence of a block defining a backend (either cloud or backend) in an override file
+						// always takes precedence over a block defining a backend in the original configuration.
+						newInnerBlocks := hclext.Blocks{}
+						for _, primaryInnerBlock := range primary.Body.Blocks {
+							if primaryInnerBlock.Type != "cloud" && primaryInnerBlock.Type != "backend" {
+								newInnerBlocks = append(newInnerBlocks, primaryInnerBlock)
+							}
+						}
+						primary.Body.Blocks = append(newInnerBlocks, overrideInnerBlock)
+
+					default:
+						newInnerBlocks := hclext.Blocks{}
+						for _, primaryInnerBlock := range primary.Body.Blocks {
+							if primaryInnerBlock.Type != overrideInnerBlock.Type {
+								newInnerBlocks = append(newInnerBlocks, primaryInnerBlock)
+							}
+						}
+						primary.Body.Blocks = append(newInnerBlocks, overrideInnerBlock)
 					}
 				}
-				primary.Body.Blocks = append(overriddenBlocks, overrideBlock)
+			}
+
+			// Any remaining required providers that aren't overridden will be added as a new block.
+			newRequiredProviders := hclext.Blocks{}
+			for _, requiredProvider := range overrideRequiredProviders {
+				if len(requiredProvider.Body.Attributes) > 0 {
+					newRequiredProviders = append(newRequiredProviders, requiredProvider)
+				}
+			}
+			if len(newRequiredProviders) > 0 {
+				newPrimaries = append(newPrimaries, &hclext.Block{
+					Type:   override.Type,
+					Labels: override.Labels,
+					Body: &hclext.BodyContent{
+						Blocks: newRequiredProviders,
+					},
+					DefRange:    override.DefRange,
+					TypeRange:   override.TypeRange,
+					LabelRanges: override.LabelRanges,
+				})
+			}
+
+		default:
+			key := fmt.Sprintf("%s[%s]", override.Type, strings.Join(override.Labels, ","))
+			if primaries, exists := dict[key]; exists {
+				// The general rule, duplicated blocks are not allowed.
+				primary := primaries[0]
+
+				// Within a top-level block, an attribute argument within an override block
+				// replaces any argument of the same name in the original block.
+				for name, attr := range override.Body.Attributes {
+					primary.Body.Attributes[name] = attr
+				}
+
+				// Within a top-level block, any nested blocks within an override block replace
+				// all blocks of the same type in the original block.
+				// Any block types that do not appear in the override block remain from the original block.
+				for _, overrideInnerBlock := range override.Body.Blocks {
+					newInnerBlocks := hclext.Blocks{}
+					for _, primaryInnerBlock := range primary.Body.Blocks {
+						if primaryInnerBlock.Type != overrideInnerBlock.Type {
+							newInnerBlocks = append(newInnerBlocks, primaryInnerBlock)
+						}
+					}
+					primary.Body.Blocks = append(newInnerBlocks, overrideInnerBlock)
+				}
 			}
 		}
 	}
 
-	return primaries
+	return append(primaries, newPrimaries...)
 }
 
 var moduleSchema = &hclext.BodySchema{

--- a/terraform/module.go
+++ b/terraform/module.go
@@ -2,9 +2,6 @@ package terraform
 
 import (
 	"fmt"
-	"maps"
-	"slices"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -24,8 +21,9 @@ type Module struct {
 	Sources map[string][]byte
 	Files   map[string]*hcl.File
 
-	primaries map[string]*hcl.File
-	overrides map[string]*hcl.File
+	primaries         map[string]*hcl.File
+	overrides         map[string]*hcl.File
+	overrideFilenames []string
 }
 
 func NewEmptyModule() *Module {
@@ -40,8 +38,9 @@ func NewEmptyModule() *Module {
 		Sources: map[string][]byte{},
 		Files:   map[string]*hcl.File{},
 
-		primaries: map[string]*hcl.File{},
-		overrides: map[string]*hcl.File{},
+		primaries:         map[string]*hcl.File{},
+		overrides:         map[string]*hcl.File{},
+		overrideFilenames: []string{},
 	}
 }
 
@@ -142,13 +141,8 @@ func (m *Module) PartialContent(schema *hclext.BodySchema, ctx *Evaluator) (*hcl
 		content.Blocks = append(content.Blocks, c.Blocks...)
 	}
 
-	// If more than one override file defines the same top-level block, the overriding effect is compounded,
-	// with later blocks taking precedence over earlier blocks.
 	// Overrides are processed in order first by filename (in lexicographical order)
-	// and then by position in each file.
-	overrideFilenames := slices.Collect(maps.Keys(m.overrides))
-	sort.Strings(overrideFilenames)
-	for _, filename := range overrideFilenames {
+	for _, filename := range m.overrideFilenames {
 		expanded, d := ctx.ExpandBlock(m.overrides[filename].Body, schema)
 		diags = diags.Extend(d)
 		c, d := hclext.PartialContent(expanded, schema)

--- a/terraform/module_test.go
+++ b/terraform/module_test.go
@@ -1050,6 +1050,37 @@ func Test_overrideBlocks(t *testing.T) {
 						Attributes: hclext.Attributes{"foo": &hclext.Attribute{Name: "foo"}, "bar": &hclext.Attribute{Name: "bar"}},
 					},
 				},
+			},
+			Overrides: hclext.Blocks{
+				{
+					Type: "locals",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"bar": &hclext.Attribute{Name: "bar2"}, "foo2": &hclext.Attribute{Name: "foo2"}},
+					},
+				},
+			},
+			Want: hclext.Blocks{
+				{
+					Type: "locals",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{
+							"foo":  &hclext.Attribute{Name: "foo"},
+							"bar":  &hclext.Attribute{Name: "bar2"},
+							"foo2": &hclext.Attribute{Name: "foo2"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "override multiple locals",
+			Primaries: hclext.Blocks{
+				{
+					Type: "locals",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"foo": &hclext.Attribute{Name: "foo"}, "bar": &hclext.Attribute{Name: "bar"}},
+					},
+				},
 				{
 					Type: "locals",
 					Body: &hclext.BodyContent{
@@ -1142,6 +1173,282 @@ func Test_overrideBlocks(t *testing.T) {
 		},
 		{
 			Name: "override required_providers",
+			Primaries: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":    &hclext.Attribute{Name: "aws"},
+										"google": &hclext.Attribute{Name: "google"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":     &hclext.Attribute{Name: "aws2"},
+										"azurerm": &hclext.Attribute{Name: "azurerm2"},
+									},
+								},
+							},
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"google": &hclext.Attribute{Name: "google2"},
+										"assert": &hclext.Attribute{Name: "assert"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"time": &hclext.Attribute{Name: "time"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":     &hclext.Attribute{Name: "aws2"},
+										"google":  &hclext.Attribute{Name: "google2"},
+										"azurerm": &hclext.Attribute{Name: "azurerm2"},
+										"assert":  &hclext.Attribute{Name: "assert"},
+										"time":    &hclext.Attribute{Name: "time"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "override multiple required_providers",
+			Primaries: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":    &hclext.Attribute{Name: "aws"},
+										"google": &hclext.Attribute{Name: "google"},
+									},
+								},
+							},
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"google-beta": &hclext.Attribute{Name: "google-beta"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":     &hclext.Attribute{Name: "aws2"},
+										"azurerm": &hclext.Attribute{Name: "azurerm2"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":    &hclext.Attribute{Name: "aws2"},
+										"google": &hclext.Attribute{Name: "google"},
+									},
+								},
+							},
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"google-beta": &hclext.Attribute{Name: "google-beta"},
+									},
+								},
+							},
+						},
+					},
+				},
+				// Blocks not present in the primaries are added.
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"azurerm": &hclext.Attribute{Name: "azurerm2"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "override multiple terraform blocks with single required_providers",
+			Primaries: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":    &hclext.Attribute{Name: "aws"},
+										"google": &hclext.Attribute{Name: "google"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"google-beta": &hclext.Attribute{Name: "google-beta"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":     &hclext.Attribute{Name: "aws2"},
+										"azurerm": &hclext.Attribute{Name: "azurerm2"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":    &hclext.Attribute{Name: "aws2"},
+										"google": &hclext.Attribute{Name: "google"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"google-beta": &hclext.Attribute{Name: "google-beta"},
+									},
+								},
+							},
+						},
+					},
+				},
+				// Blocks not present in the primaries are added.
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"azurerm": &hclext.Attribute{Name: "azurerm2"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "override multiple terraform blocks with multiple required_providers",
 			Primaries: hclext.Blocks{
 				{
 					Type: "terraform",

--- a/terraform/module_test.go
+++ b/terraform/module_test.go
@@ -236,19 +236,19 @@ resource "aws_instance" "bar" {
 						Type:   "resource",
 						Labels: []string{"aws_instance", "foo"},
 						Body: &hclext.BodyContent{
-							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main1.tf"}}},
+							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main1.tf", Start: hcl.Pos{Line: 3}}}},
 							Blocks:     hclext.Blocks{},
 						},
-						DefRange: hcl.Range{Filename: "main1.tf"},
+						DefRange: hcl.Range{Filename: "main1.tf", Start: hcl.Pos{Line: 2}},
 					},
 					{
 						Type:   "resource",
 						Labels: []string{"aws_instance", "bar"},
 						Body: &hclext.BodyContent{
-							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main2.tf"}}},
+							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main2.tf", Start: hcl.Pos{Line: 3}}}},
 							Blocks:     hclext.Blocks{},
 						},
-						DefRange: hcl.Range{Filename: "main2.tf"},
+						DefRange: hcl.Range{Filename: "main2.tf", Start: hcl.Pos{Line: 2}},
 					},
 				},
 			},
@@ -281,10 +281,53 @@ resource "aws_instance" "foo" {
 						Type:   "resource",
 						Labels: []string{"aws_instance", "foo"},
 						Body: &hclext.BodyContent{
-							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main_override.tf"}}},
+							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main_override.tf", Start: hcl.Pos{Line: 3}}}},
 							Blocks:     hclext.Blocks{},
 						},
-						DefRange: hcl.Range{Filename: "main.tf"},
+						DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 2}},
+					},
+				},
+			},
+		},
+		{
+			name: "overrides by multiple files/blocks",
+			files: map[string]string{
+				"main.tf": `
+resource "aws_instance" "foo" {
+  instance_type = "t2.micro"
+}`,
+				"main1_override.tf": `
+resource "aws_instance" "foo" {
+  instance_type = "m5.2xlarge"
+}`,
+				"main2_override.tf": `
+resource "aws_instance" "foo" {
+  instance_type = "m5.4xlarge"
+}
+resource "aws_instance" "foo" {
+  instance_type = "m5.8xlarge"
+}`,
+			},
+			schema: &hclext.BodySchema{
+				Attributes: []hclext.AttributeSchema{{Name: "foo"}},
+				Blocks: []hclext.BlockSchema{
+					{
+						Type:       "resource",
+						LabelNames: []string{"type", "name"},
+						Body:       &hclext.BodySchema{Attributes: []hclext.AttributeSchema{{Name: "instance_type"}}},
+					},
+				},
+			},
+			want: &hclext.BodyContent{
+				Blocks: hclext.Blocks{
+					{
+						Type:   "resource",
+						Labels: []string{"aws_instance", "foo"},
+						Body: &hclext.BodyContent{
+							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main2_override.tf", Start: hcl.Pos{Line: 6}}}},
+							Blocks:     hclext.Blocks{},
+						},
+						DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 2}},
 					},
 				},
 			},
@@ -312,12 +355,12 @@ locals {
 						Type: "locals",
 						Body: &hclext.BodyContent{
 							Attributes: hclext.Attributes{
-								"foo": &hclext.Attribute{Name: "foo", Range: hcl.Range{Filename: "main.tf"}},
-								"bar": &hclext.Attribute{Name: "bar", Range: hcl.Range{Filename: "main.tf"}},
+								"foo": &hclext.Attribute{Name: "foo", Range: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 3}}},
+								"bar": &hclext.Attribute{Name: "bar", Range: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 4}}},
 							},
 							Blocks: hclext.Blocks{},
 						},
-						DefRange: hcl.Range{Filename: "main.tf"},
+						DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 2}},
 					},
 				},
 			},
@@ -351,19 +394,19 @@ resource "aws_instance" "bar" {
 						Type:   "resource",
 						Labels: []string{"aws_instance", "bar"},
 						Body: &hclext.BodyContent{
-							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main.tf"}}},
+							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 8}}}},
 							Blocks:     hclext.Blocks{},
 						},
-						DefRange: hcl.Range{Filename: "main.tf"},
+						DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 6}},
 					},
 					{
 						Type:   "resource",
 						Labels: []string{"aws_instance", "bar"},
 						Body: &hclext.BodyContent{
-							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main.tf"}}},
+							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 8}}}},
 							Blocks:     hclext.Blocks{},
 						},
-						DefRange: hcl.Range{Filename: "main.tf"},
+						DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 6}},
 					},
 				},
 			},
@@ -397,19 +440,19 @@ module "bar" {
 						Type:   "module",
 						Labels: []string{"bar"},
 						Body: &hclext.BodyContent{
-							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main.tf"}}},
+							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 8}}}},
 							Blocks:     hclext.Blocks{},
 						},
-						DefRange: hcl.Range{Filename: "main.tf"},
+						DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 6}},
 					},
 					{
 						Type:   "module",
 						Labels: []string{"bar"},
 						Body: &hclext.BodyContent{
-							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main.tf"}}},
+							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 8}}}},
 							Blocks:     hclext.Blocks{},
 						},
-						DefRange: hcl.Range{Filename: "main.tf"},
+						DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 6}},
 					},
 				},
 			},
@@ -461,14 +504,14 @@ resource "aws_instance" "bar" {
 								{
 									Type: "ebs_block_device",
 									Body: &hclext.BodyContent{
-										Attributes: hclext.Attributes{"volume_size": &hclext.Attribute{Name: "volume_size", Range: hcl.Range{Filename: "main.tf"}}},
+										Attributes: hclext.Attributes{"volume_size": &hclext.Attribute{Name: "volume_size", Range: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 4}}}},
 										Blocks:     hclext.Blocks{},
 									},
-									DefRange: hcl.Range{Filename: "main.tf"},
+									DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 3}},
 								},
 							},
 						},
-						DefRange: hcl.Range{Filename: "main.tf"},
+						DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 2}},
 					},
 					{
 						Type:   "resource",
@@ -479,22 +522,22 @@ resource "aws_instance" "bar" {
 								{
 									Type: "ebs_block_device",
 									Body: &hclext.BodyContent{
-										Attributes: hclext.Attributes{"volume_size": &hclext.Attribute{Name: "volume_size", Range: hcl.Range{Filename: "main.tf"}}},
+										Attributes: hclext.Attributes{"volume_size": &hclext.Attribute{Name: "volume_size", Range: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 11}}}},
 										Blocks:     hclext.Blocks{},
 									},
-									DefRange: hcl.Range{Filename: "main.tf"},
+									DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 8}},
 								},
 								{
 									Type: "ebs_block_device",
 									Body: &hclext.BodyContent{
-										Attributes: hclext.Attributes{"volume_size": &hclext.Attribute{Name: "volume_size", Range: hcl.Range{Filename: "main.tf"}}},
+										Attributes: hclext.Attributes{"volume_size": &hclext.Attribute{Name: "volume_size", Range: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 11}}}},
 										Blocks:     hclext.Blocks{},
 									},
-									DefRange: hcl.Range{Filename: "main.tf"},
+									DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 8}},
 								},
 							},
 						},
-						DefRange: hcl.Range{Filename: "main.tf"},
+						DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 7}},
 					},
 				},
 			},
@@ -539,7 +582,8 @@ resource "aws_instance" "bar" {
 			opts := cmp.Options{
 				cmpopts.IgnoreFields(hclext.Block{}, "TypeRange", "LabelRanges"),
 				cmpopts.IgnoreFields(hclext.Attribute{}, "Expr", "NameRange"),
-				cmpopts.IgnoreFields(hcl.Range{}, "Start", "End"),
+				cmpopts.IgnoreFields(hcl.Range{}, "End"),
+				cmpopts.IgnoreFields(hcl.Pos{}, "Column", "Byte"),
 				cmpopts.SortSlices(func(i, j *hclext.Block) bool {
 					return i.DefRange.String() < j.DefRange.String()
 				}),

--- a/terraform/module_test.go
+++ b/terraform/module_test.go
@@ -806,6 +806,483 @@ func Test_overrideBlocks(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "no override multiple required_version",
+			Primaries: hclext.Blocks{
+				// The "terraform" blocks are allowed to be declared multiple times.
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version1"}},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version2"}},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{},
+			Want: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version1"}},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version2"}},
+					},
+				},
+			},
+		},
+		{
+			Name: "override multiple required_version",
+			Primaries: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version1"}},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version2"}},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version3"}},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version4"}},
+					},
+				},
+			},
+			Want: hclext.Blocks{
+				// In both the required_version and required_providers settings,
+				// each override constraint entirely replaces the constraints for the same component in the original block.
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version4"}},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version4"}},
+					},
+				},
+			},
+		},
+		{
+			Name: "no override required_providers",
+			Primaries: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":    &hclext.Attribute{Name: "aws"},
+										"google": &hclext.Attribute{Name: "google"},
+									},
+								},
+							},
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"azurerm": &hclext.Attribute{Name: "azurerm"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"google-beta": &hclext.Attribute{Name: "google-beta"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{},
+			Want: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":    &hclext.Attribute{Name: "aws"},
+										"google": &hclext.Attribute{Name: "google"},
+									},
+								},
+							},
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"azurerm": &hclext.Attribute{Name: "azurerm"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"google-beta": &hclext.Attribute{Name: "google-beta"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// If the required_providers argument is set, its value is merged on an element-by-element basis
+			Name: "override required_providers",
+			Primaries: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":    &hclext.Attribute{Name: "aws"},
+										"google": &hclext.Attribute{Name: "google"},
+									},
+								},
+							},
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"azurerm": &hclext.Attribute{Name: "azurerm"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"google-beta": &hclext.Attribute{Name: "google-beta"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":     &hclext.Attribute{Name: "aws2"},
+										"azurerm": &hclext.Attribute{Name: "azurerm2"},
+									},
+								},
+							},
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"assert": &hclext.Attribute{Name: "assert"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"google": &hclext.Attribute{Name: "google2"},
+										"time":   &hclext.Attribute{Name: "time"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"aws":    &hclext.Attribute{Name: "aws2"},
+										"google": &hclext.Attribute{Name: "google2"},
+									},
+								},
+							},
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"azurerm": &hclext.Attribute{Name: "azurerm2"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"google-beta": &hclext.Attribute{Name: "google-beta"},
+									},
+								},
+							},
+						},
+					},
+				},
+				// Blocks not present in the primaries are added
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"assert": &hclext.Attribute{Name: "assert"},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "required_providers",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"time": &hclext.Attribute{Name: "time"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "override backend",
+			Primaries: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type:   "backend",
+								Labels: []string{"local"},
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{"path": &hclext.Attribute{Name: "path"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type:   "backend",
+								Labels: []string{"remote"},
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{"host": &hclext.Attribute{Name: "host"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type:   "backend",
+								Labels: []string{"remote"},
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{"host": &hclext.Attribute{Name: "host"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// The presence of a block defining a backend (either cloud or backend) in an override file
+			// always takes precedence over a block defining a backend in the original configuration
+			Name: "override backend by cloud",
+			Primaries: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type:   "backend",
+								Labels: []string{"local"},
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{"path": &hclext.Attribute{Name: "path"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "cloud",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{"organization": &hclext.Attribute{Name: "organization"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "cloud",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{"organization": &hclext.Attribute{Name: "organization"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "override cloud by backend",
+			Primaries: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "cloud",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{"organization": &hclext.Attribute{Name: "organization"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type:   "backend",
+								Labels: []string{"remote"},
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{"host": &hclext.Attribute{Name: "host"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: hclext.Blocks{
+				{
+					Type: "terraform",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type:   "backend",
+								Labels: []string{"remote"},
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{"host": &hclext.Attribute{Name: "host"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/terraform/module_test.go
+++ b/terraform/module_test.go
@@ -807,6 +807,65 @@ func Test_overrideBlocks(t *testing.T) {
 			},
 		},
 		{
+			Name: "override locals",
+			Primaries: hclext.Blocks{
+				// The "locals" blocks are allowed to be declared multiple times.
+				{
+					Type: "locals",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"foo": &hclext.Attribute{Name: "foo"}, "bar": &hclext.Attribute{Name: "bar"}},
+					},
+				},
+				{
+					Type: "locals",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"baz": &hclext.Attribute{Name: "baz"}, "qux": &hclext.Attribute{Name: "qux"}},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{
+				{
+					Type: "locals",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"baz": &hclext.Attribute{Name: "baz2"}, "foo2": &hclext.Attribute{Name: "foo2"}},
+					},
+				},
+				{
+					Type: "locals",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"bar": &hclext.Attribute{Name: "bar2"}, "qux2": &hclext.Attribute{Name: "qux2"}},
+					},
+				},
+			},
+			Want: hclext.Blocks{
+				{
+					Type: "locals",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"foo": &hclext.Attribute{Name: "foo"}, "bar": &hclext.Attribute{Name: "bar2"}},
+					},
+				},
+				{
+					Type: "locals",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"baz": &hclext.Attribute{Name: "baz2"}, "qux": &hclext.Attribute{Name: "qux"}},
+					},
+				},
+				// Locals not present in the primaries are added
+				{
+					Type: "locals",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"foo2": &hclext.Attribute{Name: "foo2"}},
+					},
+				},
+				{
+					Type: "locals",
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"qux2": &hclext.Attribute{Name: "qux2"}},
+					},
+				},
+			},
+		},
+		{
 			Name: "no override multiple required_version",
 			Primaries: hclext.Blocks{
 				// The "terraform" blocks are allowed to be declared multiple times.

--- a/terraform/module_test.go
+++ b/terraform/module_test.go
@@ -603,6 +603,7 @@ func Test_overrideBlocks(t *testing.T) {
 					Body: &hclext.BodyContent{
 						Attributes: hclext.Attributes{
 							"foo": &hclext.Attribute{Name: "bar"},
+							"baz": &hclext.Attribute{Name: "baz"},
 						},
 					},
 				},
@@ -614,6 +615,7 @@ func Test_overrideBlocks(t *testing.T) {
 						Attributes: hclext.Attributes{
 							"foo": &hclext.Attribute{Name: "bar"},
 							"bar": &hclext.Attribute{Name: "bar"},
+							"baz": &hclext.Attribute{Name: "baz"},
 						},
 					},
 				},
@@ -651,6 +653,7 @@ func Test_overrideBlocks(t *testing.T) {
 								Body: &hclext.BodyContent{
 									Attributes: hclext.Attributes{
 										"baz": &hclext.Attribute{Name: "qux"},
+										"bar": &hclext.Attribute{Name: "bar"},
 									},
 								},
 							},
@@ -668,8 +671,89 @@ func Test_overrideBlocks(t *testing.T) {
 								Type: "nested",
 								Body: &hclext.BodyContent{
 									Attributes: hclext.Attributes{
+										// The contents of nested configuration blocks are not merged.
 										"baz": &hclext.Attribute{Name: "qux"},
+										"bar": &hclext.Attribute{Name: "bar"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "override multiple nested blocks",
+			Primaries: hclext.Blocks{
+				{
+					Type: "resource",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "nested",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"foo": &hclext.Attribute{Name: "foo"},
+									},
+								},
+							},
+							{
+								Type: "nested",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"bar": &hclext.Attribute{Name: "bar"},
+									},
+								},
+							},
+							{
+								Type: "other_nested",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
 										"qux": &hclext.Attribute{Name: "qux"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{
+				{
+					Type: "resource",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							{
+								Type: "nested",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"baz": &hclext.Attribute{Name: "baz"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: hclext.Blocks{
+				{
+					Type: "resource",
+					Body: &hclext.BodyContent{
+						Blocks: hclext.Blocks{
+							// Any block types that do not appear in the override block remain from the original block.
+							{
+								Type: "other_nested",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"qux": &hclext.Attribute{Name: "qux"},
+									},
+								},
+							},
+							// override block replace all blocks of the same type in the original block.
+							{
+								Type: "nested",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"baz": &hclext.Attribute{Name: "baz"},
 									},
 								},
 							},

--- a/terraform/module_test.go
+++ b/terraform/module_test.go
@@ -612,7 +612,8 @@ func Test_overrideBlocks(t *testing.T) {
 			Name: "no override",
 			Primaries: hclext.Blocks{
 				{
-					Type: "resource",
+					Type:   "resource",
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
 						Attributes: hclext.Attributes{"foo": &hclext.Attribute{Name: "foo"}},
 					},
@@ -621,7 +622,38 @@ func Test_overrideBlocks(t *testing.T) {
 			Overrides: hclext.Blocks{},
 			Want: hclext.Blocks{
 				{
-					Type: "resource",
+					Type:   "resource",
+					Labels: []string{"foo", "bar"},
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"foo": &hclext.Attribute{Name: "foo"}},
+					},
+				},
+			},
+		},
+		{
+			Name: "no override because resources are difference",
+			Primaries: hclext.Blocks{
+				{
+					Type:   "resource",
+					Labels: []string{"foo", "bar"},
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"foo": &hclext.Attribute{Name: "foo"}},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{
+				{
+					Type:   "resource",
+					Labels: []string{"baz", "qux"},
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{"foo": &hclext.Attribute{Name: "foo2"}},
+					},
+				},
+			},
+			Want: hclext.Blocks{
+				{
+					Type:   "resource",
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
 						Attributes: hclext.Attributes{"foo": &hclext.Attribute{Name: "foo"}},
 					},
@@ -632,7 +664,8 @@ func Test_overrideBlocks(t *testing.T) {
 			Name: "override",
 			Primaries: hclext.Blocks{
 				{
-					Type: "resource",
+					Type:   "resource",
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
 						Attributes: hclext.Attributes{
 							"foo": &hclext.Attribute{Name: "foo"},
@@ -643,7 +676,8 @@ func Test_overrideBlocks(t *testing.T) {
 			},
 			Overrides: hclext.Blocks{
 				{
-					Type: "resource",
+					Type:   "resource",
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
 						Attributes: hclext.Attributes{
 							"foo": &hclext.Attribute{Name: "bar"},
@@ -654,7 +688,8 @@ func Test_overrideBlocks(t *testing.T) {
 			},
 			Want: hclext.Blocks{
 				{
-					Type: "resource",
+					Type:   "resource",
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
 						Attributes: hclext.Attributes{
 							"foo": &hclext.Attribute{Name: "bar"},
@@ -669,7 +704,8 @@ func Test_overrideBlocks(t *testing.T) {
 			Name: "override nested blocks",
 			Primaries: hclext.Blocks{
 				{
-					Type: "resource",
+					Type:   "resource",
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
 						Attributes: hclext.Attributes{"foo": &hclext.Attribute{Name: "foo"}},
 						Blocks: hclext.Blocks{
@@ -688,7 +724,8 @@ func Test_overrideBlocks(t *testing.T) {
 			},
 			Overrides: hclext.Blocks{
 				{
-					Type: "resource",
+					Type:   "resource",
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
 						Attributes: hclext.Attributes{"foo": &hclext.Attribute{Name: "bar"}},
 						Blocks: hclext.Blocks{
@@ -707,7 +744,8 @@ func Test_overrideBlocks(t *testing.T) {
 			},
 			Want: hclext.Blocks{
 				{
-					Type: "resource",
+					Type:   "resource",
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
 						Attributes: hclext.Attributes{"foo": &hclext.Attribute{Name: "bar"}},
 						Blocks: hclext.Blocks{
@@ -730,7 +768,8 @@ func Test_overrideBlocks(t *testing.T) {
 			Name: "override multiple nested blocks",
 			Primaries: hclext.Blocks{
 				{
-					Type: "resource",
+					Type:   "resource",
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
 						Blocks: hclext.Blocks{
 							{
@@ -763,7 +802,8 @@ func Test_overrideBlocks(t *testing.T) {
 			},
 			Overrides: hclext.Blocks{
 				{
-					Type: "resource",
+					Type:   "resource",
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
 						Blocks: hclext.Blocks{
 							{
@@ -780,7 +820,8 @@ func Test_overrideBlocks(t *testing.T) {
 			},
 			Want: hclext.Blocks{
 				{
-					Type: "resource",
+					Type:   "resource",
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
 						Blocks: hclext.Blocks{
 							// Any block types that do not appear in the override block remain from the original block.
@@ -811,10 +852,15 @@ func Test_overrideBlocks(t *testing.T) {
 			Primaries: hclext.Blocks{
 				{
 					Type:   "resource",
-					Labels: []string{"random_id", "server"},
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
-						Attributes: hclext.Attributes{"create_before_destroy": &hclext.Attribute{Name: "create_before_destroy"}, "prevent_destroy": &hclext.Attribute{Name: "prevent_destroy"}},
 						Blocks: hclext.Blocks{
+							{
+								Type: "lifecycle",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{"create_before_destroy": &hclext.Attribute{Name: "create_before_destroy"}, "prevent_destroy": &hclext.Attribute{Name: "prevent_destroy"}},
+								},
+							},
 							{
 								Type:   "provisioner",
 								Labels: []string{"local-exec"},
@@ -842,10 +888,15 @@ func Test_overrideBlocks(t *testing.T) {
 			Overrides: hclext.Blocks{
 				{
 					Type:   "resource",
-					Labels: []string{"random_id", "server"},
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
-						Attributes: hclext.Attributes{"ignore_changes": &hclext.Attribute{Name: "ignore_changes"}, "create_before_destroy": &hclext.Attribute{Name: "create_before_destroy2"}},
 						Blocks: hclext.Blocks{
+							{
+								Type: "lifecycle",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{"ignore_changes": &hclext.Attribute{Name: "ignore_changes"}, "create_before_destroy": &hclext.Attribute{Name: "create_before_destroy2"}},
+								},
+							},
 							{
 								Type:   "provisioner",
 								Labels: []string{"remote-exec"},
@@ -866,13 +917,17 @@ func Test_overrideBlocks(t *testing.T) {
 			Want: hclext.Blocks{
 				{
 					Type:   "resource",
-					Labels: []string{"random_id", "server"},
+					Labels: []string{"foo", "bar"},
 					Body: &hclext.BodyContent{
-						// the contents of any lifecycle nested block are merged on an argument-by-argument basis.
-						Attributes: hclext.Attributes{"create_before_destroy": &hclext.Attribute{Name: "create_before_destroy2"}, "prevent_destroy": &hclext.Attribute{Name: "prevent_destroy"}, "ignore_changes": &hclext.Attribute{Name: "ignore_changes"}},
-						// If an overriding resource block contains one or more provisioner blocks then any provisioner blocks in the original block are ignored.
-						// If an overriding resource block contains a connection block then it completely overrides any connection block present in the original block.
 						Blocks: hclext.Blocks{
+							// the contents of any lifecycle nested block are merged on an argument-by-argument basis.
+							{
+								Type: "lifecycle",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{"create_before_destroy": &hclext.Attribute{Name: "create_before_destroy2"}, "prevent_destroy": &hclext.Attribute{Name: "prevent_destroy"}, "ignore_changes": &hclext.Attribute{Name: "ignore_changes"}},
+								},
+							},
+							// If an overriding resource block contains one or more provisioner blocks then any provisioner blocks in the original block are ignored.
 							{
 								Type:   "provisioner",
 								Labels: []string{"remote-exec"},
@@ -880,6 +935,7 @@ func Test_overrideBlocks(t *testing.T) {
 									Attributes: hclext.Attributes{"inline": &hclext.Attribute{Name: "inline"}},
 								},
 							},
+							// If an overriding resource block contains a connection block then it completely overrides any connection block present in the original block.
 							{
 								Type: "connection",
 								Body: &hclext.BodyContent{
@@ -892,9 +948,102 @@ func Test_overrideBlocks(t *testing.T) {
 			},
 		},
 		{
+			Name: "override data sources",
+			Primaries: hclext.Blocks{
+				{
+					Type:   "data",
+					Labels: []string{"foo", "bar"},
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{
+							"foo": &hclext.Attribute{Name: "foo"},
+							"bar": &hclext.Attribute{Name: "bar"},
+						},
+						Blocks: hclext.Blocks{
+							{
+								Type: "nested",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"foo": &hclext.Attribute{Name: "foo"},
+									},
+								},
+							},
+							{
+								Type: "nested",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"bar": &hclext.Attribute{Name: "bar"},
+									},
+								},
+							},
+							{
+								Type: "other_nested",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"qux": &hclext.Attribute{Name: "qux"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Overrides: hclext.Blocks{
+				{
+					Type:   "data",
+					Labels: []string{"foo", "bar"},
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{
+							"foo": &hclext.Attribute{Name: "bar"},
+							"baz": &hclext.Attribute{Name: "baz"},
+						},
+						Blocks: hclext.Blocks{
+							{
+								Type: "nested",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"baz": &hclext.Attribute{Name: "baz"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Want: hclext.Blocks{
+				{
+					Type:   "data",
+					Labels: []string{"foo", "bar"},
+					Body: &hclext.BodyContent{
+						Attributes: hclext.Attributes{
+							"foo": &hclext.Attribute{Name: "bar"},
+							"bar": &hclext.Attribute{Name: "bar"},
+							"baz": &hclext.Attribute{Name: "baz"},
+						},
+						Blocks: hclext.Blocks{
+							{
+								Type: "other_nested",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"qux": &hclext.Attribute{Name: "qux"},
+									},
+								},
+							},
+							{
+								Type: "nested",
+								Body: &hclext.BodyContent{
+									Attributes: hclext.Attributes{
+										"baz": &hclext.Attribute{Name: "baz"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			Name: "override locals",
 			Primaries: hclext.Blocks{
-				// The "locals" blocks are allowed to be declared multiple times.
 				{
 					Type: "locals",
 					Body: &hclext.BodyContent{
@@ -918,7 +1067,7 @@ func Test_overrideBlocks(t *testing.T) {
 				{
 					Type: "locals",
 					Body: &hclext.BodyContent{
-						Attributes: hclext.Attributes{"bar": &hclext.Attribute{Name: "bar2"}, "qux2": &hclext.Attribute{Name: "qux2"}},
+						Attributes: hclext.Attributes{"bar": &hclext.Attribute{Name: "bar2"}},
 					},
 				},
 			},
@@ -935,50 +1084,11 @@ func Test_overrideBlocks(t *testing.T) {
 						Attributes: hclext.Attributes{"baz": &hclext.Attribute{Name: "baz2"}, "qux": &hclext.Attribute{Name: "qux"}},
 					},
 				},
-				// Locals not present in the primaries are added
+				// Locals not present in the primaries are added.
 				{
 					Type: "locals",
 					Body: &hclext.BodyContent{
 						Attributes: hclext.Attributes{"foo2": &hclext.Attribute{Name: "foo2"}},
-					},
-				},
-				{
-					Type: "locals",
-					Body: &hclext.BodyContent{
-						Attributes: hclext.Attributes{"qux2": &hclext.Attribute{Name: "qux2"}},
-					},
-				},
-			},
-		},
-		{
-			Name: "no override multiple required_version",
-			Primaries: hclext.Blocks{
-				// The "terraform" blocks are allowed to be declared multiple times.
-				{
-					Type: "terraform",
-					Body: &hclext.BodyContent{
-						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version1"}},
-					},
-				},
-				{
-					Type: "terraform",
-					Body: &hclext.BodyContent{
-						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version2"}},
-					},
-				},
-			},
-			Overrides: hclext.Blocks{},
-			Want: hclext.Blocks{
-				{
-					Type: "terraform",
-					Body: &hclext.BodyContent{
-						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version1"}},
-					},
-				},
-				{
-					Type: "terraform",
-					Body: &hclext.BodyContent{
-						Attributes: hclext.Attributes{"required_version": &hclext.Attribute{Name: "required_version2"}},
 					},
 				},
 			},
@@ -1014,8 +1124,8 @@ func Test_overrideBlocks(t *testing.T) {
 				},
 			},
 			Want: hclext.Blocks{
-				// In both the required_version and required_providers settings,
-				// each override constraint entirely replaces the constraints for the same component in the original block.
+				// When overriding attributes, the last element in override takes precedence,
+				// so all attributes of primaries are overridden by required_version4.
 				{
 					Type: "terraform",
 					Body: &hclext.BodyContent{
@@ -1031,93 +1141,6 @@ func Test_overrideBlocks(t *testing.T) {
 			},
 		},
 		{
-			Name: "no override required_providers",
-			Primaries: hclext.Blocks{
-				{
-					Type: "terraform",
-					Body: &hclext.BodyContent{
-						Blocks: hclext.Blocks{
-							{
-								Type: "required_providers",
-								Body: &hclext.BodyContent{
-									Attributes: hclext.Attributes{
-										"aws":    &hclext.Attribute{Name: "aws"},
-										"google": &hclext.Attribute{Name: "google"},
-									},
-								},
-							},
-							{
-								Type: "required_providers",
-								Body: &hclext.BodyContent{
-									Attributes: hclext.Attributes{
-										"azurerm": &hclext.Attribute{Name: "azurerm"},
-									},
-								},
-							},
-						},
-					},
-				},
-				{
-					Type: "terraform",
-					Body: &hclext.BodyContent{
-						Blocks: hclext.Blocks{
-							{
-								Type: "required_providers",
-								Body: &hclext.BodyContent{
-									Attributes: hclext.Attributes{
-										"google-beta": &hclext.Attribute{Name: "google-beta"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			Overrides: hclext.Blocks{},
-			Want: hclext.Blocks{
-				{
-					Type: "terraform",
-					Body: &hclext.BodyContent{
-						Blocks: hclext.Blocks{
-							{
-								Type: "required_providers",
-								Body: &hclext.BodyContent{
-									Attributes: hclext.Attributes{
-										"aws":    &hclext.Attribute{Name: "aws"},
-										"google": &hclext.Attribute{Name: "google"},
-									},
-								},
-							},
-							{
-								Type: "required_providers",
-								Body: &hclext.BodyContent{
-									Attributes: hclext.Attributes{
-										"azurerm": &hclext.Attribute{Name: "azurerm"},
-									},
-								},
-							},
-						},
-					},
-				},
-				{
-					Type: "terraform",
-					Body: &hclext.BodyContent{
-						Blocks: hclext.Blocks{
-							{
-								Type: "required_providers",
-								Body: &hclext.BodyContent{
-									Attributes: hclext.Attributes{
-										"google-beta": &hclext.Attribute{Name: "google-beta"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			// If the required_providers argument is set, its value is merged on an element-by-element basis
 			Name: "override required_providers",
 			Primaries: hclext.Blocks{
 				{
@@ -1242,7 +1265,7 @@ func Test_overrideBlocks(t *testing.T) {
 						},
 					},
 				},
-				// Blocks not present in the primaries are added
+				// Blocks not present in the primaries are added.
 				{
 					Type: "terraform",
 					Body: &hclext.BodyContent{

--- a/terraform/parser_test.go
+++ b/terraform/parser_test.go
@@ -39,6 +39,7 @@ func TestLoadConfigDir(t *testing.T) {
 					"main_override.tf": {Body: hcltest.MockBody(&hcl.BodyContent{MissingItemRange: hcl.Range{Filename: "main_override.tf"}})},
 					"override.tf":      {Body: hcltest.MockBody(&hcl.BodyContent{MissingItemRange: hcl.Range{Filename: "override.tf"}})},
 				},
+				overrideFilenames: []string{"main_override.tf", "override.tf"},
 				Sources: map[string][]byte{
 					"main.tf":          {},
 					"main_override.tf": {},
@@ -69,6 +70,7 @@ func TestLoadConfigDir(t *testing.T) {
 					"main_override.tf.json": {Body: hcltest.MockBody(&hcl.BodyContent{MissingItemRange: hcl.Range{Filename: "main_override.tf.json"}})},
 					"override.tf.json":      {Body: hcltest.MockBody(&hcl.BodyContent{MissingItemRange: hcl.Range{Filename: "override.tf.json"}})},
 				},
+				overrideFilenames: []string{"main_override.tf.json", "override.tf.json"},
 				Sources: map[string][]byte{
 					"main.tf.json":          []byte("{}"),
 					"main_override.tf.json": []byte("{}"),
@@ -99,6 +101,7 @@ func TestLoadConfigDir(t *testing.T) {
 					filepath.Join("foo", "main_override.tf"): {Body: hcltest.MockBody(&hcl.BodyContent{MissingItemRange: hcl.Range{Filename: filepath.Join("foo", "main_override.tf")}})},
 					filepath.Join("foo", "override.tf"):      {Body: hcltest.MockBody(&hcl.BodyContent{MissingItemRange: hcl.Range{Filename: filepath.Join("foo", "override.tf")}})},
 				},
+				overrideFilenames: []string{filepath.Join("foo", "main_override.tf"), filepath.Join("foo", "override.tf")},
 				Sources: map[string][]byte{
 					filepath.Join("foo", "main.tf"):          {},
 					filepath.Join("foo", "main_override.tf"): {},
@@ -129,6 +132,7 @@ func TestLoadConfigDir(t *testing.T) {
 					filepath.Join("bar", "main_override.tf"): {Body: hcltest.MockBody(&hcl.BodyContent{MissingItemRange: hcl.Range{Filename: filepath.Join("bar", "main_override.tf")}})},
 					filepath.Join("bar", "override.tf"):      {Body: hcltest.MockBody(&hcl.BodyContent{MissingItemRange: hcl.Range{Filename: filepath.Join("bar", "override.tf")}})},
 				},
+				overrideFilenames: []string{filepath.Join("bar", "main_override.tf"), filepath.Join("bar", "override.tf")},
 				Sources: map[string][]byte{
 					filepath.Join("bar", "main.tf"):          {},
 					filepath.Join("bar", "main_override.tf"): {},
@@ -159,6 +163,7 @@ func TestLoadConfigDir(t *testing.T) {
 					filepath.Join("foo", "bar", "main_override.tf"): {Body: hcltest.MockBody(&hcl.BodyContent{MissingItemRange: hcl.Range{Filename: filepath.Join("foo", "bar", "main_override.tf")}})},
 					filepath.Join("foo", "bar", "override.tf"):      {Body: hcltest.MockBody(&hcl.BodyContent{MissingItemRange: hcl.Range{Filename: filepath.Join("foo", "bar", "override.tf")}})},
 				},
+				overrideFilenames: []string{filepath.Join("foo", "bar", "main_override.tf"), filepath.Join("foo", "bar", "override.tf")},
 				Sources: map[string][]byte{
 					filepath.Join("foo", "bar", "main.tf"):          {},
 					filepath.Join("foo", "bar", "main_override.tf"): {},
@@ -213,6 +218,10 @@ func TestLoadConfigDir(t *testing.T) {
 				overridesWant[i] = f.Body.MissingItemRange().Filename
 			}
 			if diff := cmp.Diff(overrides, overridesWant); diff != "" {
+				t.Errorf("diff: %s", diff)
+			}
+
+			if diff := cmp.Diff(mod.overrideFilenames, test.want.overrideFilenames); diff != "" {
 				t.Errorf("diff: %s", diff)
 			}
 


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/2114

As explained in #2114, the current override behavior is incomplete. The override behavior up to v0.53 is as follows:

- Attributes in blocks with matching headers (type and labels) are merged.
- Nested blocks are also merged recursively.
- If there are multiple blocks with the same header (e.g. `terraform`, `locals`), only one of them will be overridden. Which one gets overwritten is non-deterministic.
- The order in which override files are processed is completely random, not lexicographical.

```hcl
# main.tf
resource "aws_instance" "foo" {
  instance_type = "t2.micro" # => Should be c5.xlarge, but can be m5.xlarge

  # The entire block is overwritten, the volume_type should be discarded, but only the volume_size is overwritten
  ebs_block_device {
    volume_type = "gp3"
    volume_size = 20
  }
}

# main1_override.tf
resource "aws_instance" "foo" {
  instance_type = "m5.xlarge"

  ebs_block_device {
    volume_size = 50
  }
}

# main2_override.tf
resource "aws_instance" "foo" {
  instance_type = "c5.xlarge"
}
```

```hcl
# main.tf
terraform {
  backend "s3" {}
}

terraform {
  # If the terraform block below is overridden then "google" will be merged,
  # but if the one above is overridden then it will be ignored.
  required_providers {
    aws = {}
  }
}

# main_override.tf
terraform {
  required_providers {
    google = {}
  }
}
```

This PR fixes the override behavior to follow the Terraform spec. The following changes will be made:

- Attributes in blocks with matching headers are merged, although some blocks, such as `terraform` blocks, are merged with different rules.
  - See https://developer.hashicorp.com/terraform/language/files/override#merging-behavior
- Nested blocks are replaced entirely instead of being recursively merged.
- Overrides are processed in lexicographical order by filename.

In most cases, this change should be considered a bug fix as it results in stricter Terraform override behavior, and should have little to no impact unless you are doing complex overrides.

Finally, the behavior of overriding for multiply declarable blocks (e.g. `terraform`, `locals`) requires some caution: the `GetModuleContent` API returns different formats depending on whether there is one or more blocks.

For example, if only one `required_providers` is declared, the override will apply for that block:

```hcl
# main.tf
terraform {
  # Only one block with required_providers is returned, containing 3 attributes: "aws", "google", and "azurerm".
  required_providers {
    aws = {}
  }
}

# main_override.tf
terraform {
  required_providers {
    google = {}
  }
}

terraform {
  required_providers {
    azurerm= {}
  }
}
```

On the other hand, if multiple `required_providers` are declared, the new attributes will be returned as a new block:

```hcl
# main.tf
terraform {
  required_providers {
    aws = {}
  }
}

terraform {
  required_providers {
    google = {} # => This will be overridden
  }
}

# main_override.tf
terraform {
  required_providers {
    google = {}
    azurerm = {} # => This is not merged with either one and is returned as a new block, meaning the caller receives 3 "terraform" blocks.
  }
}
```

This is because it is not obvious which block the new attribute should be merged into.