### PR TITLE
golangci-lint v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,6 @@ jobs:
       with:
         go-version-file: 'go.mod'
     - name: Run linters
-      uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
+      uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
       with:
         version: v1.64.4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Run linters
       uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
       with:
-        version: v1.64.4
+        version: v2.0.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,34 @@
-run:
-  timeout: 5m
+version: "2"
 linters:
+  enable:
+    - copyloopvar
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        path: terraform/
+      - linters:
+          - staticcheck
+        text: 'ST1005:' # allow capitlized error strings
+    paths:
+      - terraform/
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
   enable:
     - gci
     - gofmt
-    - copyloopvar
-issues:
-  exclude-dirs:
-    - terraform/
-  exclude-rules:
-    - path: terraform/
-      linters:
-        - gosimple
+  exclusions:
+    generated: lax
+    paths:
+      - terraform/
+      - third_party$
+      - builtin$
+      - examples$

--- a/plugin/discovery.go
+++ b/plugin/discovery.go
@@ -156,11 +156,10 @@ func pluginClientError(err error, config *tflint.PluginConfig) error {
 	search := "Incompatible API version with plugin."
 
 	if strings.Contains(message, search) {
-		message = strings.Replace(
+		message = strings.ReplaceAll(
 			message,
 			search,
 			fmt.Sprintf(`TFLint is not compatible with this version of the %q plugin. A newer TFLint or plugin version may be required.`, config.Name),
-			-1,
 		)
 
 		return errors.New(message)

--- a/tflint/annotation.go
+++ b/tflint/annotation.go
@@ -56,7 +56,7 @@ func hclAnnotations(path string, file *hcl.File) (Annotations, hcl.Diagnostics) 
 		// tflint-ignore-file annotation
 		match = fileAnnotationPattern.FindStringSubmatch(string(token.Bytes))
 		if len(match) == 2 {
-			if !(token.Range.Start.Line == 1 && token.Range.Start.Column == 1) {
+			if token.Range.Start.Line != 1 || token.Range.Start.Column != 1 {
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
 					Summary:  "tflint-ignore-file annotation must be written at the top of file",


### PR DESCRIPTION
https://ldez.github.io/blog/2025/03/23/golangci-lint-v2/

* Ran `golangci-lint migrate` to migrate config
* Ran `golangci-lint run ./... --fix` to apply auto-fixes