### PR TITLE
Add support for Terraform v1.14

### DIFF
--- a/docs/user-guide/compatibility.md
+++ b/docs/user-guide/compatibility.md
@@ -4,7 +4,7 @@ TFLint interprets the [Terraform language](https://developer.hashicorp.com/terra
 
 The parser supports Terraform v1.x syntax and semantics. The language compatibility on Terraform v1.x is defined by [Compatibility Promises](https://developer.hashicorp.com/terraform/language/v1-compatibility-promises). TFLint follows this promise. New features are only supported in newer TFLint versions, and bug and experimental features compatibility are not guaranteed.
 
-The latest supported version is Terraform v1.13.
+The latest supported version is Terraform v1.14.
 
 ## Input Variables
 


### PR DESCRIPTION
This PR adds support for Terraform v1.14.
Terraform v1.14 does not include any changes for TFLint, so this change is a documentation update only.

- https://github.com/hashicorp/terraform/pull/37001
  - Although it is somewhat related, this is mainly a mechanism to ensure consistency of function return values ​​when plan/apply are executed at different times, and is unrelated to TFLint, which is completed in a single evaluation.
  - This may be supported if codebase divergence is an issue or greater compatibility with Terraform is important.
- https://github.com/hashicorp/terraform/pull/37663
  - In TFLint, many values ​​are treated as unknown, so it is expected behavior that uninitialized values ​​are treated as unknown.

By the way, `action` blocks were newly introduced in v1.14. There are now an increasing number of invalid references in `events` expressions such as `before_create`.
https://developer.hashicorp.com/terraform/language/v1.14.x/invoke-actions

TFLint has tried to handle references the same way as Terraform as much as possible, but considering the possibility that such meta-references may be referenced unexpectedly by plugins, it may be necessary to be more tolerant in how references are handled. In many cases, these references resolve to unknown values, but the important thing is that unintended errors can be prevented. For example, this can avoid issues like https://github.com/terraform-linters/tflint-ruleset-terraform/issues/199.