### PR TITLE
json: add fixed, fixable

### DIFF
--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -117,14 +117,14 @@ Reference: https://github.com
 				f.PrintErrorParallel(errors.New("an error occurred"), map[string][]byte{})
 				f.PrintErrorParallel(errors.New("failed"), map[string][]byte{})
 			},
-			stdout: `{"issues":[{"rule":{"name":"test_rule","severity":"error","link":"https://github.com"},"message":"test","range":{"filename":"test.tf","start":{"line":1,"column":1},"end":{"line":1,"column":4}},"callers":[]}],"errors":[{"message":"an error occurred","severity":"error"},{"message":"failed","severity":"error"}]}`,
+			stdout: `{"issues":[{"rule":{"name":"test_rule","severity":"error","link":"https://github.com"},"message":"test","range":{"filename":"test.tf","start":{"line":1,"column":1},"end":{"line":1,"column":4}},"callers":[],"fixable":false,"fixed":false}],"errors":[{"message":"an error occurred","severity":"error"},{"message":"failed","severity":"error"}]}`,
 			error:  true,
 		},
 		{
 			name:   "JSON without errors",
 			format: "json",
 			before: func(f *Formatter) {},
-			stdout: `{"issues":[{"rule":{"name":"test_rule","severity":"error","link":"https://github.com"},"message":"test","range":{"filename":"test.tf","start":{"line":1,"column":1},"end":{"line":1,"column":4}},"callers":[]}],"errors":[]}`,
+			stdout: `{"issues":[{"rule":{"name":"test_rule","severity":"error","link":"https://github.com"},"message":"test","range":{"filename":"test.tf","start":{"line":1,"column":1},"end":{"line":1,"column":4}},"callers":[],"fixable":false,"fixed":false}],"errors":[]}`,
 		},
 	}
 

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -16,6 +16,8 @@ type JSONIssue struct {
 	Message string      `json:"message"`
 	Range   JSONRange   `json:"range"`
 	Callers []JSONRange `json:"callers"`
+	Fixable bool        `json:"fixable"`
+	Fixed   bool        `json:"fixed"`
 }
 
 // JSONRule is a temporary structure for converting TFLint rules to JSON.
@@ -69,6 +71,8 @@ func (f *Formatter) jsonPrint(issues tflint.Issues, appErr error) {
 				End:      JSONPos{Line: issue.Range.End.Line, Column: issue.Range.End.Column},
 			},
 			Callers: make([]JSONRange, len(issue.Callers)),
+			Fixable: issue.Fixable,
+			Fixed:   issue.Fixable && f.Fix,
 		}
 		for i, caller := range issue.Callers {
 			ret.Issues[idx].Callers[i] = JSONRange{

--- a/integrationtest/autofix/chdir/result.json
+++ b/integrationtest/autofix/chdir/result.json
@@ -18,7 +18,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     }
   ],
   "errors": []

--- a/integrationtest/autofix/chdir/result_windows.json
+++ b/integrationtest/autofix/chdir/result_windows.json
@@ -18,7 +18,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     }
   ],
   "errors": []

--- a/integrationtest/autofix/chdir_with_conflict/result.json
+++ b/integrationtest/autofix/chdir_with_conflict/result.json
@@ -18,7 +18,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 33
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 33
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     },
     {
       "rule": {
@@ -78,7 +84,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     }
   ],
   "errors": []

