### PR TITLE
deps: Bump Go version to 1.26

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Run linters
       uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
       with:
-        version: v2.4.0
+        version: v2.11.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.21 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.23 AS builder
 
 ARG TARGETOS TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-linters/tflint
 
-go 1.25.5
+go 1.26.1
 
 require (
 	github.com/agext/levenshtein v1.2.3


### PR DESCRIPTION
https://go.dev/doc/go1.26