### PR TITLE
Fix variable reference for client-id in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: app-token
       with:
-        client-id: ${{ var.APP_CLIENT_ID }}
+        client-id: ${{ vars.APP_CLIENT_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
         owner: terraform-linters
         repositories: homebrew-tap


### PR DESCRIPTION
Follow up of https://github.com/terraform-linters/tflint/pull/2534

> [Invalid workflow file: .github/workflows/release.yml#L1](https://github.com/terraform-linters/tflint/actions/runs/25984014118/workflow)
(Line: 24, Col: 20): Unrecognized named-value: 'var'. Located at position 1 within expression: var.APP_CLIENT_ID

https://github.com/terraform-linters/tflint/actions/runs/25984014118