--- a/integrationtest/autofix/chdir_with_conflict/result_windows.json
+++ b/integrationtest/autofix/chdir_with_conflict/result_windows.json
@@ -8,7 +8,7 @@
       },
       "message": "Use \"# autofixed\" instead of \"// autofixed\"",
       "range": {
-        "filename": "dir\\main.tf",
+        "filename": "dir/main.tf",
         "start": {
           "line": 1,
           "column": 1
@@ -18,7 +18,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     },
     {
       "rule": {
@@ -28,7 +30,7 @@
       },
       "message": "instance type is [AUTO_FIXED]",
       "range": {
-        "filename": "dir\\main.tf",
+        "filename": "dir/main.tf",
         "start": {
           "line": 3,
           "column": 19
@@ -38,7 +40,9 @@
           "column": 33
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -48,7 +52,7 @@
       },
       "message": "instance type is [AUTO_FIXED]",
       "range": {
-        "filename": "dir\\main.tf",
+        "filename": "dir/main.tf",
         "start": {
           "line": 3,
           "column": 19
@@ -58,7 +62,9 @@
           "column": 33
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     },
     {
       "rule": {
@@ -68,7 +74,7 @@
       },
       "message": "Use \"# autofixed\" instead of \"// autofixed\"",
       "range": {
-        "filename": "dir\\main.tf",
+        "filename": "dir/main.tf",
         "start": {
           "line": 3,
           "column": 30
@@ -78,7 +84,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     }
   ],
   "errors": []

--- a/integrationtest/autofix/chdir_with_conflict/result_windows.json
+++ b/integrationtest/autofix/chdir_with_conflict/result_windows.json
@@ -8,7 +8,7 @@
       },
       "message": "Use \"# autofixed\" instead of \"// autofixed\"",
       "range": {
-        "filename": "dir/main.tf",
+        "filename": "dir\\main.tf",
         "start": {
           "line": 1,
           "column": 1
@@ -30,7 +30,7 @@
       },
       "message": "instance type is [AUTO_FIXED]",
       "range": {
-        "filename": "dir/main.tf",
+        "filename": "dir\\main.tf",
         "start": {
           "line": 3,
           "column": 19
@@ -52,7 +52,7 @@
       },
       "message": "instance type is [AUTO_FIXED]",
       "range": {
-        "filename": "dir/main.tf",
+        "filename": "dir\\main.tf",
         "start": {
           "line": 3,
           "column": 19
@@ -74,7 +74,7 @@
       },
       "message": "Use \"# autofixed\" instead of \"// autofixed\"",
       "range": {
-        "filename": "dir/main.tf",
+        "filename": "dir\\main.tf",
         "start": {
           "line": 3,
           "column": 30

--- a/integrationtest/autofix/conflict_fix/result.json
+++ b/integrationtest/autofix/conflict_fix/result.json
@@ -18,7 +18,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 33
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 33
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     },
     {
       "rule": {
@@ -78,7 +84,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     }
   ],
   "errors": []

--- a/integrationtest/autofix/filter/result.json
+++ b/integrationtest/autofix/filter/result.json
@@ -18,7 +18,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     }
   ],
   "errors": []

--- a/integrationtest/autofix/fix_by_multiple_rules/result.json
+++ b/integrationtest/autofix/fix_by_multiple_rules/result.json
@@ -18,7 +18,9 @@
           "column": 22
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     }
   ],
   "errors": []

--- a/integrationtest/autofix/ignore_by_annotation/result.json
+++ b/integrationtest/autofix/ignore_by_annotation/result.json
@@ -18,7 +18,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     }
   ],
   "errors": []

--- a/integrationtest/autofix/module/result.json
+++ b/integrationtest/autofix/module/result.json
@@ -18,7 +18,9 @@
           "column": 33
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 33
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     },
     {
       "rule": {
@@ -101,7 +107,9 @@
             "column": 28
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -144,7 +152,9 @@
             "column": 28
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/autofix/module/result_windows.json
+++ b/integrationtest/autofix/module/result_windows.json
@@ -18,7 +18,9 @@
           "column": 33
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 33
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     },
     {
       "rule": {
@@ -91,7 +97,7 @@
           }
         },
         {
-          "filename": "module\\main.tf",
+          "filename": "module/main.tf",
           "start": {
             "line": 8,
             "column": 19
@@ -101,7 +107,9 @@
             "column": 28
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -134,7 +142,7 @@
           }
         },
         {
-          "filename": "module\\main.tf",
+          "filename": "module/main.tf",
           "start": {
             "line": 8,
             "column": 19
@@ -144,7 +152,9 @@
             "column": 28
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/autofix/module/result_windows.json
+++ b/integrationtest/autofix/module/result_windows.json
@@ -97,7 +97,7 @@
           }
         },
         {
-          "filename": "module/main.tf",
+          "filename": "module\\main.tf",
           "start": {
             "line": 8,
             "column": 19
@@ -142,7 +142,7 @@
           }
         },
         {
-          "filename": "module/main.tf",
+          "filename": "module\\main.tf",
           "start": {
             "line": 8,
             "column": 19

--- a/integrationtest/autofix/multiple_files/result.json
+++ b/integrationtest/autofix/multiple_files/result.json
@@ -18,7 +18,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     }
   ],
   "errors": []

--- a/integrationtest/autofix/multiple_fix/result.json
+++ b/integrationtest/autofix/multiple_fix/result.json
@@ -18,7 +18,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     }
   ],
   "errors": []

