### PR TITLE
install: handle GitHub API JSON without newlines

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -43,8 +43,8 @@ get_latest_release() {
       headers=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
   fi
   curl --fail -sS "${headers[@]}" "https://api.github.com/repos/terraform-linters/tflint/releases/latest" | # Get latest release from GitHub api
-    grep '"tag_name":' |                                                                                    # Get tag line
-    sed -E 's/.*"([^"]+)".*/\1/'                                                                            # Pluck JSON value
+    grep '"tag_name":' |                                                                                    # Filter other lines from multiline JSON
+    sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'                                         # Get tag_name value
 }
 
 download_path=$(mktemp -d -t tflint.XXXXXXXXXX)


### PR DESCRIPTION
Handles GitHub API responses that do not include newlines. Previously, if the `releases/latest` response lacked newlines within its JSON, `get_latest_release` would return `mentions_count` since that is the last double-quoted string on the line grep matched (the whole object).

Now, `sed` will only capture the string value after `"tag_name"`. It looks past a colon and optional surrounding whitespace and captures the next double quoted group. This is compatible with both compact and multiline JSON.

We still need `grep` to handle multiline JSON, since we need to exclude all lines other than the one we want. Otherwise the output is the original object with a single malformed line containing the latest version. GNU `sed` can handle multiline input with `-z` so keeping `grep` for that preserves portability.

Closes #2175