### PR TITLE
cmd: Simplify recursive init outputs

### DIFF
--- a/integrationtest/init/init_test.go
+++ b/integrationtest/init/init_test.go
@@ -54,7 +54,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	cli.Run([]string{"./tflint", "--init"})
-	if !strings.Contains(outStream.String(), `Plugin "aws" is already installed`) {
+	if !strings.Contains(outStream.String(), `All plugins are already installed`) {
 		t.Fatalf("Expected to contain an already installed log, but did not: stdout=%s, stderr=%s", outStream, errStream)
 	}
 
@@ -74,7 +74,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	cli.Run([]string{"./tflint", "--chdir", "basic", "--init"})
-	if !strings.Contains(outStream.String(), `Plugin "aws" is already installed`) {
+	if !strings.Contains(outStream.String(), `All plugins are already installed`) {
 		t.Fatalf("Expected to contain an already installed log, but did not: stdout=%s, stderr=%s", outStream, errStream)
 	}
 
@@ -94,9 +94,6 @@ func TestIntegration(t *testing.T) {
 	}
 
 	cli.Run([]string{"./tflint", "--recursive", "--init"})
-	if !strings.Contains(outStream.String(), "Installing plugins on each working directory...") {
-		t.Fatalf("Expected to contain working dir log, but did not: stdout=%s, stderr=%s", outStream, errStream)
-	}
 	if !strings.Contains(outStream.String(), "All plugins are already installed") {
 		t.Fatalf("Expected to contain already installed log, but did not: stdout=%s, stderr=%s", outStream, errStream)
 	}


### PR DESCRIPTION
Follow up of https://github.com/terraform-linters/tflint/pull/2150

The `strings.Builder`-based approach is complicated to implement, so we'll change it to a simpler output.

## without `--recursive`

### Installed

No changes

### Already installed

**Before**
```console
$ tflint --init
Plugin "aws" is already installed
Plugin "google" is already installed
```

**After**
```console
$ tflint --init
All plugins are already installed
```

## with `--recursive`

### Installed

**Before**
```console
Installing plugins on each working directory...

====================================================
working directory: .

No plugins to install
====================================================
working directory: subdir

Installing "aws" plugin...
Installed "aws" (source: github.com/terraform-linters/tflint-ruleset-aws, version: 0.34.0)
====================================================
working directory: subdir2

Installing "google" plugin...
Installed "google" (source: github.com/terraform-linters/tflint-ruleset-google, version: 0.30.0)
```

**After**
```console
$ tflint --recursive --init
Installing "aws" plugin in subdir...
Installed "aws" (source: github.com/terraform-linters/tflint-ruleset-aws, version: 0.34.0)
Installing "google" plugin in subdir2...
Installed "google" (source: github.com/terraform-linters/tflint-ruleset-google, version: 0.30.0)
```

### Already installed

**Before**
```console
Installing plugins on each working directory...

====================================================
working directory: .

No plugins to install
====================================================
working directory: subdir

Plugin "aws" is already installed
====================================================
working directory: subdir2

Plugin "google" is already installed
```

**After**
```console
$ tflint --recursive --init
All plugins are already installed
```