--- a/integrationtest/autofix/simple/result.json
+++ b/integrationtest/autofix/simple/result.json
@@ -18,7 +18,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": true,
+      "fixed": true
     }
   ],
   "errors": []

--- a/integrationtest/bundled/basic/result.json
+++ b/integrationtest/bundled/basic/result.json
@@ -18,7 +18,9 @@
           "column": 25
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 18
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -78,7 +84,9 @@
           "column": 31
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -98,7 +106,9 @@
           "column": 19
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -118,7 +128,9 @@
           "column": 41
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/bundled/basic/result.json
+++ b/integrationtest/bundled/basic/result.json
@@ -63,7 +63,7 @@
         }
       },
       "callers": [],
-      "fixable": false,
+      "fixable": true,
       "fixed": false
     },
     {
@@ -107,7 +107,7 @@
         }
       },
       "callers": [],
-      "fixable": false,
+      "fixable": true,
       "fixed": false
     },
     {
@@ -129,7 +129,7 @@
         }
       },
       "callers": [],
-      "fixable": false,
+      "fixable": true,
       "fixed": false
     }
   ],

--- a/integrationtest/bundled/disable/result.json
+++ b/integrationtest/bundled/disable/result.json
@@ -1,1 +1,4 @@
-{"issues":[],"errors":[]}
+{
+  "issues": [],
+  "errors": []
+}

--- a/integrationtest/bundled/disabled_by_default/result.json
+++ b/integrationtest/bundled/disabled_by_default/result.json
@@ -18,7 +18,9 @@
           "column": 18
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/bundled/disabled_by_default/result.json
+++ b/integrationtest/bundled/disabled_by_default/result.json
@@ -19,7 +19,7 @@
         }
       },
       "callers": [],
-      "fixable": false,
+      "fixable": true,
       "fixed": false
     }
   ],

--- a/integrationtest/bundled/empty/result.json
+++ b/integrationtest/bundled/empty/result.json
@@ -1,1 +1,4 @@
-{"issues":[],"errors":[]}
+{
+  "issues": [],
+  "errors": []
+}

--- a/integrationtest/bundled/only/result.json
+++ b/integrationtest/bundled/only/result.json
@@ -18,7 +18,9 @@
           "column": 18
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/bundled/only/result.json
+++ b/integrationtest/bundled/only/result.json
@@ -19,7 +19,7 @@
         }
       },
       "callers": [],
-      "fixable": false,
+      "fixable": true,
       "fixed": false
     }
   ],

--- a/integrationtest/bundled/with_config/result.json
+++ b/integrationtest/bundled/with_config/result.json
@@ -18,7 +18,9 @@
           "column": 25
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 25
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 1
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/bundled/with_config/result.json
+++ b/integrationtest/bundled/with_config/result.json
@@ -41,7 +41,7 @@
         }
       },
       "callers": [],
-      "fixable": false,
+      "fixable": true,
       "fixed": false
     },
     {

--- a/integrationtest/inspection/bad-config/result.json
+++ b/integrationtest/inspection/bad-config/result.json
@@ -7,8 +7,14 @@
       "severity": "error",
       "range": {
         "filename": "template.tf",
-        "start": { "line": 2, "column": 10 },
-        "end": { "line": 2, "column": 15 }
+        "start": {
+          "line": 2,
+          "column": 10
+        },
+        "end": {
+          "line": 2,
+          "column": 15
+        }
       }
     }
   ]

