### PR TITLE
format(sarif): Add `tflint-errors` rules for errors

### DIFF
--- a/formatter/sarif_test.go
+++ b/formatter/sarif_test.go
@@ -407,14 +407,21 @@ func Test_sarifPrint(t *testing.T) {
         "driver": {
           "informationUri": "https://github.com/terraform-linters/tflint",
           "name": "tflint-errors",
-          "rules": [],
+          "rules": [
+            {
+              "id": "application_error",
+              "shortDescription": {
+                "text": ""
+              }
+            }
+          ],
           "version": "%s"
         }
       },
       "results": [
         {
           "ruleId": "application_error",
-          "ruleIndex": 18446744073709551615,
+          "ruleIndex": 0,
           "level": "error",
           "message": {
             "text": "Failed to work; I don't feel like working"
@@ -462,14 +469,21 @@ func Test_sarifPrint(t *testing.T) {
         "driver": {
           "informationUri": "https://github.com/terraform-linters/tflint",
           "name": "tflint-errors",
-          "rules": [],
+          "rules": [
+            {
+              "id": "summary",
+              "shortDescription": {
+                "text": ""
+              }
+            }
+          ],
           "version": "%s"
         }
       },
       "results": [
         {
           "ruleId": "summary",
-          "ruleIndex": 18446744073709551615,
+          "ruleIndex": 0,
           "level": "warning",
           "message": {
             "text": "detail"
@@ -535,14 +549,27 @@ func Test_sarifPrint(t *testing.T) {
         "driver": {
           "informationUri": "https://github.com/terraform-linters/tflint",
           "name": "tflint-errors",
-          "rules": [],
+          "rules": [
+            {
+              "id": "application_error",
+              "shortDescription": {
+                "text": ""
+              }
+            },
+            {
+              "id": "summary",
+              "shortDescription": {
+                "text": ""
+              }
+            }
+          ],
           "version": "%s"
         }
       },
       "results": [
         {
           "ruleId": "application_error",
-          "ruleIndex": 18446744073709551615,
+          "ruleIndex": 0,
           "level": "error",
           "message": {
             "text": "an error occurred"
@@ -550,7 +577,7 @@ func Test_sarifPrint(t *testing.T) {
         },
         {
           "ruleId": "application_error",
-          "ruleIndex": 18446744073709551615,
+          "ruleIndex": 0,
           "level": "error",
           "message": {
             "text": "failed"
@@ -558,7 +585,7 @@ func Test_sarifPrint(t *testing.T) {
         },
         {
           "ruleId": "summary",
-          "ruleIndex": 18446744073709551615,
+          "ruleIndex": 1,
           "level": "warning",
           "message": {
             "text": "detail"


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/2367

When an error occurs, the SARIF output reports it as a result in the `tflint-errors` tool. However, since the corresponding rule is not added at this time, there is a violation that the `ruleIndex` becomes an invalid value.

This PR adds a corresponding rule when adding an error result, fixing a violation of the SARIF spec.