### PR TITLE
Add support for specifying --chdir multiple times

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Application Options:
       --var-file=FILE                                           Terraform variable file name
       --var='foo=bar'                                           Set a Terraform variable
       --call-module-type=[all|local|none]                       Types of module to call (default: local)
-      --chdir=DIR                                               Switch to a different working directory before executing the command
+      --chdir=DIR                                               Switch to different working directories before executing the command
       --recursive                                               Run command in each directory recursively
       --filter=FILE                                             Filter issues by file names or globs
       --force                                                   Return zero exit status even if issues found

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -111,7 +111,7 @@ func (cli *CLI) Run(args []string) int {
 	case opts.ActAsBundledPlugin:
 		return cli.actAsBundledPlugin()
 	default:
-		if opts.Recursive {
+		if opts.Recursive || len(opts.Chdir) > 1 {
 			return cli.inspectParallel(opts)
 		} else {
 			return cli.inspect(opts)
@@ -151,33 +151,35 @@ func unknownOptionHandler(option string, arg flags.SplitArgument, args []string)
 }
 
 func findWorkingDirs(opts Options) ([]string, error) {
-	baseDir := opts.Chdir
-	if baseDir == "" {
-		baseDir = "."
+	baseDirs := opts.Chdir
+	if len(baseDirs) == 0 {
+		baseDirs = []string{"."}
 	}
 	workingDirs := []string{}
 
 	if opts.Recursive {
-		err := filepath.WalkDir(baseDir, func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if !d.IsDir() {
-				return nil
-			}
-			// hidden directories are skipped
-			if path != "." && strings.HasPrefix(d.Name(), ".") {
-				return filepath.SkipDir
-			}
+		for _, baseDir := range baseDirs {
+			err := filepath.WalkDir(baseDir, func(path string, d os.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if !d.IsDir() {
+					return nil
+				}
+				// hidden directories are skipped
+				if path != "." && strings.HasPrefix(d.Name(), ".") {
+					return filepath.SkipDir
+				}
 
-			workingDirs = append(workingDirs, path)
-			return nil
-		})
-		if err != nil {
-			return []string{}, err
+				workingDirs = append(workingDirs, path)
+				return nil
+			})
+			if err != nil {
+				return []string{}, err
+			}
 		}
 	} else {
-		workingDirs = []string{baseDir}
+		workingDirs = baseDirs
 	}
 
 	return workingDirs, nil

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,12 +18,13 @@ func (cli *CLI) init(opts Options) int {
 		return ExitCodeError
 	}
 
+	multiDir := opts.Recursive || len(workingDirs) > 1
 	installed := false
 	for _, wd := range workingDirs {
 		err := cli.withinChangedDir(wd, func() error {
 			cfg, err := tflint.LoadConfig(afero.Afero{Fs: afero.NewOsFs()}, opts.Config)
 			if err != nil {
-				if opts.Recursive {
+				if multiDir {
 					return fmt.Errorf("Failed to load TFLint config in %s; %w", wd, err)
 				} else {
 					return fmt.Errorf("Failed to load TFLint config; %w", err)
@@ -40,7 +41,7 @@ func (cli *CLI) init(opts Options) int {
 
 				_, err := plugin.FindPluginPath(installCfg)
 				if os.IsNotExist(err) {
-					if opts.Recursive {
+					if multiDir {
 						fmt.Fprintf(cli.outStream, "Installing \"%s\" plugin in %s...\n", pluginCfg.Name, wd)
 					} else {
 						fmt.Fprintf(cli.outStream, "Installing \"%s\" plugin...\n", pluginCfg.Name)
@@ -68,7 +69,7 @@ func (cli *CLI) init(opts Options) int {
 				}
 
 				if err != nil {
-					if opts.Recursive {
+					if multiDir {
 						return fmt.Errorf("Failed to find a plugin in %s; %w", wd, err)
 					} else {
 						return fmt.Errorf("Failed to find a plugin; %w", err)

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -20,7 +20,12 @@ func (cli *CLI) inspect(opts Options) int {
 	issues := tflint.Issues{}
 	changes := map[string][]byte{}
 
-	err := cli.withinChangedDir(opts.Chdir, func() error {
+	chdir := ""
+	if len(opts.Chdir) > 0 {
+		chdir = opts.Chdir[0]
+	}
+
+	err := cli.withinChangedDir(chdir, func() error {
 		filterFiles := []string{}
 		for _, pattern := range opts.Filter {
 			files, err := filepath.Glob(pattern)
@@ -36,7 +41,7 @@ func (cli *CLI) inspect(opts Options) int {
 
 		// Join with the working directory to create the fullpath
 		for i, file := range filterFiles {
-			filterFiles[i] = filepath.Join(opts.Chdir, file)
+			filterFiles[i] = filepath.Join(chdir, file)
 		}
 
 		var err error

--- a/cmd/langserver.go
+++ b/cmd/langserver.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (cli *CLI) startLanguageServer(opts Options) int {
-	if opts.Chdir != "" {
+	if len(opts.Chdir) > 0 {
 		fmt.Fprintf(cli.errStream, "Cannot use --chdir with --langserver\n")
 		return ExitCodeError
 	}

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -24,7 +24,7 @@ type Options struct {
 	Varfiles               []string `long:"var-file" description:"Terraform variable file name" value-name:"FILE"`
 	Variables              []string `long:"var" description:"Set a Terraform variable" value-name:"'foo=bar'"`
 	CallModuleType         *string  `long:"call-module-type" description:"Types of module to call (default: local)" choice:"all" choice:"local" choice:"none"`
-	Chdir                  string   `long:"chdir" description:"Switch to a different working directory before executing the command" value-name:"DIR"`
+	Chdir                  []string `long:"chdir" description:"Switch to different working directories before executing the command" value-name:"DIR"`
 	Recursive              bool     `long:"recursive" description:"Run command in each directory recursively"`
 	Filter                 []string `long:"filter" description:"Filter issues by file names or globs" value-name:"FILE"`
 	Force                  *bool    `long:"force" description:"Return zero exit status even if issues found"`

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -87,13 +87,13 @@ func (cli *CLI) printVersion(opts Options) int {
 		return ExitCodeError
 	}
 
-	if opts.Recursive {
+	if opts.Recursive || len(workingDirs) > 1 {
 		fmt.Fprint(cli.outStream, "\n")
 	}
 
 	for _, wd := range workingDirs {
 		err := cli.withinChangedDir(wd, func() error {
-			if opts.Recursive {
+			if opts.Recursive || len(workingDirs) > 1 {
 				fmt.Fprint(cli.outStream, "====================================================\n")
 				fmt.Fprintf(cli.outStream, "working directory: %s\n\n", wd)
 			}
@@ -103,7 +103,7 @@ func (cli *CLI) printVersion(opts Options) int {
 			for _, plugin := range plugins {
 				fmt.Fprintf(cli.outStream, "+ %s (%s)\n", plugin.Name, plugin.Version)
 			}
-			if len(plugins) == 0 && opts.Recursive {
+			if len(plugins) == 0 && (opts.Recursive || len(workingDirs) > 1) {
 				fmt.Fprint(cli.outStream, "No plugins\n")
 			}
 			return nil
@@ -144,8 +144,8 @@ func (cli *CLI) printVersionJSON(opts Options, updateInfo *versioncheck.UpdateIn
 		}
 	}
 
-	// Handle multiple working directories for --recursive
-	if opts.Recursive && len(workingDirs) > 1 {
+	// Handle multiple working directories for --recursive or multiple --chdir
+	if len(workingDirs) > 1 {
 		// Track all unique plugins across modules
 		pluginMap := make(map[string]PluginVersion)
 

--- a/integrationtest/recursive/recursive_test.go
+++ b/integrationtest/recursive/recursive_test.go
@@ -45,6 +45,12 @@ func TestIntegration(t *testing.T) {
 			command: "tflint --chdir=subdir1 --recursive --format json --force",
 			dir:     "chdir",
 		},
+		{
+			name:        "multiple chdir",
+			command:     "tflint --chdir=subdir1 --chdir=subdir2 --format json --force",
+			dir:         "basic",
+			ignoreOrder: true,
+		},
 	}
 
 	dir, _ := os.Getwd()


### PR DESCRIPTION
Add support for specifying --chdir multiple times. This reuses the current support for running multiple subprocesses in parallel, used by --recursive. With this option, we can now run multiple --chdir without running _all_ --chdir, which is useful, for example, in pre-commit or CI systems on PRs where you may want to run on all modified roots rather than all roots.