### PR TITLE
docs: annotations cannot ignore errors

### DIFF
--- a/docs/user-guide/annotations.md
+++ b/docs/user-guide/annotations.md
@@ -1,5 +1,7 @@
 # Annotations
 
+TFLint supports several comment annotations for suppressing issues for specific lines or files. Annotations can only suppress _issues_ emitted from fully valid, parseable Terraform modules. _Errors_ cannot be ignored.
+
 Annotation comments can disable rules on specific lines:
 
 ```hcl


### PR DESCRIPTION
Clarifies that annotations are for ignoring issues from rules, not errors parsing HCL documents or evaluating their expressions. A search for `tflint-ignore error` turns up plenty of existing issues, among them:

https://github.com/terraform-linters/tflint/discussions/2310
https://github.com/terraform-linters/tflint/issues/1688
https://github.com/terraform-linters/tflint/issues/1353
