### PR TITLE
terraform: support escaping blocks

### DIFF
--- a/terraform/module.go
+++ b/terraform/module.go
@@ -133,9 +133,12 @@ func (m *Module) PartialContent(schema *hclext.BodySchema, ctx *Evaluator) (*hcl
 	for _, f := range m.primaries {
 		expanded, d := ctx.ExpandBlock(f.Body, schema)
 		diags = diags.Extend(d)
-		c, d := hclext.PartialContent(expanded, schema)
+		c, d := partialContentWithEscaping(expanded, schema)
 		diags = diags.Extend(d)
 		for name, attr := range c.Attributes {
+			if content.Attributes == nil {
+				content.Attributes = hclext.Attributes{}
+			}
 			content.Attributes[name] = attr
 		}
 		content.Blocks = append(content.Blocks, c.Blocks...)
@@ -145,15 +148,75 @@ func (m *Module) PartialContent(schema *hclext.BodySchema, ctx *Evaluator) (*hcl
 	for _, filename := range m.overrideFilenames {
 		expanded, d := ctx.ExpandBlock(m.overrides[filename].Body, schema)
 		diags = diags.Extend(d)
-		c, d := hclext.PartialContent(expanded, schema)
+		c, d := partialContentWithEscaping(expanded, schema)
 		diags = diags.Extend(d)
 		for name, attr := range c.Attributes {
+			if content.Attributes == nil {
+				content.Attributes = hclext.Attributes{}
+			}
 			content.Attributes[name] = attr
 		}
 		content.Blocks = overrideBlocks(content.Blocks, c.Blocks)
 	}
 
 	return content, diags
+}
+
+func partialContentWithEscaping(body hcl.Body, schema *hclext.BodySchema) (*hclext.BodyContent, hcl.Diagnostics) {
+	content, diags := hclext.PartialContent(body, schemaWithEscapingBlock(schema))
+	mergeEscapingBlocks(content)
+	return content, diags
+}
+
+func schemaWithEscapingBlock(schema *hclext.BodySchema) *hclext.BodySchema {
+	if schema == nil || schema.Mode == hclext.SchemaJustAttributesMode {
+		return schema
+	}
+
+	ret := &hclext.BodySchema{
+		Mode:       schema.Mode,
+		Attributes: append([]hclext.AttributeSchema{}, schema.Attributes...),
+		Blocks:     make([]hclext.BlockSchema, 0, len(schema.Blocks)+1),
+	}
+
+	escapingBody := &hclext.BodySchema{
+		Mode:       schema.Mode,
+		Attributes: append([]hclext.AttributeSchema{}, schema.Attributes...),
+		Blocks:     append([]hclext.BlockSchema{}, schema.Blocks...),
+	}
+	for _, block := range schema.Blocks {
+		copied := block
+		copied.Body = schemaWithEscapingBlock(block.Body)
+		ret.Blocks = append(ret.Blocks, copied)
+	}
+	ret.Blocks = append(ret.Blocks, hclext.BlockSchema{Type: "_", Body: escapingBody})
+
+	return ret
+}
+
+func mergeEscapingBlocks(content *hclext.BodyContent) {
+	if content == nil {
+		return
+	}
+
+	blocks := make(hclext.Blocks, 0, len(content.Blocks))
+	for _, block := range content.Blocks {
+		if block.Type != "_" {
+			mergeEscapingBlocks(block.Body)
+			blocks = append(blocks, block)
+			continue
+		}
+
+		mergeEscapingBlocks(block.Body)
+		for name, attr := range block.Body.Attributes {
+			if content.Attributes == nil {
+				content.Attributes = hclext.Attributes{}
+			}
+			content.Attributes[name] = attr
+		}
+		blocks = append(blocks, block.Body.Blocks...)
+	}
+	content.Blocks = blocks
 }
 
 // blockAddr returns an identifier of the given block (e.g. "resource.aws_instance.main").

--- a/terraform/module_test.go
+++ b/terraform/module_test.go
@@ -333,6 +333,41 @@ resource "aws_instance" "foo" {
 			},
 		},
 		{
+			name: "escaping blocks",
+			files: map[string]string{
+				"main.tf": `
+resource "aws_instance" "foo" {
+  _ {
+    count = 0
+    instance_type = "t2.micro"
+  }
+}`,
+			},
+			schema: &hclext.BodySchema{
+				Attributes: []hclext.AttributeSchema{{Name: "foo"}},
+				Blocks: []hclext.BlockSchema{
+					{
+						Type:       "resource",
+						LabelNames: []string{"type", "name"},
+						Body:       &hclext.BodySchema{Attributes: []hclext.AttributeSchema{{Name: "instance_type"}}},
+					},
+				},
+			},
+			want: &hclext.BodyContent{
+				Blocks: hclext.Blocks{
+					{
+						Type:   "resource",
+						Labels: []string{"aws_instance", "foo"},
+						Body: &hclext.BodyContent{
+							Attributes: hclext.Attributes{"instance_type": &hclext.Attribute{Name: "instance_type", Range: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 5}}}},
+							Blocks:     hclext.Blocks{},
+						},
+						DefRange: hcl.Range{Filename: "main.tf", Start: hcl.Pos{Line: 2}},
+					},
+				},
+			},
+		},
+		{
 			name: "just attributes",
 			files: map[string]string{
 				"main.tf": `


### PR DESCRIPTION
## Summary

Add support for Terraform escaping blocks in `Module.PartialContent` so attributes declared inside `_ { ... }` are exposed like normal block attributes.

This keeps meta-arguments inside escaping blocks out of block expansion by applying the escaping-block schema only when collecting partial content, after the normal expansion step.

Fixes #1644.

## Validation

- `gofmt -w terraform/module.go terraform/module_test.go`
- `go test ./terraform -run TestPartialContent`
- `go test ./terraform -run 'Test(Rebuild|PartialContent|_overrideBlocks)$'`
- `git diff --check`

Note: `go test ./terraform` currently also requires the existing loader test submodule fixtures; without those fixtures, unrelated `TestLoadConfig` cases fail while the focused module tests above pass.