### PR TITLE
go: modernize

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-linters/tflint/tflint"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"maps"
 )
 
 func (cli *CLI) inspect(opts Options) int {
@@ -171,7 +172,7 @@ By setting TFLINT_LOG=trace, you can confirm the changes made by the autofix and
 					}(runner)
 				}
 			}
-			for i := 0; i < len(moduleRunners); i++ {
+			for range moduleRunners {
 				err = <-ch
 				if err != nil {
 					return issues, changes, fmt.Errorf("Failed to check ruleset; %w", err)
@@ -203,9 +204,7 @@ By setting TFLINT_LOG=trace, you can confirm the changes made by the autofix and
 	}
 
 	// Set module sources to CLI
-	for path, source := range cli.loader.Sources() {
-		cli.sources[path] = source
-	}
+	maps.Copy(cli.sources, cli.loader.Sources())
 
 	return issues, changes, nil
 }

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -42,7 +42,7 @@ func (opts *Options) toConfig() *tflint.Config {
 	ignoreModules := map[string]bool{}
 	for _, module := range opts.IgnoreModules {
 		// For the backward compatibility, allow specifying like "source1,source2" style
-		for _, m := range strings.Split(module, ",") {
+		for m := range strings.SplitSeq(module, ",") {
 			ignoreModules[m] = true
 		}
 	}

--- a/integrationtest/langserver/langserver_test.go
+++ b/integrationtest/langserver/langserver_test.go
@@ -19,10 +19,10 @@ import (
 )
 
 type jsonrpcMessage struct {
-	JSONRPC string      `json:"jsonrpc"`
-	ID      int         `json:"id,omitempty"`
-	Method  string      `json:"method"`
-	Params  interface{} `json:"params"`
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id,omitempty"`
+	Method  string `json:"method"`
+	Params  any    `json:"params"`
 }
 
 func TestMain(m *testing.M) {

--- a/langserver/handler.go
+++ b/langserver/handler.go
@@ -101,7 +101,7 @@ type handler struct {
 	diagsPaths        []string
 }
 
-func (h *handler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *handler) handle(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
 	if req.Params != nil {
 		params, err := json.Marshal(&req.Params)
 		if err != nil {

--- a/langserver/initialize.go
+++ b/langserver/initialize.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/jsonrpc2"
 )
 
-func initialize(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func initialize(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
 	return lsp.InitializeResult{
 		Capabilities: lsp.ServerCapabilities{
 			TextDocumentSync: &lsp.TextDocumentSyncOptionsOrKind{

--- a/langserver/text_document_did_change.go
+++ b/langserver/text_document_did_change.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (h *handler) textDocumentDidChange(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *handler) textDocumentDidChange(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{
 			Code:    jsonrpc2.CodeInvalidRequest,

--- a/langserver/text_document_did_open.go
+++ b/langserver/text_document_did_open.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (h *handler) textDocumentDidOpen(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *handler) textDocumentDidOpen(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
 	if req.Params == nil {
 		return nil, &jsonrpc2.Error{
 			Code:    jsonrpc2.CodeInvalidRequest,

--- a/langserver/workspace_did_change_watched_files.go
+++ b/langserver/workspace_did_change_watched_files.go
@@ -11,7 +11,7 @@ import (
 	"github.com/terraform-linters/tflint/tflint"
 )
 
-func (h *handler) workspaceDidChangeWatchedFiles(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result interface{}, err error) {
+func (h *handler) workspaceDidChangeWatchedFiles(ctx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
 	if h.rootDir == "" {
 		return nil, fmt.Errorf("root directory is undefined")
 	}

--- a/plugin/server_test.go
+++ b/plugin/server_test.go
@@ -18,6 +18,7 @@ import (
 	sdk "github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/terraform-linters/tflint/tflint"
 	"github.com/zclconf/go-cty/cty"
+	"maps"
 )
 
 var SDKVersion = version.Must(version.NewVersion(plugin.SDKVersion))
@@ -264,9 +265,7 @@ resource "aws_instance" "foo" {
 }`,
 			})
 			files := runner.Files()
-			for name, file := range rootRunner.Files() {
-				files[name] = file
-			}
+			maps.Copy(files, rootRunner.Files())
 
 			server := NewGRPCServer(runner, rootRunner, files, SDKVersion)
 
@@ -480,7 +479,7 @@ variable "foo" {
 
 	// test util functions
 	hclExpr := func(expr string) hcl.Expression {
-		file, diags := hclsyntax.ParseConfig([]byte(fmt.Sprintf(`expr = %s`, expr)), "test.tf", hcl.InitialPos)
+		file, diags := hclsyntax.ParseConfig(fmt.Appendf(nil, `expr = %s`, expr), "test.tf", hcl.InitialPos)
 		if diags.HasErrors() {
 			panic(diags)
 		}

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
 	sdk "github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/terraform-linters/tflint/terraform"
+	"maps"
 )
 
 var defaultConfigFile = ".tflint.hcl"
@@ -484,9 +485,7 @@ func (c *Config) Sources() map[string][]byte {
 		bundledPluginConfigFilename: []byte(bundledPluginConfigContent),
 	}
 
-	for name, content := range c.sources {
-		ret[name] = content
-	}
+	maps.Copy(ret, c.sources)
 	return ret
 }
 
@@ -518,9 +517,7 @@ func (c *Config) Merge(other *Config) {
 	c.Variables = append(c.Variables, other.Variables...)
 	c.Only = append(c.Only, other.Only...)
 
-	for name, ignore := range other.IgnoreModules {
-		c.IgnoreModules[name] = ignore
-	}
+	maps.Copy(c.IgnoreModules, other.IgnoreModules)
 
 	for name, rule := range other.Rules {
 		// HACK: If you enable the rule through the CLI instead of the file, its hcl.Body will be nil.

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/terraform-linters/tflint/terraform/addrs"
 	"github.com/terraform-linters/tflint/terraform/lang"
 	"github.com/zclconf/go-cty/cty"
+	"maps"
 )
 
 // Runner checks templates according rules.
@@ -213,9 +214,7 @@ func (r *Runner) File(path string) *hcl.File {
 // Files returns the raw *hcl.File representation of all Terraform configuration in the module directory.
 func (r *Runner) Files() map[string]*hcl.File {
 	result := make(map[string]*hcl.File)
-	for name, file := range r.TFConfig.Module.Files {
-		result[name] = file
-	}
+	maps.Copy(result, r.TFConfig.Module.Files)
 	return result
 }
 
@@ -284,9 +283,7 @@ func (r *Runner) ApplyChanges(changes map[string][]byte) hcl.Diagnostics {
 	if diags.HasErrors() {
 		return diags
 	}
-	for path, source := range changes {
-		r.changes[path] = source
-	}
+	maps.Copy(r.changes, changes)
 	return nil
 }
 


### PR DESCRIPTION
Uses modern Go features where possible to improve performance and readability, primarily:

* `maps.Copy`
* `range` over integer
* `interface{}` to `any`
* 

```sh
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix ./...
```