### PR TITLE
workflow: validate issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report an bug/issue in TFLint's CLI
-labels: 
+labels:
   - bug
 body:
   - type: markdown
@@ -9,7 +9,7 @@ body:
         Thanks for reporting a bug in TFLint. Please be sure to complete the fields below as we can only investigate reproducible issues.
         You **must** include an isolated reproduction with all issues. We will not accept reports that reference private modules or otherwise cannot be run.
         If you need additional room/files to demonstrate your issue, create a public repository and upload your modules there.
-        If you're having an issue with a specific rule/ruleset, report that in the relevant [ruleset repository](https://github.com/terraform-linters?q=topic%3Atflint-ruleset&type=source&language=&sort=). 
+        If you're having an issue with a specific rule/ruleset, report that in the relevant [ruleset repository](https://github.com/terraform-linters?q=topic%3Atflint-ruleset&type=source&language=&sort=).
   - type: textarea
     attributes:
       label: Summary
@@ -29,6 +29,8 @@ body:
       description: >
         The Terraform configuration (typically HCL) that reproduces the bug.
         You may need to reduce your project to an isolated configuration.
+        This will automatically be validated by GitHub Actions on submission.
+        We will not investigate issues submitted with incomplete reproductions.
       render: terraform
     validations:
       required: true

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,11 @@
+name: issues
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  terraform:
+    uses: terraform-linters/actions-workflows/.github/workflows/validate-terraform-issues.yml@main
+    permissions:
+      issues: write


### PR DESCRIPTION
Call out to https://github.com/terraform-linters/actions-workflows/blob/main/.github/workflows/validate-terraform-issues.yml to validate any submitted issue with a triple backtick `terraform` code block. If `terraform init && terraform validate` don't pass, warn the user that they must fix their config.

Goal: discourage users from frequent submissions of broken configuration with elided sections, references to other files, etc. Emphasize that they are expected to provide something we can copy and paste. Avoid time-waster issues caused by users running outdated Terraform versions.