### PR TITLE
plugin: Skip keyless verification for private third-party plugins

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -54,6 +54,7 @@ func (cli *CLI) init(opts Options) int {
 					if err != nil {
 						if errors.Is(err, plugin.ErrPluginNotVerified) {
 							_, _ = color.New(color.FgYellow).Fprintln(cli.outStream, `No signing key configured. Set "signing_key" to verify that the release is signed by the plugin developer`)
+							err = nil
 						} else {
 							return fmt.Errorf("Failed to install a plugin; %w", err)
 						}

--- a/plugin/install.go
+++ b/plugin/install.go
@@ -206,8 +206,7 @@ func (c *InstallConfig) tryKeylessVerifyChecksumsSignature(sigchecker *Signature
 	// If the repository is private, artifact attestations is not always available
 	// because it requires GitHub Enterprise Cloud plan, so we skip verification here.
 	if repo.Private != nil && *repo.Private {
-		log.Printf("[DEBUG] Bypassing verification of artifact attestations for private repository")
-		return true, nil
+		return false, nil
 	}
 
 	log.Printf("[DEBUG] Download artifact attestations")

--- a/plugin/install.go
+++ b/plugin/install.go
@@ -206,7 +206,8 @@ func (c *InstallConfig) tryKeylessVerifyChecksumsSignature(sigchecker *Signature
 	// If the repository is private, artifact attestations is not always available
 	// because it requires GitHub Enterprise Cloud plan, so we skip verification here.
 	if repo.Private != nil && *repo.Private {
-		return false, nil
+		log.Printf("[DEBUG] Bypassing verification of artifact attestations for private repository")
+		return true, nil
 	}
 
 	log.Printf("[DEBUG] Download artifact attestations")


### PR DESCRIPTION
Comparable to #2223, which became ineffective in #2224. 

https://github.com/terraform-linters/tflint/issues/2209#issuecomment-2835204766