### PR TITLE
cmd: Apply `format` set in config file

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -64,6 +64,7 @@ func (cli *CLI) Run(args []string) int {
 	cli.formatter = &formatter.Formatter{
 		Stdout: cli.outStream,
 		Stderr: cli.errStream,
+		// NOTE: The format may be set in config file, but the flag will take precedence until it is loaded.
 		Format: opts.Format,
 		Fix:    opts.Fix,
 	}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -93,6 +93,8 @@ func (cli *CLI) inspectModule(opts Options, dir string, filterFiles []string) (t
 		return issues, changes, fmt.Errorf("Failed to load TFLint config; %w", err)
 	}
 	cli.config.Merge(opts.toConfig())
+	// Apply format set in config file
+	cli.formatter.Format = cli.config.Format
 
 	// Setup loader
 	cli.loader, err = terraform.NewLoader(afero.Afero{Fs: afero.NewOsFs()}, cli.originalWorkingDir)

--- a/cmd/inspect_parallel.go
+++ b/cmd/inspect_parallel.go
@@ -90,6 +90,8 @@ func (cli *CLI) inspectParallel(opts Options) int {
 		force = *opts.Force
 	}
 
+	// Parallel inspection ignores the format set in the config file
+	// and the --format CLI flag always takes precedence.
 	if err := cli.formatter.PrintParallel(issues, cli.sources); err != nil {
 		return ExitCodeError
 	}

--- a/integrationtest/cli/chdir_format/subdir/.tflint.hcl
+++ b/integrationtest/cli/chdir_format/subdir/.tflint.hcl
@@ -1,0 +1,3 @@
+config {
+  format = "json"
+}

--- a/integrationtest/cli/cli_test.go
+++ b/integrationtest/cli/cli_test.go
@@ -50,9 +50,24 @@ func TestIntegration(t *testing.T) {
 			stdout:  "",
 		},
 		{
-			name:    "specify format",
+			name:    "--format option",
 			command: "./tflint --format json",
 			dir:     "no_issues",
+			status:  cmd.ExitCodeOK,
+			stdout:  "[]",
+		},
+		{
+			name:    "format config",
+			command: "./tflint",
+			dir:     "format_config",
+			status:  cmd.ExitCodeOK,
+			stdout: `<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle></checkstyle>`,
+		},
+		{
+			name:    "--format + config",
+			command: "./tflint --format json",
+			dir:     "format_config",
 			status:  cmd.ExitCodeOK,
 			stdout:  "[]",
 		},
@@ -378,6 +393,13 @@ func TestIntegration(t *testing.T) {
 			dir:     "chdir",
 			status:  cmd.ExitCodeIssuesFound,
 			stdout:  fmt.Sprintf("%s (aws_instance_example_type)", color.New(color.Bold).Sprint("instance type is m5.2xlarge")),
+		},
+		{
+			name:    "--chdir and format config",
+			command: "./tflint --chdir=subdir", // Apply config in subdir
+			dir:     "chdir_format",
+			status:  cmd.ExitCodeOK,
+			stdout:  "[]",
 		},
 		{
 			name:    "invalid max workers",

--- a/integrationtest/cli/format_config/.tflint.hcl
+++ b/integrationtest/cli/format_config/.tflint.hcl
@@ -1,0 +1,3 @@
+config {
+  format = "checkstyle"
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/2305

Due to a regression introduced by the [parallel inspection added in v0.51](https://github.com/terraform-linters/tflint/pull/2021), the `format` that can be set in the config file was always ignored.

This PR changes the `inspectModule` so that the `format` setting is set to the `cli.formatter.Format` after loading the config file. Note that this is intentionally not set with `--recursive`, as mentioned in the documentation.