### PR TITLE
docs: windows plugin development

### DIFF
--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -108,8 +108,6 @@ When enabled, TFLint looks for the plugin binary following the pattern tflint-ru
 
 Thus, with the configuration above where the plugin name is "foo", the executable must be named tflint-ruleset-foo (or tflint-ruleset-foo.exe on Windows). So you should move the binary into the plugin directory in advance.
 
-**Important for Windows Users:** On Windows, make sure to place the executable directly into the plugins folder (e.g. C:\Users\\[username]\\.tflint.d\plugins\) without using any subfolders. This direct placement is required for TFLint to detect and load the plugin correctly.
-
 ## Bundled plugin
 
 [TFLint Ruleset for Terraform Language](https://github.com/terraform-linters/tflint-ruleset-terraform) is built directly into TFLint binary. This is called a bundled plugin. Unlike other plugins, bundled plugins can be used without installation.


### PR DESCRIPTION
Updating docs for plugin development. Docs seem to be wrong for windows systems.

.tflint.hcl
```
plugin "azurerm" {
    enabled = true
    version = "0.28.0"
    source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
}

plugin "terraform" {
    enabled = true
    version = "0.12.0"
    source  = "github.com/terraform-linters/tflint-ruleset-terraform"
}

plugin "postch" {
  enabled = true
}
```


Placing local plugin into directory defined in docs
![image](https://github.com/user-attachments/assets/cd2390e7-30c8-49c9-b5f7-784c6c7ba77e)

tflint debug
```
12:06:40 runner.go:47: [INFO] Initialize new runner for root
12:06:40 discovery.go:90: [DEBUG] Find plugin path: C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-azurerm\0.28.0\tflint-ruleset-azurerm.exe
12:06:40 discovery.go:54: [INFO] Plugin "azurerm" found
12:06:40 [DEBUG] cmdrunner/cmd_runner.go:73: starting plugin: path=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-azurerm\0.28.0\tflint-ruleset-azurerm.exe args=["C:\\Users\\SamAccountName\\.tflint.d\\plugins\\github.com\\terraform-linters\\tflint-ruleset-azurerm\\0.28.0\\tflint-ruleset-azurerm.exe"]
12:06:40 [DEBUG] cmdrunner/cmd_runner.go:80: plugin started: path=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-azurerm\0.28.0\tflint-ruleset-azurerm.exe pid=22628
12:06:40 [DEBUG] go-plugin@v1.6.3/client.go:827: waiting for RPC address: plugin=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-azurerm\0.28.0\tflint-ruleset-azurerm.exe  
12:06:40 [DEBUG] go-plugin@v1.6.3/client.go:1216: tflint-ruleset-azurerm.exe: 12:06:40 [DEBUG] go-plugin@v1.6.2/server.go:419: plugin address: network=tcp address=127.0.0.1:10000
12:06:40 [DEBUG] go-plugin@v1.6.3/client.go:880: using plugin: version=11
12:06:40 discovery.go:90: [DEBUG] Find plugin path: C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-terraform\0.12.0\tflint-ruleset-terraform.exe
12:06:40 discovery.go:54: [INFO] Plugin "terraform" found
12:06:40 [DEBUG] cmdrunner/cmd_runner.go:73: starting plugin: path=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-terraform\0.12.0\tflint-ruleset-terraform.exe args=["C:\\Users\\SamAccountName\\.tflint.d\\plugins\\github.com\\terraform-linters\\tflint-ruleset-terraform\\0.12.0\\tflint-ruleset-terraform.exe"]
12:06:40 [DEBUG] cmdrunner/cmd_runner.go:80: plugin started: path=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-terraform\0.12.0\tflint-ruleset-terraform.exe pid=23204
12:06:40 [DEBUG] go-plugin@v1.6.3/client.go:827: waiting for RPC address: plugin=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-terraform\0.12.0\tflint-ruleset-terraform.exe
12:06:40 [DEBUG] go-plugin@v1.6.3/client.go:1216: tflint-ruleset-terraform.exe: 12:06:40 [DEBUG] go-plugin@v1.6.2/server.go:419: plugin address: network=tcp address=127.0.0.1:10001
12:06:40 [DEBUG] go-plugin@v1.6.3/client.go:880: using plugin: version=11
Failed to initialize plugins; Plugin "postch" not found in C:\Users\SamAccountName\.tflint.d\plugins
```

Placing local plugin directly into to the plugin folder without further subfolders
![image](https://github.com/user-attachments/assets/81bb02a7-f6a2-4684-afbb-feb4be98e79d)
tflint debug
```
12:16:34 runner.go:47: [INFO] Initialize new runner for root
12:16:34 discovery.go:90: [DEBUG] Find plugin path: C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-azurerm\0.28.0\tflint-ruleset-azurerm.exe
12:16:34 discovery.go:54: [INFO] Plugin "azurerm" found
12:16:34 [DEBUG] cmdrunner/cmd_runner.go:73: starting plugin: path=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-azurerm\0.28.0\tflint-ruleset-azurerm.exe args=["C:\\Users\\SamAccountName\\.tflint.d\\plugins\\github.com\\terraform-linters\\tflint-ruleset-azurerm\\0.28.0\\tflint-ruleset-azurerm.exe"]
12:16:34 [DEBUG] cmdrunner/cmd_runner.go:80: plugin started: path=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-azurerm\0.28.0\tflint-ruleset-azurerm.exe pid=13636       
12:16:34 [DEBUG] go-plugin@v1.6.3/client.go:827: waiting for RPC address: plugin=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-azurerm\0.28.0\tflint-ruleset-azurerm.exe  
12:16:34 [DEBUG] go-plugin@v1.6.3/client.go:1216: tflint-ruleset-azurerm.exe: 12:16:34 [DEBUG] go-plugin@v1.6.2/server.go:419: plugin address: network=tcp address=127.0.0.1:10002
12:16:34 [DEBUG] go-plugin@v1.6.3/client.go:880: using plugin: version=11
12:16:34 discovery.go:90: [DEBUG] Find plugin path: C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-terraform\0.12.0\tflint-ruleset-terraform.exe
12:16:34 discovery.go:54: [INFO] Plugin "terraform" found
12:16:34 [DEBUG] cmdrunner/cmd_runner.go:73: starting plugin: path=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-terraform\0.12.0\tflint-ruleset-terraform.exe args=["C:\\Users\\SamAccountName\\.tflint.d\\plugins\\github.com\\terraform-linters\\tflint-ruleset-terraform\\0.12.0\\tflint-ruleset-terraform.exe"]
12:16:34 [DEBUG] cmdrunner/cmd_runner.go:80: plugin started: path=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-terraform\0.12.0\tflint-ruleset-terraform.exe pid=21220   
12:16:34 [DEBUG] go-plugin@v1.6.3/client.go:827: waiting for RPC address: plugin=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-terraform\0.12.0\tflint-ruleset-terraform.exe
12:16:34 [DEBUG] go-plugin@v1.6.3/client.go:880: using plugin: version=11
12:16:34 [DEBUG] go-plugin@v1.6.3/client.go:1216: tflint-ruleset-terraform.exe: 12:16:34 [DEBUG] go-plugin@v1.6.2/server.go:419: plugin address: network=tcp address=127.0.0.1:10003
12:16:34 discovery.go:90: [DEBUG] Find plugin path: C:\Users\SamAccountName\.tflint.d\plugins\tflint-ruleset-postch.exe
12:16:34 discovery.go:54: [INFO] Plugin "postch" found
12:16:34 [DEBUG] cmdrunner/cmd_runner.go:73: starting plugin: path=C:\Users\SamAccountName\.tflint.d\plugins\tflint-ruleset-postch.exe args=["C:\\Users\\SamAccountName\\.tflint.d\\plugins\\tflint-ruleset-postch.exe"] 
12:16:35 [DEBUG] cmdrunner/cmd_runner.go:80: plugin started: path=C:\Users\SamAccountName\.tflint.d\plugins\tflint-ruleset-postch.exe pid=17556
12:16:35 [DEBUG] go-plugin@v1.6.3/client.go:827: waiting for RPC address: plugin=C:\Users\SamAccountName\.tflint.d\plugins\tflint-ruleset-postch.exe
12:16:35 [DEBUG] go-plugin@v1.6.3/client.go:1216: tflint-ruleset-postch.exe: 12:16:35 [DEBUG] go-plugin@v1.6.2/server.go:419: plugin address: network=tcp address=127.0.0.1:10004
12:16:35 [DEBUG] go-plugin@v1.6.3/client.go:880: using plugin: version=11
12:16:35 [DEBUG] host2plugin/client.go:124: starting host-side gRPC server
12:16:35 [DEBUG] host2plugin/client.go:124: starting host-side gRPC server
12:16:35 [DEBUG] host2plugin/client.go:124: starting host-side gRPC server
12:16:35 [DEBUG] go-plugin@v1.6.3/grpc_stdio.go:142: stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
12:16:35 [INFO]  go-plugin@v1.6.3/client.go:780: plugin process exited: plugin=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-azurerm\0.28.0\tflint-ruleset-azurerm.exe id=13636
12:16:35 [DEBUG] go-plugin@v1.6.3/client.go:558: plugin exited
12:16:35 [DEBUG] go-plugin@v1.6.3/grpc_stdio.go:142: stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
12:16:35 [INFO]  go-plugin@v1.6.3/client.go:780: plugin process exited: plugin=C:\Users\SamAccountName\.tflint.d\plugins\github.com\terraform-linters\tflint-ruleset-terraform\0.12.0\tflint-ruleset-terraform.exe id=21220
12:16:35 [DEBUG] go-plugin@v1.6.3/client.go:558: plugin exited
12:16:35 [DEBUG] go-plugin@v1.6.3/grpc_stdio.go:142: stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
12:16:35 [INFO]  go-plugin@v1.6.3/client.go:780: plugin process exited: plugin=C:\Users\SamAccountName\.tflint.d\plugins\tflint-ruleset-postch.exe id=17556
12:16:35 [DEBUG] go-plugin@v1.6.3/client.go:558: plugin exited
3 issue(s) found:
```

using tflint 0.58.0
![image](https://github.com/user-attachments/assets/d833f915-e9ad-4513-aca2-e172b2ad364e)

