### PR TITLE
Add support for tflint-ignore-file annotations in JSON

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
@@ -223,9 +222,6 @@ func (cli *CLI) setupRunners(opts Options, dir string) (*tflint.Runner, []*tflin
 	}
 	annotations := map[string]tflint.Annotations{}
 	for path, file := range files {
-		if !strings.HasSuffix(path, ".tf") {
-			continue
-		}
 		ants, lexDiags := tflint.NewAnnotations(path, file)
 		diags = diags.Extend(lexDiags)
 		annotations[path] = ants

--- a/docs/user-guide/annotations.md
+++ b/docs/user-guide/annotations.md
@@ -79,3 +79,52 @@ resource "aws_instance" "foo" { # tflint-ignore-file: aws_instance_invalid_type
   instance_type = "t1.2xlarge"
 }
 ```
+
+The `tflint-ignore-file` annotation is also supported in Terraform JSON by
+using a top-level [comment property](https://developer.hashicorp.com/terraform/language/syntax/json#comment-properties):
+
+```json
+{
+  "//": "tflint-ignore-file: aws_instance_invalid_type",
+  "resource": {
+    "aws_instance": {
+      "foo": {
+        "instance_type": "t2.micro"
+      }
+    }
+  }
+}
+```
+
+As with annotations in HCL files, multiple rules can be specified as a
+comma-separated list:
+
+```json
+{
+  "//": "tflint-ignore-file: aws_instance_invalid_type, other_rule",
+  "resource": {
+    "aws_instance": {
+      "foo": {
+        "instance_type": "t2.micro"
+      }
+    }
+  }
+}
+```
+
+Similarly, annotations in JSON can be followed with arbitrary comments, but the annotation must be the first thing in the comment property string:
+
+```json
+{
+  "//": "tflint-ignore-file: aws_instance_invalid_type # This instance type is new and TFLint doesn't know about it yet",
+  "resource": {
+    "aws_instance": {
+      "foo": {
+        "instance_type": "t2.micro"
+      }
+    }
+  }
+}
+```
+
+The `tflint-ignore` annotation is not supported in JSON configuration.

--- a/docs/user-guide/annotations.md
+++ b/docs/user-guide/annotations.md
@@ -55,6 +55,8 @@ resource "aws_instance" "foo" {
 }
 ```
 
+## Files
+
 To disable an entire file, you can also use the `tflint-ignore-file` annotation:
 
 ```hcl
@@ -80,8 +82,9 @@ resource "aws_instance" "foo" { # tflint-ignore-file: aws_instance_invalid_type
 }
 ```
 
-The `tflint-ignore-file` annotation is also supported in Terraform JSON by
-using a top-level [comment property](https://developer.hashicorp.com/terraform/language/syntax/json#comment-properties):
+## JSON
+
+The `tflint-ignore-file` annotation is also supported in Terraform JSON by using a top-level [comment property](https://developer.hashicorp.com/terraform/language/syntax/json#comment-properties):
 
 ```json
 {

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -178,9 +178,6 @@ func (h *handler) inspect() (map[string][]lsp.Diagnostic, error) {
 	}
 	annotations := map[string]tflint.Annotations{}
 	for path, file := range files {
-		if !strings.HasSuffix(path, ".tf") {
-			continue
-		}
 		ants, lexDiags := tflint.NewAnnotations(path, file)
 		diags = diags.Extend(lexDiags)
 		annotations[path] = ants

--- a/tflint/annotation_test.go
+++ b/tflint/annotation_test.go
@@ -223,7 +223,7 @@ resource "aws_instance" "foo" {
 			},
 		},
 		{
-			name:     "tglint-ignore-file with multiple rules in JSON comment property and following comment",
+			name:     "tflint-ignore-file with multiple rules in JSON comment property and following comment",
 			filename: "resource.tf.json",
 			src: `{
   "//": "tflint-ignore-file: aws_instance_invalid_type, terraform_deprecated_syntax # this is an extra comment",
@@ -282,8 +282,10 @@ resource "aws_instance" "foo" {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			parser := hclparse.NewParser()
-			var file *hcl.File
-			var diags hcl.Diagnostics
+			var (
+				file  *hcl.File
+				diags hcl.Diagnostics
+			)
 			switch {
 			case strings.HasSuffix(test.filename, ".json"):
 				file, diags = parser.ParseJSON([]byte(test.src), test.filename)


### PR DESCRIPTION
I have a use case where I'm generating `.tf.json` files for a bunch of different root modules; these `.tf.json` files define several locals for convenience, which may or may not be used by the root modules they're placed in. I wanted to be able to ignore the `terraform_unused_declarations` rule without disabling it globally, but I realized that there wasn't a way to do this since the annotation system didn't support JSON files at all. This change adds limited support for `tflint-ignore-file` annotations in a top-level comment property.