### PR TITLE
plugin: Ignore forbidden attestation fetch errors

### DIFF
--- a/plugin/install.go
+++ b/plugin/install.go
@@ -222,10 +222,10 @@ func (c *InstallConfig) fetchFromGitHub(ctx context.Context, client *github.Clie
 
 	attestations, err := c.fetchArtifactAttestations(ctx, client, checksum)
 	if err != nil {
-		var gerr *github.ErrorResponse
-		// If there are no attestations, it will be ignored without errors.
-		if errors.As(err, &gerr) && gerr.Response.StatusCode == 404 {
-			log.Printf("[DEBUG] Artifact attestations not found and will be ignored: %s", err)
+		// If attestations are not available or not accessible, ignore them and
+		// continue with the remaining verification flow.
+		if isIgnorableAttestationError(err) {
+			log.Printf("[DEBUG] Artifact attestations unavailable and will be ignored: %s", err)
 			return assets, checksum, nil, nil, nil
 		} else {
 			return assets, checksum, nil, nil, fmt.Errorf("Failed to download artifact attestations: %s", err)
@@ -276,6 +276,20 @@ func (c *InstallConfig) fetchArtifactAttestations(ctx context.Context, client *g
 		return []*github.Attestation{}, err
 	}
 	return resp.Attestations, nil
+}
+
+func isIgnorableAttestationError(err error) bool {
+	var gerr *github.ErrorResponse
+	if !errors.As(err, &gerr) || gerr.Response == nil {
+		return false
+	}
+
+	switch gerr.Response.StatusCode {
+	case http.StatusForbidden, http.StatusNotFound:
+		return true
+	default:
+		return false
+	}
 }
 
 // downloadToTempFile download assets from GitHub to a local temp file.

--- a/plugin/install_test.go
+++ b/plugin/install_test.go
@@ -2,9 +2,11 @@ package plugin
 
 import (
 	"errors"
+	"net/http"
 	"os"
 	"testing"
 
+	"github.com/google/go-github/v81/github"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -332,6 +334,54 @@ func TestGetGitHubToken(t *testing.T) {
 			got := test.config.getGitHubToken()
 			if got != test.want {
 				t.Errorf("got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsIgnorableAttestationError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "403 forbidden",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusForbidden},
+			},
+			want: true,
+		},
+		{
+			name: "404 not found",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusNotFound},
+			},
+			want: true,
+		},
+		{
+			name: "401 unauthorized",
+			err: &github.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusUnauthorized},
+			},
+			want: false,
+		},
+		{
+			name: "non github error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+		{
+			name: "github error without response",
+			err:  &github.ErrorResponse{},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isIgnorableAttestationError(test.err); got != test.want {
+				t.Fatalf("isIgnorableAttestationError() = %v, want %v", got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes https://github.com/terraform-linters/tflint/issues/2460

With the keyless verification introduced in https://github.com/terraform-linters/tflint/pull/2453, if attestation does not exist or if it is a private repository, it will now fall back to signing key-based verification.

However, as a result of always fetching attestations, errors now occur when the `GITHUB_TOKEN` does not have permission to fetch attestations, as in #2460.

Since attestations can always be fetched from a public repository, if it cannot be fetched due to a permission error, it is likely that it is a private repository. So, in this PR, if a 403 error occurs, we will assume that attestations are unavailable and fall back to signing key-based verification.