### PR TITLE
go: Remove patch version from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-linters/tflint
 
-go 1.23.0
+go 1.23
 
 require (
 	github.com/agext/levenshtein v1.2.3


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint/pull/2031

Previously, a patch version had to be pinned, but that no longer seems to be the case.