--- a/integrationtest/inspection/basic/result.json
+++ b/integrationtest/inspection/basic/result.json
@@ -18,7 +18,9 @@
           "column": 29
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/chdir/result.json
+++ b/integrationtest/inspection/chdir/result.json
@@ -41,7 +41,9 @@
             "column": 36
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/chdir/result_windows.json
+++ b/integrationtest/inspection/chdir/result_windows.json
@@ -41,7 +41,9 @@
             "column": 36
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/conditional/result.json
+++ b/integrationtest/inspection/conditional/result.json
@@ -18,7 +18,9 @@
           "column": 29
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 29
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 29
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -78,7 +84,9 @@
           "column": 29
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -98,7 +106,9 @@
           "column": 16
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -118,7 +128,9 @@
           "column": 15
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -138,7 +150,9 @@
           "column": 25
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/cty-based-eval/result.json
+++ b/integrationtest/inspection/cty-based-eval/result.json
@@ -18,7 +18,9 @@
           "column": 18
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/disabled-rules/result.json
+++ b/integrationtest/inspection/disabled-rules/result.json
@@ -18,7 +18,9 @@
           "column": 29
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/dynblock-unknown/result.json
+++ b/integrationtest/inspection/dynblock-unknown/result.json
@@ -18,7 +18,9 @@
           "column": 17
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 19
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 27
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -78,7 +84,9 @@
           "column": 16
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -98,7 +106,9 @@
           "column": 20
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -118,7 +128,9 @@
           "column": 17
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -138,7 +150,9 @@
           "column": 18
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/dynblock/result.json
+++ b/integrationtest/inspection/dynblock/result.json
@@ -18,7 +18,9 @@
           "column": 17
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 20
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 15
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -78,7 +84,9 @@
           "column": 25
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -98,7 +106,9 @@
           "column": 27
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -118,7 +128,9 @@
           "column": 27
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -138,7 +150,9 @@
           "column": 65
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -158,7 +172,9 @@
           "column": 65
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -178,7 +194,9 @@
           "column": 27
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -198,7 +216,9 @@
           "column": 27
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -218,7 +238,9 @@
           "column": 27
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -238,7 +260,9 @@
           "column": 27
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -258,7 +282,9 @@
           "column": 90
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -278,7 +304,9 @@
           "column": 90
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -298,7 +326,9 @@
           "column": 90
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -318,7 +348,9 @@
           "column": 90
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -338,7 +370,9 @@
           "column": 27
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -358,7 +392,9 @@
           "column": 27
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -378,7 +414,9 @@
           "column": 27
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -398,7 +436,9 @@
           "column": 27
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -418,7 +458,9 @@
           "column": 51
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -438,7 +480,9 @@
           "column": 51
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -458,7 +502,9 @@
           "column": 51
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -478,7 +524,9 @@
           "column": 51
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/enable-config-rule-by-cli/result.json
+++ b/integrationtest/inspection/enable-config-rule-by-cli/result.json
@@ -18,7 +18,9 @@
           "column": 19
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/enable-plugin-by-cli/result.json
+++ b/integrationtest/inspection/enable-plugin-by-cli/result.json
@@ -18,7 +18,9 @@
           "column": 29
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/eval-on-root-context/result.json
+++ b/integrationtest/inspection/eval-on-root-context/result.json
@@ -18,7 +18,9 @@
           "column": 30
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/expand/result.json
+++ b/integrationtest/inspection/expand/result.json
@@ -18,7 +18,9 @@
           "column": 42
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 42
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 46
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -78,7 +84,9 @@
           "column": 46
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -121,7 +129,9 @@
             "column": 36
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -164,7 +174,9 @@
             "column": 36
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -207,7 +219,9 @@
             "column": 36
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -250,7 +264,9 @@
             "column": 36
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/expand/result_windows.json
+++ b/integrationtest/inspection/expand/result_windows.json
@@ -18,7 +18,9 @@
           "column": 42
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 42
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 46
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -78,7 +84,9 @@
           "column": 46
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -121,7 +129,9 @@
             "column": 36
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -164,7 +174,9 @@
             "column": 36
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -207,7 +219,9 @@
             "column": 36
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -250,7 +264,9 @@
             "column": 36
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/functions/result.json
+++ b/integrationtest/inspection/functions/result.json
@@ -18,7 +18,9 @@
           "column": 33
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 39
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 64
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/heredoc/result.json
+++ b/integrationtest/inspection/heredoc/result.json
@@ -18,7 +18,9 @@
           "column": 4
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/heredoc/result_windows.json
+++ b/integrationtest/inspection/heredoc/result_windows.json
@@ -18,7 +18,9 @@
           "column": 4
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/jsonsyntax/result.json
+++ b/integrationtest/inspection/jsonsyntax/result.json
@@ -18,7 +18,9 @@
           "column": 37
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/just-attributes/result.json
+++ b/integrationtest/inspection/just-attributes/result.json
@@ -18,7 +18,9 @@
           "column": 7
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/map-attribute/result.json
+++ b/integrationtest/inspection/map-attribute/result.json
@@ -18,7 +18,9 @@
           "column": 25
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/marked/result.json
+++ b/integrationtest/inspection/marked/result.json
@@ -18,7 +18,9 @@
           "column": 32
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 27
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 27
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -78,7 +84,9 @@
           "column": 21
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/module/result.json
+++ b/integrationtest/inspection/module/result.json
@@ -52,7 +52,9 @@
             "column": 62
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -106,7 +108,9 @@
             "column": 62
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -160,7 +164,9 @@
             "column": 62
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -214,7 +220,9 @@
             "column": 62
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/module/result_windows.json
+++ b/integrationtest/inspection/module/result_windows.json
@@ -52,7 +52,9 @@
             "column": 62
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -106,7 +108,9 @@
             "column": 62
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -160,7 +164,9 @@
             "column": 62
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -214,7 +220,9 @@
             "column": 62
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/no_calling_module/result.json
+++ b/integrationtest/inspection/no_calling_module/result.json
@@ -18,7 +18,9 @@
           "column": 36
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/override/result.json
+++ b/integrationtest/inspection/override/result.json
@@ -18,7 +18,9 @@
           "column": 21
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 38
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/path/result.json
+++ b/integrationtest/inspection/path/result.json
@@ -41,7 +41,9 @@
             "column": 52
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -84,7 +86,9 @@
             "column": 56
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/path/result_windows.json
+++ b/integrationtest/inspection/path/result_windows.json
@@ -41,7 +41,9 @@
             "column": 52
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -84,7 +86,9 @@
             "column": 56
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/plugin/result.json
+++ b/integrationtest/inspection/plugin/result.json
@@ -18,7 +18,9 @@
           "column": 36
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -72,7 +74,9 @@
             "column": 62
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -92,7 +96,9 @@
           "column": 37
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/plugin/result_windows.json
+++ b/integrationtest/inspection/plugin/result_windows.json
@@ -18,7 +18,9 @@
           "column": 36
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -72,7 +74,9 @@
             "column": 62
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -92,7 +96,9 @@
           "column": 37
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/provider-config/result.json
+++ b/integrationtest/inspection/provider-config/result.json
@@ -18,7 +18,9 @@
           "column": 29
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/rule-config/result.json
+++ b/integrationtest/inspection/rule-config/result.json
@@ -18,7 +18,9 @@
           "column": 17
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/rule-optional-config/result.json
+++ b/integrationtest/inspection/rule-optional-config/result.json
@@ -18,7 +18,9 @@
           "column": 19
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/variables/result.json
+++ b/integrationtest/inspection/variables/result.json
@@ -18,7 +18,9 @@
           "column": 30
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -38,7 +40,9 @@
           "column": 42
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -58,7 +62,9 @@
           "column": 39
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -78,7 +84,9 @@
           "column": 34
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -98,7 +106,9 @@
           "column": 26
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/with_module_init/result.json
+++ b/integrationtest/inspection/with_module_init/result.json
@@ -41,7 +41,9 @@
             "column": 36
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -84,7 +86,9 @@
             "column": 43
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/with_module_init/result_windows.json
+++ b/integrationtest/inspection/with_module_init/result_windows.json
@@ -41,7 +41,9 @@
             "column": 36
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     },
     {
       "rule": {
@@ -84,7 +86,9 @@
             "column": 43
           }
         }
