### PR TITLE
Allow calling provider-defined functions with variadic arguments

### DIFF
--- a/terraform/evaluator_test.go
+++ b/terraform/evaluator_test.go
@@ -157,6 +157,13 @@ variable "string_var" {
 			errCheck: neverHappend,
 		},
 		{
+			name:     "provider-defined functions without arguments",
+			expr:     expr(`provider::tflint::rand()`),
+			ty:       cty.String,
+			want:     `cty.UnknownVal(cty.String)`,
+			errCheck: neverHappend,
+		},
+		{
 			name:     "built-in provider-defined functions",
 			expr:     expr(`provider::terraform::decode_tfvars("a = 1")`),
 			ty:       cty.Object(map[string]cty.Type{"a": cty.Number}),

--- a/terraform/lang/function_calls.go
+++ b/terraform/lang/function_calls.go
@@ -13,8 +13,7 @@ import (
 // The difference with hclsyntax.FunctionCallExpr is that
 // function calls are also available in JSON syntax.
 type FunctionCall struct {
-	Name      string
-	ArgsCount int
+	Name string
 }
 
 // FunctionCallsInExpr finds all of the function calls in the given expression.
@@ -33,8 +32,7 @@ func FunctionCallsInExpr(expr hcl.Expression) ([]*FunctionCall, hcl.Diagnostics)
 		visitDiags := hclsyntax.VisitAll(node, func(n hclsyntax.Node) hcl.Diagnostics {
 			if funcCallExpr, ok := n.(*hclsyntax.FunctionCallExpr); ok {
 				ret = append(ret, &FunctionCall{
-					Name:      funcCallExpr.Name,
-					ArgsCount: len(funcCallExpr.Args),
+					Name: funcCallExpr.Name,
 				})
 			}
 			return nil

--- a/terraform/lang/function_calls_test.go
+++ b/terraform/lang/function_calls_test.go
@@ -66,44 +66,44 @@ func TestFunctionCallsInExpr(t *testing.T) {
 			name: "single function call",
 			expr: parse(`md5("hello")`),
 			want: []*FunctionCall{
-				{Name: "md5", ArgsCount: 1},
+				{Name: "md5"},
 			},
 		},
 		{
 			name: "single function call (JSON)",
 			expr: parseJSON(`"${md5(\"hello\")}"`),
 			want: []*FunctionCall{
-				{Name: "md5", ArgsCount: 1},
+				{Name: "md5"},
 			},
 		},
 		{
 			name: "multiple function calls",
 			expr: parse(`[md5("hello"), "world", provider::tflint::world()]`),
 			want: []*FunctionCall{
-				{Name: "md5", ArgsCount: 1},
-				{Name: "provider::tflint::world", ArgsCount: 0},
+				{Name: "md5"},
+				{Name: "provider::tflint::world"},
 			},
 		},
 		{
 			name: "multiple function calls (JSON)",
 			expr: parseJSON(`["${md5(\"hello\")}", "world", "${provider::tflint::world()}"]`),
 			want: []*FunctionCall{
-				{Name: "md5", ArgsCount: 1},
-				{Name: "provider::tflint::world", ArgsCount: 0},
+				{Name: "md5"},
+				{Name: "provider::tflint::world"},
 			},
 		},
 		{
 			name: "bound expr with native syntax",
 			expr: hclext.BindValue(cty.StringVal("foo-Hello, John and Mike"), parse(`"foo-${hello("John", "Mike")}"`)),
 			want: []*FunctionCall{
-				{Name: "hello", ArgsCount: 2},
+				{Name: "hello"},
 			},
 		},
 		{
 			name: "bound expr with JSON syntax",
 			expr: hclext.BindValue(cty.StringVal("foo-Hello, John and Mike"), parseJSON(`"foo-${hello(\"John\", \"Mike\")}"`)),
 			want: []*FunctionCall{
-				{Name: "hello", ArgsCount: 2},
+				{Name: "hello"},
 			},
 		},
 	}

--- a/terraform/lang/functions.go
+++ b/terraform/lang/functions.go
@@ -228,20 +228,15 @@ func (s *Scope) Functions() map[string]function.Function {
 // NewMockFunction creates a mock function that returns a dynamic value.
 // This is primarily used to replace provider-defined functions.
 func NewMockFunction(call *FunctionCall) function.Function {
-	params := make([]function.Parameter, call.ArgsCount)
-	for idx := 0; idx < call.ArgsCount; idx++ {
-		params[idx] = function.Parameter{
+	return function.New(&function.Spec{
+		VarParam: &function.Parameter{
 			Type:             cty.DynamicPseudoType,
 			AllowNull:        true,
 			AllowUnknown:     true,
 			AllowDynamicType: true,
 			AllowMarked:      true,
-		}
-	}
-
-	return function.New(&function.Spec{
-		Params: params,
-		Type:   function.StaticReturnType(cty.DynamicPseudoType),
+		},
+		Type: function.StaticReturnType(cty.DynamicPseudoType),
 		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
 			return cty.DynamicVal, nil
 		},

--- a/terraform/lang/functions_test.go
+++ b/terraform/lang/functions_test.go
@@ -1278,56 +1278,49 @@ func TestNewMockFunction(t *testing.T) {
 		{
 			name: "no args",
 			call: &FunctionCall{
-				Name:      "foo",
-				ArgsCount: 0,
+				Name: "foo",
 			},
 			args: []cty.Value{},
 		},
 		{
 			name: "single arg",
 			call: &FunctionCall{
-				Name:      "bar",
-				ArgsCount: 1,
+				Name: "bar",
 			},
 			args: []cty.Value{cty.StringVal("hello")},
 		},
 		{
 			name: "multiple args",
 			call: &FunctionCall{
-				Name:      "baz",
-				ArgsCount: 2,
+				Name: "baz",
 			},
 			args: []cty.Value{cty.BoolVal(false), cty.NumberIntVal(1)},
 		},
 		{
 			name: "null arg",
 			call: &FunctionCall{
-				Name:      "null",
-				ArgsCount: 1,
+				Name: "null",
 			},
 			args: []cty.Value{cty.NullVal(cty.String)},
 		},
 		{
 			name: "unknown arg",
 			call: &FunctionCall{
-				Name:      "unknown",
-				ArgsCount: 1,
+				Name: "unknown",
 			},
 			args: []cty.Value{cty.UnknownVal(cty.Number)},
 		},
 		{
 			name: "dynamic value arg",
 			call: &FunctionCall{
-				Name:      "dynamic",
-				ArgsCount: 1,
+				Name: "dynamic",
 			},
 			args: []cty.Value{cty.DynamicVal},
 		},
 		{
 			name: "marked value arg",
 			call: &FunctionCall{
-				Name:      "marked",
-				ArgsCount: 1,
+				Name: "marked",
 			},
 			args: []cty.Value{cty.StringVal("marked").Mark(marks.Sensitive)},
 		},


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/2339
Follow up of https://github.com/terraform-linters/tflint/pull/2030

Because TFLint cannot statically infer the behavior of provider-defined functions, we took the approach of inferring the function interface from function calls when parsing the HCL and generating mock functions.

As part of this, mocks were generated as fixed-length functions based on the number of arguments, which caused errors when calling provider-defined functions that accepted variadic argument, such as `provider::deepmerge::merge`, with a different number of arguments from the second time onwards.

This change fixes this issue by generating mock functions as always accepting variadic arguments.