### PR TITLE
Update config.md

### DIFF
--- a/docs/user-guide/config.md
+++ b/docs/user-guide/config.md
@@ -139,7 +139,7 @@ Adding a module source to `ignore_module` will cause it to be ignored when [call
 
 ```hcl
 config {
-  module = true
+  call_module_type = "all"
   ignore_module = {
     "terraform-aws-modules/vpc/aws"            = true
     "terraform-aws-modules/security-group/aws" = true


### PR DESCRIPTION
Fix the `ignore-module` example as the example used the deprecated `module` rather than `call_module_type`.

I'm unsure which value between `all` and `local` is appropriate, but feel `all` is more appropriate.