### PR TITLE
terraform: Cache resolved local values

### DIFF
--- a/terraform/evaluator_test.go
+++ b/terraform/evaluator_test.go
@@ -704,6 +704,18 @@ locals {
 			errCheck: neverHappend,
 		},
 		{
+			name: "local value with impure function calls",
+			config: `
+locals {
+  foo = uuid()
+  bar = local.foo
+}`,
+			expr:     expr(`local.foo == local.bar`),
+			ty:       cty.Bool,
+			want:     `cty.True`,
+			errCheck: neverHappend,
+		},
+		{
 			name:   "self-referencing local value",
 			config: `locals { foo = local.foo }`,
 			expr:   expr(`local.foo`),

--- a/terraform/lang/scope.go
+++ b/terraform/lang/scope.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 
 	"github.com/terraform-linters/tflint/terraform/addrs"
@@ -34,6 +35,11 @@ type Scope struct {
 	// CallStack is a stack for recording local value references to detect
 	// circular references.
 	CallStack *CallStack
+
+	// ResolvedLocalValues ​​is a cache of evaluated local values.
+	// This prevents the slowdown caused by evaluating the same local value
+	// multiple times in the same scope.
+	ResolvedLocalValues map[string]cty.Value
 
 	funcs     map[string]function.Function
 	funcsLock sync.Mutex


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/2287

In cases such as `Invicton-Labs/deepmerge`, where a chain of local values is evaluated nearly 100 times, there is an issue with TFLint's evaluation strategy of evaluating local values each time, which makes it very slow.

To prevent this, we add a cache of evaluated local values to `lang.Scope` as `ResolvedLocalValues` and have `GetLocalValue` return the cache instead of re-evaluating the expression.

As a side effect, impure function calls like `uuid()` will be cached to the first evaluation result instead of being called every time:

```hcl
locals {
  foo = uuid()
  bar = local.foo
}

# Before
local.foo # => 550e8400-e29b-41d4-a716-446655440000
local.bar # => 89e2e3fd-32a3-1412-085a-8b7c78353750

# After
local.foo # => 550e8400-e29b-41d4-a716-446655440000
local.bar # => 550e8400-e29b-41d4-a716-446655440000
```

This is the same behavior as Terraform, and this change more closely follows the original semantics.