-      ]
+      ],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []

--- a/integrationtest/inspection/without_module_init/result.json
+++ b/integrationtest/inspection/without_module_init/result.json
@@ -18,7 +18,9 @@
           "column": 31
         }
       },
-      "callers": []
+      "callers": [],
+      "fixable": false,
+      "fixed": false
     }
   ],
   "errors": []


### PR DESCRIPTION
Extends the JSON formatter to include information about whether issues are fixable or have been fixed, addressing the feature request in #2354.

## Changes

- `fixable`: Set to `true` when an issue can be automatically fixed
- `fixed`: Set to `true` when an issue is fixable AND the `--fix` flag is used
- **Test Updates**: Updated all JSON test expectation files to include the new fields

## Testing

- Unit tests for different fixable/fixed combinations 
- Integration tests for autofix scenarios
- Manual verification with the example from the issue

## Example Output

### Before

```json
{
  "issues": [{
    "rule": {"name": "terraform_comment_syntax", "severity": "warning"},
    "message": "Single line comments should begin with #",
    "range": {...},
    "callers": []
  }]
}
```

### After

```json
{
  "issues": [{
    "rule": {"name": "terraform_comment_syntax", "severity": "warning"}, 
    "message": "Single line comments should begin with #",
    "range": {...},
    "callers": [],
    "fixable": true,
    "fixed": false
  }]
}
```

With `--fix`:

```json
{
  "issues": [{
    "rule": {"name": "terraform_comment_syntax", "severity": "warning"},
    "message": "Single line comments should begin with #", 
    "range": {...},
    "callers": [],
    "fixable": true,
    "fixed": true
  }]
}
```

Closes #2354