### PR TITLE
config: add ignorable rule setting

### DIFF
--- a/docs/user-guide/annotations.md
+++ b/docs/user-guide/annotations.md
@@ -2,6 +2,10 @@
 
 TFLint supports several comment annotations for suppressing issues for specific lines or files. Annotations can only suppress _issues_ emitted from fully valid, parseable Terraform modules. _Errors_ cannot be ignored.
 
+Rule configs can opt out of annotation-based suppression by setting
+`ignorable = false`. In that case, `tflint-ignore` and `tflint-ignore-file`
+annotations do not suppress issues from that rule.
+
 Annotation comments can disable rules on specific lines:
 
 ```hcl

--- a/docs/user-guide/config.md
+++ b/docs/user-guide/config.md
@@ -242,6 +242,17 @@ rule "aws_instance_previous_type" {
 }
 ```
 
+By default, annotations can suppress issues from a rule. Set `ignorable = false`
+to prevent `tflint-ignore` and `tflint-ignore-file` annotations from suppressing
+that rule:
+
+```hcl
+rule "aws_instance_previous_type" {
+  enabled   = true
+  ignorable = false
+}
+```
+
 Some rules support additional attributes that configure their behavior. See the documentation for each rule for details.
 
 ### `plugin` blocks

--- a/tflint/config.go
+++ b/tflint/config.go
@@ -114,9 +114,24 @@ type Config struct {
 
 // RuleConfig is a TFLint's rule config
 type RuleConfig struct {
-	Name    string   `hcl:"name,label"`
-	Enabled bool     `hcl:"enabled"`
-	Body    hcl.Body `hcl:",remain"`
+	Name      string   `hcl:"name,label"`
+	Enabled   bool     `hcl:"enabled"`
+	Ignorable *bool    `hcl:"ignorable,optional"`
+	Body      hcl.Body `hcl:",remain"`
+}
+
+func (r *RuleConfig) isIgnorable() bool {
+	if r == nil || r.Ignorable == nil {
+		return true
+	}
+	return *r.Ignorable
+}
+
+func (c *Config) ruleIsIgnorable(name string) bool {
+	if c == nil {
+		return true
+	}
+	return c.Rules[name].isIgnorable()
 }
 
 // PluginConfig is a TFLint's plugin config

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/terraform-linters/tflint/terraform"
 )
 
