### PR TITLE
plugin: Drop support for plugin SDK v0.14/v0.15

### DIFF
--- a/docs/developer-guide/api_compatibility.md
+++ b/docs/developer-guide/api_compatibility.md
@@ -3,14 +3,9 @@
 This is an internal documentation summarizing the currently supported SDK and TFLint versions and any compatibility caveats.
 
 Protocol version: 11  
-SDK version: v0.14.0+
+SDK version: v0.16.0+
 TFLint version: v0.42.0+
 
-- Client-side value handling is introduced in SDK v0.16.0 and TFLint v0.46.0. TFLint v0.45.0 returns an error instead of a value.
-  - https://github.com/terraform-linters/tflint/pull/1700
-  - https://github.com/terraform-linters/tflint/pull/1722
-  - https://github.com/terraform-linters/tflint-plugin-sdk/pull/235
-  - https://github.com/terraform-linters/tflint-plugin-sdk/pull/239
 - Ephemeral value is introduced in SDK v0.22.0 and TFLint v0.55.0. TFLint returns ErrSensitive instead of ephemeral values to plugins built with SDK v0.21.0.
   - https://github.com/terraform-linters/tflint/pull/2178
   - https://github.com/terraform-linters/tflint-plugin-sdk/pull/358

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -14,7 +14,7 @@ var (
 )
 
 // SDKVersionConstraints is the version constraint of the supported SDK version.
-var SDKVersionConstraints = version.MustConstraints(version.NewConstraint(">= 0.14.0"))
+var SDKVersionConstraints = version.MustConstraints(version.NewConstraint(">= 0.16.0"))
 
 // Plugin is an object handling plugins
 // Basically, it is a wrapper for go-plugin and provides an API to handle them collectively.

