### PR TITLE
Alphabetize rulesets in version output

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"maps"
+	"slices"
 
 	"github.com/spf13/afero"
 	"github.com/terraform-linters/tflint/plugin"
@@ -63,9 +65,13 @@ func getPluginVersions(opts Options) []string {
 	}
 	defer rulesetPlugin.Clean()
 
+	// Sort ruleset names to ensure consistent ordering
+	rulesetNames := slices.Sorted(maps.Keys(rulesetPlugin.RuleSets))
+
 	versions := []string{}
-	for _, ruleset := range rulesetPlugin.RuleSets {
-		name, err := ruleset.RuleSetName()
+	for _, name := range rulesetNames {
+		ruleset := rulesetPlugin.RuleSets[name]
+		rulesetName, err := ruleset.RuleSetName()
 		if err != nil {
 			log.Printf("[ERROR] Failed to get ruleset name: %s", err)
 			continue
@@ -76,7 +82,7 @@ func getPluginVersions(opts Options) []string {
 			continue
 		}
 
-		versions = append(versions, fmt.Sprintf("+ ruleset.%s (%s)\n", name, version))
+		versions = append(versions, fmt.Sprintf("+ ruleset.%s (%s)\n", rulesetName, version))
 	}
 
 	return versions

--- a/integrationtest/cli/cli_test.go
+++ b/integrationtest/cli/cli_test.go
@@ -36,6 +36,13 @@ func TestIntegration(t *testing.T) {
 			stdout:  fmt.Sprintf("TFLint version %s", tflint.Version),
 		},
 		{
+			name:    "print version with plugins in alphabetical order",
+			command: "./tflint --version",
+			dir:     "version_ordering",
+			status:  cmd.ExitCodeOK,
+			stdout:  "ruleset.bar (0.1.0)\n+ ruleset.foo (0.1.0)",
+		},
+		{
 			name:    "print help",
 			command: "./tflint --help",
 			dir:     "no_issues",

--- a/integrationtest/cli/version_ordering/.tflint.d
+++ b/integrationtest/cli/version_ordering/.tflint.d
@@ -1,0 +1,1 @@
+../../../plugin/test-fixtures/locals/.tflint.d

--- a/integrationtest/cli/version_ordering/.tflint.hcl
+++ b/integrationtest/cli/version_ordering/.tflint.hcl
@@ -1,0 +1,9 @@
+plugin "foo" {
+  enabled = true
+}
+
+plugin "bar" {
+  enabled = true
+  version = "0.1.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-bar"
+}


### PR DESCRIPTION
Fixes inconsistent ordering of rulesets in `tflint --version` output. Previously, rulesets were iterated in random order (as a `map`) which caused the output of `tflint --version` to be non-deterministic. 

## Changes

- Sort ruleset names alphabetically before displaying using `slices.Sorted(maps.Keys())`
- Add integration test to verify alphabetical ordering

## References

Closes #2403