### PR TITLE
docs: deprecate curl pipe bash installation

### DIFF
--- a/.github/workflows/install_script.yml
+++ b/.github/workflows/install_script.yml
@@ -50,8 +50,9 @@ jobs:
     - name: Non-existent version
       id: fail
       continue-on-error: true
-      # Install instructions pipe the script from curl to bash
-      # Passing scripts via stdin can have differing behavior from passing as a file arg
+      # Keep coverage for executing the installation script via stdin.
+      # This matches the deprecated convenience pattern and can behave differently
+      # from passing the script as a file argument.
       run: |
         bash < install_linux.sh
         tflint -v

--- a/README.md
+++ b/README.md
@@ -18,11 +18,29 @@ TFLint is a framework and each feature is provided by plugins, the key features 
 
 ## Installation
 
-Bash script (Linux):
+Linux:
+
+Download the appropriate archive from the [latest release](https://github.com/terraform-linters/tflint/releases/latest), verify it, and install the binary:
 
 ```console
-curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+curl -sSLO https://github.com/terraform-linters/tflint/releases/latest/download/tflint_linux_amd64.zip
+curl -sSLO https://github.com/terraform-linters/tflint/releases/latest/download/checksums.txt
+gh attestation verify checksums.txt -R terraform-linters/tflint
+sha256sum --ignore-missing -c checksums.txt
+unzip tflint_linux_amd64.zip
+sudo install -c -v tflint /usr/local/bin/
 ```
+
+For other architectures, replace `linux_amd64` with the archive that matches your system.
+
+For local convenience, the installation script is still available in this repository, but it is not recommended for CI workflows or Dockerfiles:
+
+```console
+./install_linux.sh
+```
+
+> [!WARNING]
+> Piping remote scripts directly into a shell is not recommended for CI workflows or Dockerfiles.
 
 Homebrew (macOS):
 


### PR DESCRIPTION
## What

Updates the Linux installation instructions to avoid recommending the `curl ... | bash` pattern as the default installation method.

The README now points users to release archives plus verification, and keeps the install script documented only as a temporary local convenience option.

## Why

Piping remote scripts directly into a shell is convenient, but it is not a good default recommendation from a supply chain security perspective, especially for CI workflows and Dockerfiles.

## Changes

- Replace the default Linux `curl ... | bash` installation example with release archive download + verification + install steps.
- Add a note that piping remote scripts directly into a shell is not recommended for CI workflows or Dockerfiles.
- Keep the install script documented as a temporary local convenience option.

## Validation

- Reviewed the README Markdown locally.
- Ran `git diff --check`.

Fixes #2510