### PR TITLE
fix: load `format` from config file

### DIFF
--- a/integrationtest/cli/cli_test.go
+++ b/integrationtest/cli/cli_test.go
@@ -50,11 +50,25 @@ func TestIntegration(t *testing.T) {
 			stdout:  "",
 		},
 		{
-			name:    "specify format",
+			name:    "format flag",
 			command: "./tflint --format json",
 			dir:     "no_issues",
 			status:  cmd.ExitCodeOK,
-			stdout:  "[]",
+			stdout:  `{"issues":[],"errors":[]}`,
+		},
+		{
+			name:    "format config",
+			command: "./tflint",
+			dir:     "format_config",
+			status:  cmd.ExitCodeIssuesFound,
+			stdout:  `main.tf:2:19: Error - instance type is t2.micro (aws_instance_example_type)`,
+		},
+		{
+			name:    "format flag overrides config",
+			command: "./tflint --format json",
+			dir:     "format_config",
+			status:  cmd.ExitCodeIssuesFound,
+			stdout:  `{"issues":[{"rule":{"name":"aws_instance_example_type","severity":"error","link":""},"message":"instance type is t2.micro","range":{"filename":"main.tf","start":{"line":2,"column":19},"end":{"line":2,"column":29}},"callers":[]}],"errors":[]}`,
 		},
 		{
 			name:    "`--force` option with no issues",

--- a/integrationtest/cli/format_config/.tflint.hcl
+++ b/integrationtest/cli/format_config/.tflint.hcl
@@ -1,0 +1,7 @@
+config {
+  format = "compact"
+}
+
+plugin "testing" {
+  enabled = true
+}

--- a/integrationtest/cli/format_config/main.tf
+++ b/integrationtest/cli/format_config/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "main" {
+  instance_type = "t2.micro"
+}

--- a/integrationtest/recursive/recursive_test.go
+++ b/integrationtest/recursive/recursive_test.go
@@ -92,6 +92,14 @@ func TestIntegration(t *testing.T) {
 
 			opts := []cmp.Option{
 				cmpopts.IgnoreFields(formatter.JSONRule{}, "Link"),
+				// Only compare error messages up to the double new line.
+				// After this, stderr will be printed which is verbose.
+				cmp.Transformer("TruncateMessage", func(e formatter.JSONError) formatter.JSONError {
+					if parts := strings.Split(e.Message, "\n\n"); len(parts) > 1 {
+						e.Message = parts[0]
+					}
+					return e
+				}),
 			}
 			if test.ignoreOrder {
 				opts = append(opts, cmpopts.SortSlices(func(a, b formatter.JSONError) bool {


### PR DESCRIPTION
Fixes handling of `format` inside a `config {}` block in a TFLint configuration file. Previously, `cli.formatter.Format` was set to `options.Format` and never considered the configuration file.

Now, `NewCLI` parses the config too and uses the merged config and options to set the format. The implementation is a bit hacky because a formatter needs to be constructed early to print errors.

Closes #2305