### PR TITLE
Move recursive init output to debug when there are no changes

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/afero"
@@ -17,19 +19,25 @@ func (cli *CLI) init(opts Options) int {
 		return ExitCodeError
 	}
 
+	var builder strings.Builder
+
 	if opts.Recursive {
 		fmt.Fprint(cli.outStream, "Installing plugins on each working directory...\n\n")
 	}
 
+	any_installed := false
 	for _, wd := range workingDirs {
+		builder.Reset()
 		err := cli.withinChangedDir(wd, func() error {
+			installed := false
 			if opts.Recursive {
-				fmt.Fprint(cli.outStream, "====================================================\n")
-				fmt.Fprintf(cli.outStream, "working directory: %s\n\n", wd)
+				builder.WriteString("====================================================\n")
+				builder.WriteString(fmt.Sprintf("working directory: %s\n\n", wd))
 			}
 
 			cfg, err := tflint.LoadConfig(afero.Afero{Fs: afero.NewOsFs()}, opts.Config)
 			if err != nil {
+				fmt.Fprint(cli.outStream, builder.String())
 				return fmt.Errorf("Failed to load TFLint config; %w", err)
 			}
 
@@ -45,6 +53,8 @@ func (cli *CLI) init(opts Options) int {
 
 				_, err := plugin.FindPluginPath(installCfg)
 				if os.IsNotExist(err) {
+					fmt.Fprint(cli.outStream, builder.String())
+					builder.Reset()
 					fmt.Fprintf(cli.outStream, "Installing \"%s\" plugin...\n", pluginCfg.Name)
 
 					sigchecker := plugin.NewSignatureChecker(installCfg)
@@ -57,19 +67,34 @@ func (cli *CLI) init(opts Options) int {
 						return fmt.Errorf("Failed to install a plugin; %w", err)
 					}
 
+					any_installed = true
+					installed = true
 					fmt.Fprintf(cli.outStream, "Installed \"%s\" (source: %s, version: %s)\n", pluginCfg.Name, pluginCfg.Source, pluginCfg.Version)
-					continue
 				}
 
 				if err != nil {
+					fmt.Fprint(cli.outStream, builder.String())
 					return fmt.Errorf("Failed to find a plugin; %w", err)
 				}
 
-				fmt.Fprintf(cli.outStream, "Plugin \"%s\" is already installed\n", pluginCfg.Name)
+				builder.WriteString(fmt.Sprintf("Plugin \"%s\" is already installed\n", pluginCfg.Name))
 			}
 
 			if opts.Recursive && !found {
-				fmt.Fprint(cli.outStream, "No plugins to install\n")
+				builder.WriteString("No plugins to install\n")
+			}
+
+			if installed || !opts.Recursive {
+				fmt.Fprint(cli.outStream, builder.String())
+				return nil
+			}
+
+			// If there are no changes, send logs to debug
+			prefix := "[DEBUG]   "
+			lines := strings.Split(builder.String(), "\n")
+
+			for _, line := range lines {
+				log.Printf("%s%s", prefix, line)
 			}
 
 			return nil
@@ -78,6 +103,9 @@ func (cli *CLI) init(opts Options) int {
 			cli.formatter.Print(tflint.Issues{}, err, map[string][]byte{})
 			return ExitCodeError
 		}
+	}
+	if opts.Recursive && !any_installed {
+		fmt.Fprint(cli.outStream, "All plugins are already installed\n")
 	}
 
 	return ExitCodeOK

--- a/integrationtest/init/init_test.go
+++ b/integrationtest/init/init_test.go
@@ -94,17 +94,11 @@ func TestIntegration(t *testing.T) {
 	}
 
 	cli.Run([]string{"./tflint", "--recursive", "--init"})
-	if !strings.Contains(outStream.String(), "working directory: .") {
+	if !strings.Contains(outStream.String(), "Installing plugins on each working directory...") {
 		t.Fatalf("Expected to contain working dir log, but did not: stdout=%s, stderr=%s", outStream, errStream)
 	}
-	if !strings.Contains(outStream.String(), "No plugins to install") {
-		t.Fatalf("Expected to contain no plugins log, but did not: stdout=%s, stderr=%s", outStream, errStream)
-	}
-	if !strings.Contains(outStream.String(), "working directory: basic") {
-		t.Fatalf("Expected to contain working dir log, but did not: stdout=%s, stderr=%s", outStream, errStream)
-	}
-	if !strings.Contains(outStream.String(), `Plugin "aws" is already installed`) {
-		t.Fatalf("Expected to contain an already installed log, but did not: stdout=%s, stderr=%s", outStream, errStream)
+	if !strings.Contains(outStream.String(), "All plugins are already installed") {
+		t.Fatalf("Expected to contain alread installed log, but did not: stdout=%s, stderr=%s", outStream, errStream)
 	}
 
 	outStream, errStream = new(bytes.Buffer), new(bytes.Buffer)


### PR DESCRIPTION
With the current version of tflint, there can be a lot of output even when there are no changes. This PR moves the unneeded logs to DEBUG if there are no changes. 

Fixes https://github.com/terraform-linters/tflint/issues/2146

```bash
❯ tflint --recursive --config=$(pwd)/.tflint.hcl --init

Installing plugins on each working directory...

====================================================
working directory: dir1

Plugin "aws" is already installed
====================================================
working directory: dir2

Plugin "aws" is already installed
====================================================
working directory: dir3

Plugin "aws" is already installed
...
```

```bash
❯ ~/projects/dist/tflint --recursive --config=$(pwd)/.tflint.hcl --init

Installing plugins on each working directory...

All plugins are already installed
```