### PR TITLE
fix: only read TF_VAR for root module

### DIFF
--- a/integrationtest/inspection/child-module-env-vars/.terraform/modules/modules.json
+++ b/integrationtest/inspection/child-module-env-vars/.terraform/modules/modules.json
@@ -1,0 +1,1 @@
+{"Modules":[{"Key":"","Source":"","Dir":"."},{"Key":"child","Source":"./child-module","Dir":"child-module"}]}

--- a/integrationtest/inspection/child-module-env-vars/child-module/main.tf
+++ b/integrationtest/inspection/child-module-env-vars/child-module/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_version = ">= 1.7.0"
+}
+
+variable "environment" {
+  type = list(string)
+}
+
+output "child_env" {
+  value = var.environment
+}

--- a/integrationtest/inspection/child-module-env-vars/main.tf
+++ b/integrationtest/inspection/child-module-env-vars/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.7.0"
+}
+
+variable "environment" {
+  type = string
+}
+
+module "child" {
+  source = "./child-module"
+
+  environment = [var.environment]
+}
+
+output "env_output" {
+  value = var.environment
+}

--- a/integrationtest/inspection/child-module-env-vars/result.json
+++ b/integrationtest/inspection/child-module-env-vars/result.json
@@ -1,0 +1,1 @@
+{"issues":[],"errors":[]}

--- a/integrationtest/inspection/inspection_test.go
+++ b/integrationtest/inspection/inspection_test.go
@@ -210,6 +210,14 @@ func TestIntegration(t *testing.T) {
 			Command: "tflint --format json",
 			Dir:     "functions",
 		},
+		{
+			Name:    "child module with environment variables",
+			Command: "tflint --format json",
+			Env: map[string]string{
+				"TF_VAR_environment": "prod",
+			},
+			Dir: "child-module-env-vars",
+		},
 	}
 
 	// Disable the bundled plugin because the `os.Executable()` is go(1) in the tests

--- a/terraform/input_value_test.go
+++ b/terraform/input_value_test.go
@@ -292,7 +292,7 @@ func TestVariableValues(t *testing.T) {
 				"module.child1.module.child2": {
 					"a": cty.StringVal("input2"),
 					"b": cty.StringVal("input1"),
-					"c": cty.StringVal("env"),
+					"c": cty.StringVal("config"), // Environment variables don't apply to child modules
 					"d": cty.StringVal("config"),
 				},
 			},


### PR DESCRIPTION
Prevents child modules from processing `TF_VAR_*` environment variables during evaluation. Child modules now receive variable values exclusively through module call arguments, matching Terraform's behavior. This fixes parsing errors when a parent and child module declare variables with the same name but different types.

## Changes

- Modified `VariableValues()` in `terraform/input_value.go` to skip environment variable processing for child modules using `config.Path.IsRoot()` check
- Updated `TestVariableValues` to verify environment variables are not applied to child modules

## Testing

Added integration test `child-module-env-vars` that verifies a child module with `environment` variable typed as `list(string)` does not receive `TF_VAR_environment=prod` from the environment when the parent module evaluates it.

## References

Closes #2412
