### PR TITLE
Remove dependency on dpkg in install_linux.sh

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -6,11 +6,10 @@ set -o pipefail
 get_machine_arch () {
     machine_arch=""
     case $(uname -m) in
-        i386)     machine_arch="386" ;;
-        i686)     machine_arch="386" ;;
-        x86_64)   machine_arch="amd64" ;;
-        arm64)    machine_arch="arm64" ;;
-        aarch64)  dpkg --print-architecture | grep -q "arm64" && machine_arch="arm64" || machine_arch="arm" ;;
+        i386)             machine_arch="386" ;;
+        i686)             machine_arch="386" ;;
+        x86_64)           machine_arch="amd64" ;;
+        arm64|aarch64)    machine_arch="arm64" ;;
     esac
     echo $machine_arch
 }


### PR DESCRIPTION
For the purposes of tflint arm64 and aarch64 are equivalent and so we don't need to keep the logic that checks for the user space being 32 bit. This allows us to not rely on dpkg being installed, but more importantly stops 64 bit systems from falling back to 32bit tflint install when dpkg is not present