### PR TITLE
Add an integration test for root only traversal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-linters/tflint
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/agext/levenshtein v1.2.3

--- a/integrationtest/inspection/inspection_test.go
+++ b/integrationtest/inspection/inspection_test.go
@@ -218,6 +218,11 @@ func TestIntegration(t *testing.T) {
 			},
 			Dir: "child-module-env-vars",
 		},
+		{
+			Name:    "traversals",
+			Command: "tflint --format json",
+			Dir:     "traversals",
+		},
 	}
 
 	// Disable the bundled plugin because the `os.Executable()` is go(1) in the tests

--- a/integrationtest/inspection/traversals/.tflint.hcl
+++ b/integrationtest/inspection/traversals/.tflint.hcl
@@ -1,0 +1,3 @@
+plugin "testing" {
+  enabled = true
+}

--- a/integrationtest/inspection/traversals/main.tf
+++ b/integrationtest/inspection/traversals/main.tf
@@ -1,0 +1,7 @@
+resource "aws_prometheus_workspace" "main" {
+  lifecycle {
+    ignore_changes = [
+      logging_configuration
+    ]
+  }
+}

--- a/integrationtest/inspection/traversals/result.json
+++ b/integrationtest/inspection/traversals/result.json
@@ -1,0 +1,27 @@
+{
+  "issues": [
+    {
+      "rule": {
+        "name": "aws_prometheus_workspace_unignorable_logging_configuration",
+        "severity": "warning",
+        "link": ""
+      },
+      "message": "ignore_changes should not include logging_configuration",
+      "range": {
+        "filename": "main.tf",
+        "start": {
+          "line": 3,
+          "column": 5
+        },
+        "end": {
+          "line": 5,
+          "column": 6
+        }
+      },
+      "callers": [],
+      "fixable": false,
+      "fixed": false
+    }
+  ],
+  "errors": []
+}

--- a/plugin/stub-generator/sources/testing/main.go
+++ b/plugin/stub-generator/sources/testing/main.go
@@ -28,6 +28,7 @@ func main() {
 				rules.NewTerraformAutofixCommentRule(),
 				rules.NewAwsInstanceAutofixConflictRule(), // should be later than terraform_autofix_comment because this rule adds an issue for terraform_autofix_comment
 				rules.NewTerraformRequiredProvidersRule(),
+				rules.NewAwsPrometheusWorkspaceUnignorableLoggingConfigurationRule(),
 			},
 		},
 	})

--- a/plugin/stub-generator/sources/testing/rules/aws_prometheus_workspace_unignorable_logging_configuration_rule.go
+++ b/plugin/stub-generator/sources/testing/rules/aws_prometheus_workspace_unignorable_logging_configuration_rule.go
@@ -1,0 +1,85 @@
+package rules
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// AwsPrometheusWorkspaceUnignorableLoggingConfiguration checks whether ...
+type AwsPrometheusWorkspaceUnignorableLoggingConfiguration struct {
+	tflint.DefaultRule
+}
+
+// NewAwsPrometheusWorkspaceUnignorableLoggingConfigurationRule returns a new rule
+func NewAwsPrometheusWorkspaceUnignorableLoggingConfigurationRule() *AwsPrometheusWorkspaceUnignorableLoggingConfiguration {
+	return &AwsPrometheusWorkspaceUnignorableLoggingConfiguration{}
+}
+
+// Name returns the rule name
+func (r *AwsPrometheusWorkspaceUnignorableLoggingConfiguration) Name() string {
+	return "aws_prometheus_workspace_unignorable_logging_configuration"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsPrometheusWorkspaceUnignorableLoggingConfiguration) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsPrometheusWorkspaceUnignorableLoggingConfiguration) Severity() tflint.Severity {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *AwsPrometheusWorkspaceUnignorableLoggingConfiguration) Link() string {
+	return ""
+}
+
+// Check checks whether ...
+func (r *AwsPrometheusWorkspaceUnignorableLoggingConfiguration) Check(runner tflint.Runner) error {
+	resources, err := runner.GetResourceContent("aws_prometheus_workspace", &hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{
+				Type: "lifecycle",
+				Body: &hclext.BodySchema{
+					Attributes: []hclext.AttributeSchema{
+						{
+							Name: "ignore_changes",
+						},
+					},
+				},
+			},
+		},
+	}, &tflint.GetModuleContentOption{ExpandMode: tflint.ExpandModeNone})
+	if err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Blocks {
+		for _, lifecycleBlock := range resource.Body.Blocks {
+			if ignoreChangesAttr, exists := lifecycleBlock.Body.Attributes["ignore_changes"]; exists {
+				exprs, diags := hcl.ExprList(ignoreChangesAttr.Expr)
+				if diags.HasErrors() {
+					// Skip if the ignore_changes is not a list
+					continue
+				}
+
+				for _, expr := range exprs {
+					keyword := hcl.ExprAsKeyword(expr)
+					if keyword == "logging_configuration" {
+						err := runner.EmitIssue(
+							r,
+							"ignore_changes should not include logging_configuration",
+							ignoreChangesAttr.Range,
+						)
+						if err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Closes https://github.com/terraform-linters/tflint/issues/2431

This PR adds an integration test for root-only traversal.

Initially, I thought we needed #2435 to support this use case, but after some research I realized we could currently support it using `ExpandModeNone`. Here's a test to prove it.