### PR TITLE
Add support for Terraform v1.13

### DIFF
--- a/docs/user-guide/compatibility.md
+++ b/docs/user-guide/compatibility.md
@@ -4,7 +4,7 @@ TFLint interprets the [Terraform language](https://developer.hashicorp.com/terra
 
 The parser supports Terraform v1.x syntax and semantics. The language compatibility on Terraform v1.x is defined by [Compatibility Promises](https://developer.hashicorp.com/terraform/language/v1-compatibility-promises). TFLint follows this promise. New features are only supported in newer TFLint versions, and bug and experimental features compatibility are not guaranteed.
 
-The latest supported version is Terraform v1.12.
+The latest supported version is Terraform v1.13.
 
 ## Input Variables
 


### PR DESCRIPTION
This PR adds support for Terraform v1.13.
Terraform v1.13 does not include any changes for TFLint, so this change is a documentation update only.
