### PR TITLE
cmd: include worker dir for no-range recursive issues

### DIFF
--- a/cmd/inspect_parallel.go
+++ b/cmd/inspect_parallel.go
@@ -72,6 +72,7 @@ func (cli *CLI) inspectParallel(opts Options) int {
 		if err := json.Unmarshal(stdout, &workerIssues); err != nil {
 			panic(fmt.Errorf("failed to parse issues in %s; %s; stdout=%s; stderr=%s", worker.dir, err, stdout, stderr))
 		}
+		fillNoRangeIssueFilenames(worker.dir, workerIssues)
 		issues = append(issues, workerIssues...)
 
 		if len(stderr) > 0 {
@@ -101,6 +102,19 @@ func (cli *CLI) inspectParallel(opts Options) int {
 	}
 
 	return ExitCodeOK
+}
+
+func fillNoRangeIssueFilenames(dir string, issues tflint.Issues) {
+	for _, issue := range issues {
+		if issue.Range.Filename == "" {
+			issue.Range.Filename = dir
+		}
+		for idx := range issue.Callers {
+			if issue.Callers[idx].Filename == "" {
+				issue.Callers[idx].Filename = dir
+			}
+		}
+	}
 }
 
 // Spawn workers to run in parallel for each directory.

--- a/cmd/inspect_parallel_test.go
+++ b/cmd/inspect_parallel_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func TestFillNoRangeIssueFilenames(t *testing.T) {
+	issues := tflint.Issues{
+		{
+			Range: hcl.Range{},
+			Callers: []hcl.Range{
+				{},
+				{Filename: "main.tf"},
+			},
+		},
+		{
+			Range: hcl.Range{Filename: "subdir/main.tf"},
+		},
+	}
+
+	fillNoRangeIssueFilenames("subdir", issues)
+
+	expected := tflint.Issues{
+		{
+			Range: hcl.Range{Filename: "subdir"},
+			Callers: []hcl.Range{
+				{Filename: "subdir"},
+				{Filename: "main.tf"},
+			},
+		},
+		{
+			Range: hcl.Range{Filename: "subdir/main.tf"},
+		},
+	}
+
+	if diff := cmp.Diff(expected, issues); diff != "" {
+		t.Fatal(diff)
+	}
+}


### PR DESCRIPTION
## Summary

Populate the worker directory as the filename for issues that have no source range when results are collected in recursive mode.

This keeps normal file-backed issues unchanged, but gives no-range diagnostics enough context to identify which recursive workspace produced them instead of rendering an empty filename as `on  line 0`.

Fixes #1790.

## Validation

- `gofmt -w cmd/inspect_parallel.go cmd/inspect_parallel_test.go`
- `go test ./cmd -run TestFillNoRangeIssueFilenames`
- `go test ./cmd`
- `git diff --check`