### PR TITLE
dependabot: group golang.org/x/* deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      go-x:
+        patterns:
+          - "golang.org/x/*"
+        applies-to: version-updates
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
These frequently hit merge conflicts with `go.mod` since they are heavily inter-dependent.

https://go.dev/wiki/X-Repositories