### PR TITLE
plugin: Add signature mode to control plugin verifications

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -49,7 +49,11 @@ func (cli *CLI) init(opts Options) int {
 					_, err = installCfg.Install()
 					if err != nil {
 						if errors.Is(err, plugin.ErrPluginNotVerified) {
-							_, _ = color.New(color.FgYellow).Fprintln(cli.outStream, `No signing key or attestations found. The plugin signature is not verified`)
+							if installCfg.Signature == string(plugin.SignatureModeNone) {
+								_, _ = color.New(color.FgYellow).Fprintln(cli.outStream, `The plugin signature verification is disabled. Please be aware that disabling verification can pose security risks`)
+							} else {
+								_, _ = color.New(color.FgYellow).Fprintln(cli.outStream, `No signing key or attestations found. The plugin signature is not verified`)
+							}
 							err = nil
 						} else if errors.Is(err, plugin.ErrLegacySigningKeyUsed) {
 							_, _ = color.New(color.FgYellow).Fprintln(cli.outStream, `The plugin was signed using a legacy PGP signing key. Please update the plugin to the latest version`)

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -39,13 +39,18 @@ The source URL to install the plugin. Must be in the format `github.com/org/repo
 
 Plugin version. Do not prefix with "v". This attribute cannot be omitted when the `source` is set. Version constraints (like `>= 0.3`) are not supported.
 
+### `signature`
+
+Controls how TFLint verifies plugin releases. Valid values are:
+
+- `auto`: Prefer `attestation` when available, then fall back to `pgp`. This is the default behavior.
+- `attestation`: Require [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds). Attestation verification in private repositories is not supported.
+- `pgp`: Require PGP signature verification with `signing_key`.
+- `none`: Skip plugin signature verification.
+
 ### `signing_key`
 
-Plugins are verified by default with [Artifact Attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) when available. If no attestations are found, TFLint falls back to PGP signature verification using the `signing_key`.
-
-If the plugin developer distributes a PGP public key, setting the `signing_key` will ensure that the signature of the checksum file downloaded from GitHub is signed by the key.
-
-NOTE: Artifact Attestations will not be verified if the `source` is a private repository. If you want to verify signatures in a private repository, you must set the `signing_key`.
+The signing key used when `signature = "pgp"` or `"auto"`.
 
 ## Plugin directory
 

--- a/plugin/install.go
+++ b/plugin/install.go
@@ -25,6 +25,15 @@ import (
 
 const defaultSourceHost = "github.com"
 
+type SignatureMode string
+
+const (
+	SignatureModeAuto        SignatureMode = "auto"
+	SignatureModeAttestation SignatureMode = "attestation"
+	SignatureModePGP         SignatureMode = "pgp"
+	SignatureModeNone        SignatureMode = "none"
+)
+
 // InstallConfig is a config for plugin installation.
 // This is a wrapper for PluginConfig and manages naming conventions
 // and directory names for installation.
@@ -120,21 +129,18 @@ func (c *InstallConfig) Install() (string, error) {
 		return "", err
 	}
 
-	var verified bool
 	var legacyKeyUsed bool
 	sigchecker := NewSignatureChecker(c)
-	switch {
-	// Prefer to use artifact attestations if available
-	case c.shouldVerifyAttestations(repo, attestations):
+	sigMode := c.signatureMode(repo, attestations, sigchecker)
+	switch sigMode {
+	case SignatureModeAttestation:
 		log.Printf("[DEBUG] Verifying using artifact attestations")
 		if err := sigchecker.VerifyAttestations(bytes.NewReader(checksum), attestations); err != nil {
 			return "", fmt.Errorf("Failed to check checksums.txt signature: %s", err)
 		}
 		log.Printf("[DEBUG] Verified signature successfully")
-		verified = true
 
-	// Fallback to PGP signing key verification
-	case sigchecker.HasSigningKey():
+	case SignatureModePGP:
 		log.Printf("[DEBUG] Download checksums.txt.sig")
 		signatureFile, err := c.downloadToTempFile(ctx, client, assets["checksums.txt.sig"])
 		if signatureFile != nil {
@@ -149,15 +155,17 @@ func (c *InstallConfig) Install() (string, error) {
 			return "", fmt.Errorf("Failed to check checksums.txt signature: %s", err)
 		}
 		log.Printf("[DEBUG] Verified signature successfully")
-		verified = true
 
 		// If using built-in signing key, a warning will be shown.
 		if sigchecker.GetSigningKey() == builtinSigningKey {
 			legacyKeyUsed = true
 		}
 
+	case SignatureModeNone:
+		log.Printf("[DEBUG] Skipping signature verification")
+
 	default:
-		log.Printf("[DEBUG] No signing key or attestations found, skipping signature verification")
+		panic(fmt.Sprintf("never happened. signature=%s", sigMode))
 	}
 
 	log.Printf("[DEBUG] Download %s", c.AssetName())
@@ -183,13 +191,35 @@ func (c *InstallConfig) Install() (string, error) {
 	}
 
 	log.Printf("[DEBUG] Installed %s successfully", path)
-	if !verified {
+	if sigMode == SignatureModeNone {
 		return path, ErrPluginNotVerified
 	}
 	if legacyKeyUsed {
 		return path, ErrLegacySigningKeyUsed
 	}
 	return path, nil
+}
+
+func (c *InstallConfig) signatureMode(repo *github.Repository, attestations []*github.Attestation, sigchecker *SignatureChecker) SignatureMode {
+	switch SignatureMode(c.Signature) {
+	case SignatureModeAttestation, SignatureModePGP, SignatureModeNone:
+		return SignatureMode(c.Signature)
+
+	case "", SignatureModeAuto:
+		// Prefer to use artifact attestations if available
+		if c.shouldVerifyAttestations(repo, attestations) {
+			return SignatureModeAttestation
+		}
+		// Fallback to PGP signing key verification
+		if sigchecker.HasSigningKey() {
+			return SignatureModePGP
+		}
+		log.Printf("[DEBUG] No signing key or attestations found, skipping signature verification")
+		return SignatureModeNone
+
+	default:
+		panic(fmt.Sprintf("never happened. signature=%s", c.Signature))
+	}
 }
 
 func (c *InstallConfig) shouldVerifyAttestations(repo *github.Repository, attestations []*github.Attestation) bool {

--- a/plugin/install_test.go
+++ b/plugin/install_test.go
@@ -167,6 +167,70 @@ func Test_Install_withoutAttestationsAndPGPSignature(t *testing.T) {
 	}
 }
 
+func TestInstallConfigSignatureMode(t *testing.T) {
+	private := true
+	public := false
+
+	tests := []struct {
+		name         string
+		config       *InstallConfig
+		repo         *github.Repository
+		attestations []*github.Attestation
+		want         SignatureMode
+	}{
+		{
+			name:   "auto prefers attestations",
+			config: NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{}),
+			repo:   &github.Repository{Private: &public},
+			attestations: []*github.Attestation{
+				{},
+			},
+			want: SignatureModeAttestation,
+		},
+		{
+			name:   "auto falls back to signing key",
+			config: NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SigningKey: testSigningKey}),
+			repo:   &github.Repository{Private: &public},
+			want:   SignatureModePGP,
+		},
+		{
+			name:   "auto skips private repo attestations",
+			config: NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{}),
+			repo:   &github.Repository{Private: &private},
+			attestations: []*github.Attestation{
+				{},
+			},
+			want: SignatureModeNone,
+		},
+		{
+			name:   "forced attestation",
+			config: NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{Signature: "attestation", SigningKey: testSigningKey}),
+			want:   SignatureModeAttestation,
+		},
+		{
+			name:   "forced pgp",
+			config: NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{Signature: "pgp"}),
+			want:   SignatureModePGP,
+		},
+		{
+			name:   "forced none",
+			config: NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{Signature: "none", SigningKey: testSigningKey}),
+			want:   SignatureModeNone,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sigchecker := NewSignatureChecker(test.config)
+
+			got := test.config.signatureMode(test.repo, test.attestations, sigchecker)
+			if got != test.want {
+				t.Fatalf("unexpected signature mode: want %s, got %s", test.want, got)
+			}
+		})
+	}
+}
+
 func TestNewGitHubClient(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/go-version"
@@ -69,6 +70,20 @@ var validFormats = []string{
 	"sarif",
 }
 
+const (
+	signatureModeAuto        = "auto"
+	signatureModeAttestation = "attestation"
+	signatureModePGP         = "pgp"
+	signatureModeNone        = "none"
+)
+
+var validPluginSignatures = []string{
+	signatureModeAuto,
+	signatureModeAttestation,
+	signatureModePGP,
+	signatureModeNone,
+}
+
 // Config describes the behavior of TFLint
 type Config struct {
 	CallModuleType    terraform.CallModuleType
@@ -110,6 +125,7 @@ type PluginConfig struct {
 	Enabled    bool   `hcl:"enabled"`
 	Version    string `hcl:"version,optional"`
 	Source     string `hcl:"source,optional"`
+	Signature  string `hcl:"signature,optional"`
 	SigningKey string `hcl:"signing_key,optional"`
 
 	Body hcl.Body `hcl:",remain"`
@@ -681,6 +697,15 @@ func (c *PluginConfig) validate() error {
 		c.SourceHost = parts[0]
 		c.SourceOwner = parts[1]
 		c.SourceRepo = parts[2]
+	}
+
+	if c.Signature != "" {
+		if !slices.Contains(validPluginSignatures, c.Signature) {
+			return fmt.Errorf(`plugin "%s": %q is invalid signature. Allowed values are: %s`, c.Name, c.Signature, strings.Join(validPluginSignatures, ", "))
+		}
+		if c.SigningKey != "" && slices.Contains([]string{signatureModeAttestation, signatureModeNone}, c.Signature) {
+			return fmt.Errorf(`plugin "%s": "signing_key" cannot be used when "signature" is %q`, c.Name, c.Signature)
+		}
 	}
 
 	return nil

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -72,6 +72,7 @@ plugin "bar" {
 	version = "0.1.0"
 	source = "github.com/foo/bar"
 	signing_key = "SIGNING_KEY"
+	signature = "pgp"
 }
 
 plugin "baz" {
@@ -115,6 +116,7 @@ plugin "baz" {
 						Version:     "0.1.0",
 						Source:      "github.com/foo/bar",
 						SigningKey:  "SIGNING_KEY",
+						Signature:   "pgp",
 						SourceHost:  "github.com",
 						SourceOwner: "foo",
 						SourceRepo:  "bar",
@@ -344,6 +346,56 @@ plugin "foo" {
 			},
 		},
 		{
+			name: "plugin with invalid signature",
+			file: "plugin_with_invalid_signature.hcl",
+			files: map[string]string{
+				"plugin_with_invalid_signature.hcl": `
+plugin "foo" {
+	enabled = true
+	version = "0.1.0"
+	source = "github.com/foo/bar"
+	signature = "invalid"
+}`,
+			},
+			errCheck: func(err error) bool {
+				return err == nil || err.Error() != `plugin "foo": "invalid" is invalid signature. Allowed values are: auto, attestation, pgp, none`
+			},
+		},
+		{
+			name: "plugin with attestation signature and signing key",
+			file: "plugin_with_attestation_signature_and_signing_key.hcl",
+			files: map[string]string{
+				"plugin_with_attestation_signature_and_signing_key.hcl": `
+plugin "foo" {
+	enabled = true
+	version = "0.1.0"
+	source = "github.com/foo/bar"
+	signature = "attestation"
+	signing_key = "SIGNING_KEY"
+}`,
+			},
+			errCheck: func(err error) bool {
+				return err == nil || err.Error() != `plugin "foo": "signing_key" cannot be used when "signature" is "attestation"`
+			},
+		},
+		{
+			name: "plugin with none signature and signing key",
+			file: "plugin_with_none_signature_and_signing_key.hcl",
+			files: map[string]string{
+				"plugin_with_none_signature_and_signing_key.hcl": `
+plugin "foo" {
+	enabled = true
+	version = "0.1.0"
+	source = "github.com/foo/bar"
+	signature = "none"
+	signing_key = "SIGNING_KEY"
+}`,
+			},
+			errCheck: func(err error) bool {
+				return err == nil || err.Error() != `plugin "foo": "signing_key" cannot be used when "signature" is "none"`
+			},
+		},
+		{
 			name: "plugin with GHES source host",
 			file: "plugin_with_ghes_source_host.hcl",
 			files: map[string]string{
@@ -509,7 +561,8 @@ config {
       "enabled": false,
       "version": "0.1.0",
       "source": "github.com/foo/bar",
-      "signing_key": "SIGNING_KEY"
+      "signing_key": "SIGNING_KEY",
+      "signature": "pgp"
     },
     "baz": {
       "enabled": true,
@@ -554,6 +607,7 @@ config {
 						Version:     "0.1.0",
 						Source:      "github.com/foo/bar",
 						SigningKey:  "SIGNING_KEY",
+						Signature:   "pgp",
 						SourceHost:  "github.com",
 						SourceOwner: "foo",
 						SourceRepo:  "bar",
@@ -1293,6 +1347,7 @@ plugin "test" {
 	source  = "github.com/example/example"
 
 	signing_key = "PUBLIC_KEY"
+	signature = "pgp"
 
 	foo = "bar"
 }`,


### PR DESCRIPTION
Follow up of https://github.com/terraform-linters/tflint/issues/2460#issuecomment-3873767636

This PR introduces a new `plugin` attribute, `signature`. The `signature` is an option that controls the verification mode, and valid values ​​are:

- `auto`
  - Prefer `attestation` when available, then fall back to `pgp`. This is the default behavior.
- `attestation`
  - Require artifact attestations. Attestation verification in private repositories is not supported.
- `pgp`
  - Require PGP signature verification with `signing_key`.
- `none`
  - Skip plugin signature verification.

The behavior remains the same as before, and this PR does not change that behavior. Users can now more explicitly control the verification mode.