### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete regular expression for hostnames

### DIFF
--- a/tools/release/main.go
+++ b/tools/release/main.go
@@ -20,7 +20,7 @@ import (
 var token = os.Getenv("GITHUB_TOKEN")
 var versionRegexp = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
 var goModRequireSDKRegexp = regexp.MustCompile(`github.com/terraform-linters/tflint-plugin-sdk v(.+)`)
-var goModRequireBundledPluginRegexp = regexp.MustCompile(`github.com/terraform-linters/tflint-ruleset-terraform v(.+)`)
+var goModRequireBundledPluginRegexp = regexp.MustCompile(`github\.com/terraform-linters/tflint-ruleset-terraform v(.+)`)
 
 func main() {
 	currentVersion := getCurrentVersion()


### PR DESCRIPTION
Potential fix for [https://github.com/terraform-linters/tflint/security/code-scanning/12](https://github.com/terraform-linters/tflint/security/code-scanning/12)

To fix the issue, the dot (`.`) in the regular expression should be escaped to ensure it matches a literal dot rather than any character. This can be done by replacing `.` with `\.`. Additionally, using a raw string literal (enclosed in backticks) for the regular expression is recommended to avoid the need for double escaping backslashes.

Specifically, the regular expression on line 23 should be updated from:
```go
`github.com/terraform-linters/tflint-ruleset-terraform v(.+)`
```
to:
```go
`github\.com/terraform-linters/tflint-ruleset-terraform v(.+)`
```

This ensures that the pattern matches only the intended domain `github.com` and not any other unintended strings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