+func boolPtr(v bool) *bool {
+	return &v
+}
+
 func TestLoadConfig(t *testing.T) {
 	// default error check helper
 	neverHappend := func(err error) bool { return err != nil }
@@ -56,6 +60,7 @@ config {
 
 rule "aws_instance_invalid_type" {
 	enabled = false
+	ignorable = false
 }
 
 rule "aws_instance_previous_type" {
@@ -97,8 +102,9 @@ plugin "baz" {
 				FormatSet:         true,
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_type": {
-						Name:    "aws_instance_invalid_type",
-						Enabled: false,
+						Name:      "aws_instance_invalid_type",
+						Enabled:   false,
+						Ignorable: boolPtr(false),
 					},
 					"aws_instance_previous_type": {
 						Name:    "aws_instance_previous_type",
@@ -546,7 +552,8 @@ config {
   },
   "rule": {
     "aws_instance_invalid_type": {
-      "enabled": false
+      "enabled": false,
+      "ignorable": false
     },
     "aws_instance_previous_type": {
       "enabled": false,
@@ -588,8 +595,9 @@ config {
 				FormatSet:         true,
 				Rules: map[string]*RuleConfig{
 					"aws_instance_invalid_type": {
-						Name:    "aws_instance_invalid_type",
-						Enabled: false,
+						Name:      "aws_instance_invalid_type",
+						Enabled:   false,
+						Ignorable: boolPtr(false),
 					},
 					"aws_instance_previous_type": {
 						Name:    "aws_instance_previous_type",

--- a/tflint/runner.go
+++ b/tflint/runner.go
@@ -293,7 +293,7 @@ func (r *Runner) ClearChanges() {
 }
 
 func (r *Runner) emitIssue(issue *Issue) bool {
-	if annotations, ok := r.annotations[issue.Range.Filename]; ok {
+	if annotations, ok := r.annotations[issue.Range.Filename]; ok && r.config.ruleIsIgnorable(issue.Rule.Name()) {
 		for _, annotation := range annotations {
 			if annotation.IsAffected(issue) {
 				log.Printf("[INFO] %s (%s) is ignored by %s", issue.Range.String(), issue.Rule.Name(), annotation.String())

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -469,6 +469,7 @@ func Test_EmitIssue(t *testing.T) {
 		Location    hcl.Range
 		Fixable     bool
 		Annotations map[string]Annotations
+		Config      *Config
 		Module      *moduleConfig
 		Expected    Issues
 		Applied     bool
@@ -543,6 +544,94 @@ func Test_EmitIssue(t *testing.T) {
 			},
 			Expected: Issues{},
 			Applied:  false,
+		},
+		{
+			Name:    "ignore annotation is disabled by rule config",
+			Rule:    &testRule{},
+			Message: "This is test message",
+			Location: hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1},
+			},
+			Annotations: map[string]Annotations{
+				"test.tf": {
+					&LineAnnotation{
+						Content: "test_rule",
+						Token: hclsyntax.Token{
+							Type: hclsyntax.TokenComment,
+							Range: hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 1},
+							},
+						},
+					},
+				},
+			},
+			Config: &Config{
+				Rules: map[string]*RuleConfig{
+					"test_rule": {
+						Name:      "test_rule",
+						Enabled:   true,
+						Ignorable: boolPtr(false),
+					},
+				},
+			},
+			Expected: Issues{
+				{
+					Rule:    &testRule{},
+					Message: "This is test message",
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1},
+					},
+					Source: []byte("foo = 1"),
+				},
+			},
+			Applied: true,
+		},
+		{
+			Name:    "ignore file annotation is disabled by rule config",
+			Rule:    &testRule{},
+			Message: "This is test message",
+			Location: hcl.Range{
+				Filename: "test.tf",
+				Start:    hcl.Pos{Line: 1},
+			},
+			Annotations: map[string]Annotations{
+				"test.tf": {
+					&FileAnnotation{
+						Content: "test_rule",
+						Token: hclsyntax.Token{
+							Type: hclsyntax.TokenComment,
+							Range: hcl.Range{
+								Filename: "test.tf",
+								Start:    hcl.Pos{Line: 1},
+							},
+						},
+					},
+				},
+			},
+			Config: &Config{
+				Rules: map[string]*RuleConfig{
+					"test_rule": {
+						Name:      "test_rule",
+						Enabled:   true,
+						Ignorable: boolPtr(false),
+					},
+				},
+			},
+			Expected: Issues{
+				{
+					Rule:    &testRule{},
+					Message: "This is test message",
+					Range: hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1},
+					},
+					Source: []byte("foo = 1"),
+				},
+			},
+			Applied: true,
 		},
 		{
 			Name:    "module",
@@ -719,6 +808,9 @@ func Test_EmitIssue(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			runner := testRunnerWithAnnotations(t, sources, tc.Annotations)
+			if tc.Config != nil {
+				runner.config = tc.Config
+			}
 			if tc.Module != nil {
 				runner.TFConfig.Path = []string{"module", "module1"}
 				runner.currentExpr = tc.Module.currentExpr


### PR DESCRIPTION
Closes #2387.

## What changed

- Add an optional `ignorable` rule config attribute.
- Keep the default behavior unchanged: rules remain ignorable unless `ignorable = false` is set.
- Skip `tflint-ignore` and `tflint-ignore-file` annotation suppression for rules configured as unignorable.
- Document the new setting in the config and annotations user guides.

## Validation

- `gofmt -w tflint/config.go tflint/runner.go tflint/runner_test.go tflint/config_test.go`
- `go test ./tflint -run TestLoadConfig`
- `go test ./tflint -run Test_EmitIssue`
- `go test ./tflint ./cmd`
- `git diff --check`