--- a/plugin/server_test.go
+++ b/plugin/server_test.go
@@ -476,7 +476,6 @@ variable "foo" {
 
 	server := NewGRPCServer(runner, rootRunner, runner.Files(), SDKVersion)
 
-	sdkv15 := version.Must(version.NewVersion("0.15.0"))
 	sdkv21 := version.Must(version.NewVersion("0.21.0"))
 
 	// test util functions
@@ -526,29 +525,6 @@ variable "foo" {
 			ErrCheck: neverHappend,
 		},
 		{
-			Name: "sensitive value (SDK v0.15)",
-			Args: func() (hcl.Expression, sdk.EvaluateExprOption) {
-				return hclExpr(`var.sensitive`), sdk.EvaluateExprOption{WantType: &cty.String, ModuleCtx: sdk.SelfModuleCtxType}
-			},
-			Want:       cty.NullVal(cty.NilType),
-			SDKVersion: sdkv15,
-			ErrCheck: func(err error) bool {
-				return err == nil || !errors.Is(err, sdk.ErrSensitive)
-			},
-		},
-		{
-			Name: "sensitive value in object (SDK v0.15)",
-			Args: func() (hcl.Expression, sdk.EvaluateExprOption) {
-				ty := cty.Object(map[string]cty.Type{"value": cty.String})
-				return hclExpr(`{ value = var.sensitive }`), sdk.EvaluateExprOption{WantType: &ty, ModuleCtx: sdk.SelfModuleCtxType}
-			},
-			Want:       cty.NullVal(cty.NilType),
-			SDKVersion: sdkv15,
-			ErrCheck: func(err error) bool {
-				return err == nil || !errors.Is(err, sdk.ErrSensitive)
-			},
-		},
-		{
 			Name: "sensitive value (SDK v0.21)",
 			Args: func() (hcl.Expression, sdk.EvaluateExprOption) {
 				return hclExpr(`var.sensitive`), sdk.EvaluateExprOption{WantType: &cty.String, ModuleCtx: sdk.SelfModuleCtxType}
@@ -566,76 +542,12 @@ variable "foo" {
 			ErrCheck: neverHappend,
 		},
 		{
-			Name: "no default (SDK v0.15)",
-			Args: func() (hcl.Expression, sdk.EvaluateExprOption) {
-				return hclExpr(`var.no_default`), sdk.EvaluateExprOption{WantType: &cty.String, ModuleCtx: sdk.SelfModuleCtxType}
-			},
-			SDKVersion: sdkv15,
-			Want:       cty.NullVal(cty.NilType),
-			ErrCheck: func(err error) bool {
-				return err == nil || !errors.Is(err, sdk.ErrUnknownValue)
-			},
-		},
-		{
-			Name: "no default as cty.Value (SDK v0.15)",
-			Args: func() (hcl.Expression, sdk.EvaluateExprOption) {
-				return hclExpr(`var.no_default`), sdk.EvaluateExprOption{WantType: &cty.DynamicPseudoType, ModuleCtx: sdk.SelfModuleCtxType}
-			},
-			SDKVersion: sdkv15,
-			Want:       cty.DynamicVal,
-			ErrCheck:   neverHappend,
-		},
-		{
-			Name: "no default value in object (SDK v0.15)",
-			Args: func() (hcl.Expression, sdk.EvaluateExprOption) {
-				ty := cty.Object(map[string]cty.Type{"value": cty.String})
-				return hclExpr(`{ value = var.no_default }`), sdk.EvaluateExprOption{WantType: &ty, ModuleCtx: sdk.SelfModuleCtxType}
-			},
-			SDKVersion: sdkv15,
-			Want:       cty.NullVal(cty.NilType),
-			ErrCheck: func(err error) bool {
-				return err == nil || !errors.Is(err, sdk.ErrUnknownValue)
-			},
-		},
-		{
 			Name: "null",
 			Args: func() (hcl.Expression, sdk.EvaluateExprOption) {
 				return hclExpr(`var.null`), sdk.EvaluateExprOption{WantType: &cty.String, ModuleCtx: sdk.SelfModuleCtxType}
 			},
 			Want:     cty.NullVal(cty.String),
 			ErrCheck: neverHappend,
-		},
-		{
-			Name: "null (SDK v0.15)",
-			Args: func() (hcl.Expression, sdk.EvaluateExprOption) {
-				return hclExpr(`var.null`), sdk.EvaluateExprOption{WantType: &cty.String, ModuleCtx: sdk.SelfModuleCtxType}
-			},
-			SDKVersion: sdkv15,
-			Want:       cty.NullVal(cty.NilType),
-			ErrCheck: func(err error) bool {
-				return err == nil || !errors.Is(err, sdk.ErrNullValue)
-			},
-		},
-		{
-			Name: "null as cty.Value (SDK v0.15)",
-			Args: func() (hcl.Expression, sdk.EvaluateExprOption) {
-				return hclExpr(`var.null`), sdk.EvaluateExprOption{WantType: &cty.DynamicPseudoType, ModuleCtx: sdk.SelfModuleCtxType}
-			},
-			SDKVersion: sdkv15,
-			Want:       cty.NullVal(cty.String),
-			ErrCheck:   neverHappend,
-		},
-		{
-			Name: "null value in object (SDK v0.15)",
-			Args: func() (hcl.Expression, sdk.EvaluateExprOption) {
-				ty := cty.Object(map[string]cty.Type{"value": cty.String})
-				return hclExpr(`{ value = var.null }`), sdk.EvaluateExprOption{WantType: &ty, ModuleCtx: sdk.SelfModuleCtxType}
-			},
-			Want:       cty.NullVal(cty.NilType),
-			SDKVersion: sdkv15,
-			ErrCheck: func(err error) bool {
-				return err == nil || !errors.Is(err, sdk.ErrNullValue)
-			},
 		},
 		{
 			Name: "ephemeral value",

--- a/terraform/tfhcl/expand_body.go
+++ b/terraform/tfhcl/expand_body.go
@@ -160,7 +160,8 @@ func (b *expandBody) prepareAttributes(rawAttrs hcl.Attributes) (hcl.Attributes,
 				diags = append(diags, evalDiags...)
 				continue
 			}
-			// Marked values (e.g. sensitive values) are unbound for serialization.
+			// Marked values (e.g. ephemeral values) are unbound for serialization.
+			// TODO: Update the minimum supported SDK version to v0.22+ and then remove this condition.
 			if !val.ContainsMarked() {
 				attr.Expr = hclext.BindValue(val, expr)
 			}


### PR DESCRIPTION
This PR drops support for plugins built with SDK v0.14/v0.15.

SDK v0.15 was released two years ago and this change is in line with the deprecation plan. This allows plugins to handle `cty.Value` ​​except for ephemeral values.