### PR TITLE
release: Pin Cosign version and deprecate Cosign signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
         go-version-file: 'go.mod'
     - name: Install Cosign
       uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+      with:
+        cosign-release: 'v2.6.1'
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
       with:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ gh attestation verify checksums.txt -R terraform-linters/tflint
 sha256sum --ignore-missing -c checksums.txt
 ```
 
-#### Cosign
+#### Cosign (Deprecated)
+
+> [!WARNING]
+> Cosign signatures are now deprecated. Please use GitHub CLI.
 
 [Cosign](https://github.com/sigstore/cosign) `verify-blob` command ensures that the release was built with GitHub Actions in this repository.
 


### PR DESCRIPTION
See https://github.com/terraform-linters/tflint/pull/1361 https://github.com/terraform-linters/tflint/pull/2038
See https://blog.sigstore.dev/cosign-3-0-available/

We initially introduced Cosign for keyless verification, but now we use GitHub Artifact Attestations.

Until now, we have maintained these two signature methods, but the Cosign v3 introduced breaking changes to the signature format, so we are deprecating Cosign signatures and encouraging a full transition to Artifact Attestations.

Cosign signatures will be removed in a future release, but there will be a transition period. Signatures signed with v2 can be verified with v3, so until then, sign with v2.