### PR TITLE
formatter: make JUnit testcase names unique

### DIFF
--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -14,10 +14,11 @@ import (
 
 func (f *Formatter) junitPrint(issues tflint.Issues, appErr error, sources map[string][]byte) {
 	cases := make([]formatter.JUnitTestCase, len(issues))
+	names := map[string]int{}
 
 	for i, issue := range issues.Sort() {
 		cases[i] = formatter.JUnitTestCase{
-			Name:      issue.Rule.Name(),
+			Name:      uniqueJUnitTestCaseName(issue.Rule.Name(), names),
 			Classname: issue.Range.Filename,
 			Time:      "0",
 			Failure: &formatter.JUnitFailure{
@@ -55,6 +56,14 @@ func (f *Formatter) junitPrint(issues tflint.Issues, appErr error, sources map[s
 	}
 	fmt.Fprint(f.Stdout, xml.Header)
 	fmt.Fprint(f.Stdout, string(out))
+}
+
+func uniqueJUnitTestCaseName(name string, counts map[string]int) string {
+	counts[name]++
+	if counts[name] == 1 {
+		return name
+	}
+	return fmt.Sprintf("%s_%d", name, counts[name])
 }
 
 func (f *Formatter) junitErrors(err error) []formatter.JUnitTestCase {

--- a/formatter/junit_test.go
+++ b/formatter/junit_test.go
@@ -91,6 +91,41 @@ func Test_junitPrint(t *testing.T) {
   </testsuite>
 </testsuites>`,
 		},
+		{
+			Name: "duplicate issue names",
+			Issues: tflint.Issues{
+				{
+					Rule:    &testRule{},
+					Message: "first issue",
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+				{
+					Rule:    &testRule{},
+					Message: "second issue",
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 4},
+						End:      hcl.Pos{Line: 2, Column: 4, Byte: 7},
+					},
+				},
+			},
+			Stdout: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite tests="2" failures="2" time="0" name="">
+    <properties></properties>
+    <testcase classname="test.tf" name="test_rule" time="0">
+      <failure message="test.tf:1,1-4: first issue" type="Error">Error: first issue&#xA;Rule: test_rule&#xA;Range: test.tf:1,1-4</failure>
+    </testcase>
+    <testcase classname="test.tf" name="test_rule_2" time="0">
+      <failure message="test.tf:2,1-4: second issue" type="Error">Error: second issue&#xA;Rule: test_rule&#xA;Range: test.tf:2,1-4</failure>
+    </testcase>
+  </testsuite>
+</testsuites>`,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes #1608.

## Summary

The JUnit formatter previously used only the rule name as each lint issue's testcase name, so multiple failures from the same rule produced duplicate testcase names. This keeps the first testcase name unchanged and appends an incrementing suffix to later occurrences in the sorted issue output, for example:

- `terraform_deprecated_interpolation`
- `terraform_deprecated_interpolation_2`
- `terraform_deprecated_interpolation_3`

This intentionally avoids adding source ranges or resource names to testcase names; detailed range context remains in the failure message/body.

## Validation

- `gofmt -w formatter/junit.go formatter/junit_test.go`
- `go test ./formatter`
- `git diff --check HEAD~1 HEAD`