### PR TITLE
Refactor formatter dispatch into format adapters

### DIFF
--- a/formatter/checkstyle.go
+++ b/formatter/checkstyle.go
@@ -33,6 +33,14 @@ type checkstyle struct {
 	Files   []*checkstyleFile `xml:"file"`
 }
 
+type checkstyleFormat struct{}
+
+func (checkstyleFormat) print(f *Formatter, issues tflint.Issues, err error, sources map[string][]byte) {
+	f.checkstylePrint(issues, err, sources)
+}
+
+func (checkstyleFormat) buffersErrors() bool { return true }
+
 func (f *Formatter) checkstylePrint(issues tflint.Issues, appErr error, sources map[string][]byte) {
 	files := map[string]*checkstyleFile{}
 	for _, issue := range issues {
@@ -101,14 +109,18 @@ func (f *Formatter) checkstylePrint(issues tflint.Issues, appErr error, sources 
 
 func (f *Formatter) checkstyleErrors(err error) []*checkstyleError {
 	return mapErrors(err, errorMapper[*checkstyleError]{
-		diagnostic: func(diag *hcl.Diagnostic) *checkstyleError {
-			return &checkstyleError{
-				Source:   diag.Summary,
-				Line:     diag.Subject.Start.Line,
-				Column:   diag.Subject.Start.Column,
-				Severity: fromHclSeverity(diag.Severity),
-				Message:  diag.Detail,
+		diagnostics: func(_ error, diags hcl.Diagnostics) []*checkstyleError {
+			errors := make([]*checkstyleError, len(diags))
+			for i, diag := range diags {
+				errors[i] = &checkstyleError{
+					Source:   diag.Summary,
+					Line:     diag.Subject.Start.Line,
+					Column:   diag.Subject.Start.Column,
+					Severity: fromHclSeverity(diag.Severity),
+					Message:  diag.Detail,
+				}
 			}
+			return errors
 		},
 		error: func(err error) *checkstyleError {
 			return &checkstyleError{

--- a/formatter/checkstyle.go
+++ b/formatter/checkstyle.go
@@ -33,13 +33,11 @@ type checkstyle struct {
 	Files   []*checkstyleFile `xml:"file"`
 }
 
-type checkstyleFormat struct{}
+type checkstyleFormat struct{ bufferedFormat }
 
 func (checkstyleFormat) print(f *Formatter, issues tflint.Issues, err error, sources map[string][]byte) {
 	f.checkstylePrint(issues, err, sources)
 }
-
-func (checkstyleFormat) buffersErrors() bool { return true }
 
 func (f *Formatter) checkstylePrint(issues tflint.Issues, appErr error, sources map[string][]byte) {
 	files := map[string]*checkstyleFile{}

--- a/formatter/checkstyle.go
+++ b/formatter/checkstyle.go
@@ -21,6 +21,11 @@ type checkstyleError struct {
 
 	// Deprecated: Use `source` instead
 	Rule string `xml:"rule,attr"`
+
+	// filename groups the error under a <file>. It is unexported so it is not
+	// marshaled as an attribute; diagnostics carry their source file here while
+	// Source holds the summary.
+	filename string
 }
 
 type checkstyleFile struct {
@@ -64,7 +69,7 @@ func (f *Formatter) checkstylePrint(issues tflint.Issues, appErr error, sources 
 	}
 
 	for _, cherr := range f.checkstyleErrors(appErr) {
-		filename := cherr.Source
+		filename := cherr.filename
 		if filename == "" {
 			filename = applicationErrorSource
 		}
@@ -116,6 +121,7 @@ func (f *Formatter) checkstyleErrors(err error) []*checkstyleError {
 					Column:   diag.Subject.Start.Column,
 					Severity: fromHclSeverity(diag.Severity),
 					Message:  diag.Detail,
+					filename: diag.Subject.Filename,
 				}
 			}
 			return errors

--- a/formatter/checkstyle_test.go
+++ b/formatter/checkstyle_test.go
@@ -77,6 +77,28 @@ func Test_checkstylePrint(t *testing.T) {
   </file>
 </checkstyle>`,
 		},
+		{
+			Name:   "diagnostics group under the subject filename",
+			Issues: tflint.Issues{},
+			Error: hcl.Diagnostics{
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "summary",
+					Detail:   "detail",
+					Subject: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+			},
+			Stdout: `<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+  <file name="test.tf">
+    <error source="summary" line="1" column="1" severity="error" message="detail" link="" rule=""></error>
+  </file>
+</checkstyle>`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/formatter/compact.go
+++ b/formatter/compact.go
@@ -1,12 +1,19 @@
 package formatter
 
 import (
-	"errors"
 	"fmt"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/terraform-linters/tflint/tflint"
 )
+
+type compactFormat struct{}
+
+func (compactFormat) print(f *Formatter, issues tflint.Issues, err error, sources map[string][]byte) {
+	f.compactPrint(issues, err, sources)
+}
+
+func (compactFormat) buffersErrors() bool { return true }
 
 func (f *Formatter) compactPrint(issues tflint.Issues, appErr error, sources map[string][]byte) {
 	if len(issues) > 0 {
@@ -30,35 +37,25 @@ func (f *Formatter) compactPrint(issues tflint.Issues, appErr error, sources map
 }
 
 func (f *Formatter) compactPrintErrors(err error, sources map[string][]byte) {
-	if err == nil {
-		return
-	}
-
-	// errors.Join
-	if errs, ok := err.(interface{ Unwrap() []error }); ok {
-		for _, err := range errs.Unwrap() {
-			f.compactPrintErrors(err, sources)
-		}
-		return
-	}
-
-	// hcl.Diagnostics
-	var diags hcl.Diagnostics
-	if errors.As(err, &diags) {
-		for _, diag := range diags {
-			fmt.Fprintf(
-				f.Stdout,
-				"%s:%d:%d: %s - %s. %s\n",
-				diag.Subject.Filename,
-				diag.Subject.Start.Line,
-				diag.Subject.Start.Column,
-				fromHclSeverity(diag.Severity),
-				diag.Summary,
-				diag.Detail,
-			)
-		}
-		return
-	}
-
-	f.prettyPrintErrors(err, sources, false)
+	mapErrors(err, errorMapper[struct{}]{
+		diagnostics: func(_ error, diags hcl.Diagnostics) []struct{} {
+			for _, diag := range diags {
+				fmt.Fprintf(
+					f.Stdout,
+					"%s:%d:%d: %s - %s. %s\n",
+					diag.Subject.Filename,
+					diag.Subject.Start.Line,
+					diag.Subject.Start.Column,
+					fromHclSeverity(diag.Severity),
+					diag.Summary,
+					diag.Detail,
+				)
+			}
+			return nil
+		},
+		error: func(err error) struct{} {
+			f.prettyPrintErrors(err, sources, false)
+			return struct{}{}
+		},
+	})
 }

--- a/formatter/compact.go
+++ b/formatter/compact.go
@@ -7,13 +7,11 @@ import (
 	"github.com/terraform-linters/tflint/tflint"
 )
 
-type compactFormat struct{}
+type compactFormat struct{ bufferedFormat }
 
 func (compactFormat) print(f *Formatter, issues tflint.Issues, err error, sources map[string][]byte) {
 	f.compactPrint(issues, err, sources)
 }
-
-func (compactFormat) buffersErrors() bool { return true }
 
 func (f *Formatter) compactPrint(issues tflint.Issues, appErr error, sources map[string][]byte) {
 	if len(issues) > 0 {

--- a/formatter/errors.go
+++ b/formatter/errors.go
@@ -7,8 +7,8 @@ import (
 )
 
 type errorMapper[T any] struct {
-	diagnostic func(*hcl.Diagnostic) T
-	error      func(error) T
+	diagnostics func(error, hcl.Diagnostics) []T
+	error       func(error) T
 }
 
 func mapErrors[T any](err error, mapper errorMapper[T]) []T {
@@ -26,11 +26,7 @@ func mapErrors[T any](err error, mapper errorMapper[T]) []T {
 
 	var diags hcl.Diagnostics
 	if errors.As(err, &diags) {
-		results := make([]T, len(diags))
-		for i, diag := range diags {
-			results[i] = mapper.diagnostic(diag)
-		}
-		return results
+		return mapper.diagnostics(err, diags)
 	}
 
 	return []T{mapper.error(err)}

--- a/formatter/errors_test.go
+++ b/formatter/errors_test.go
@@ -72,8 +72,12 @@ func Test_mapErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			results := mapErrors(tt.err, errorMapper[string]{
-				diagnostic: func(diag *hcl.Diagnostic) string {
-					return fmt.Sprintf("diagnostic: %s - %s", diag.Summary, diag.Detail)
+				diagnostics: func(_ error, diags hcl.Diagnostics) []string {
+					mapped := make([]string, len(diags))
+					for i, diag := range diags {
+						mapped[i] = fmt.Sprintf("diagnostic: %s - %s", diag.Summary, diag.Detail)
+					}
+					return mapped
 				},
 				error: func(err error) string {
 					return fmt.Sprintf("error: %s", err.Error())

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -32,6 +32,12 @@ type format interface {
 	buffersErrors() bool
 }
 
+// bufferedFormat is embedded by formats that accumulate parallel errors and
+// print them at the end rather than in real time. Only pretty streams errors.
+type bufferedFormat struct{}
+
+func (bufferedFormat) buffersErrors() bool { return true }
+
 var formats = map[string]format{
 	"default":    prettyFormat{},
 	"json":       jsonFormat{},

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"slices"
 
 	hcl "github.com/hashicorp/hcl/v2"
 	sdk "github.com/terraform-linters/tflint-plugin-sdk/tflint"
@@ -26,24 +25,32 @@ type Formatter struct {
 	errInParallel error
 }
 
+// format is a per-format adapter owning how a format prints output and
+// whether it buffers parallel errors to the end instead of printing them in real time.
+type format interface {
+	print(f *Formatter, issues tflint.Issues, err error, sources map[string][]byte)
+	buffersErrors() bool
+}
+
+var formats = map[string]format{
+	"default":    prettyFormat{},
+	"json":       jsonFormat{},
+	"checkstyle": checkstyleFormat{},
+	"junit":      junitFormat{},
+	"compact":    compactFormat{},
+	"sarif":      sarifFormat{},
+}
+
+func (f *Formatter) resolveFormat() format {
+	if format, ok := formats[f.Format]; ok {
+		return format
+	}
+	return prettyFormat{} // unknown format falls back to pretty, matching today's default
+}
+
 // Print outputs the given issues and errors according to configured format
 func (f *Formatter) Print(issues tflint.Issues, err error, sources map[string][]byte) {
-	switch f.Format {
-	case "default":
-		f.prettyPrint(issues, err, sources)
-	case "json":
-		f.jsonPrint(issues, err)
-	case "checkstyle":
-		f.checkstylePrint(issues, err, sources)
-	case "junit":
-		f.junitPrint(issues, err, sources)
-	case "compact":
-		f.compactPrint(issues, err, sources)
-	case "sarif":
-		f.sarifPrint(issues, err)
-	default:
-		f.prettyPrint(issues, err, sources)
-	}
+	f.resolveFormat().print(f, issues, err, sources)
 }
 
 // PrintErrorParallel outputs an error occurred in parallel workers.
@@ -56,7 +63,7 @@ func (f *Formatter) PrintErrorParallel(err error, sources map[string][]byte) {
 		f.errInParallel = errors.Join(f.errInParallel, err)
 	}
 
-	if slices.Contains([]string{"json", "checkstyle", "junit", "compact", "sarif"}, f.Format) {
+	if f.resolveFormat().buffersErrors() {
 		// These formats require errors to be printed at the end, so do nothing here
 		return
 	}
@@ -69,7 +76,7 @@ func (f *Formatter) PrintErrorParallel(err error, sources map[string][]byte) {
 // Errors stored with PrintErrorParallel are output,
 // but in the default format they are output in real time, so they are ignored.
 func (f *Formatter) PrintParallel(issues tflint.Issues, sources map[string][]byte) error {
-	if slices.Contains([]string{"json", "checkstyle", "junit", "compact", "sarif"}, f.Format) {
+	if f.resolveFormat().buffersErrors() {
 		f.Print(issues, f.errInParallel, sources)
 		return f.errInParallel
 	}

--- a/formatter/formatter_test.go
+++ b/formatter/formatter_test.go
@@ -30,6 +30,72 @@ func (r *testRule) Link() string {
 	return "https://github.com"
 }
 
+func TestResolveFormat(t *testing.T) {
+	tests := []struct {
+		name          string
+		format        string
+		resolved      format
+		buffersErrors bool
+	}{
+		{
+			name:          "default",
+			format:        "default",
+			resolved:      prettyFormat{},
+			buffersErrors: false,
+		},
+		{
+			name:          "json",
+			format:        "json",
+			resolved:      jsonFormat{},
+			buffersErrors: true,
+		},
+		{
+			name:          "checkstyle",
+			format:        "checkstyle",
+			resolved:      checkstyleFormat{},
+			buffersErrors: true,
+		},
+		{
+			name:          "junit",
+			format:        "junit",
+			resolved:      junitFormat{},
+			buffersErrors: true,
+		},
+		{
+			name:          "compact",
+			format:        "compact",
+			resolved:      compactFormat{},
+			buffersErrors: true,
+		},
+		{
+			name:          "sarif",
+			format:        "sarif",
+			resolved:      sarifFormat{},
+			buffersErrors: true,
+		},
+		{
+			name:          "unknown format falls back to pretty",
+			format:        "unknown",
+			resolved:      prettyFormat{},
+			buffersErrors: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := &Formatter{Format: test.format}
+
+			resolved := f.resolveFormat()
+			if resolved != test.resolved {
+				t.Errorf("expected %T, got %T", test.resolved, resolved)
+			}
+			if buffers := resolved.buffersErrors(); buffers != test.buffersErrors {
+				t.Errorf("expected buffersErrors %t, got %t", test.buffersErrors, buffers)
+			}
+		})
+	}
+}
+
 func TestPrintErrorParallel(t *testing.T) {
 	// Disable color
 	color.NoColor = true

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -53,6 +53,14 @@ type JSONOutput struct {
 	Errors []JSONError `json:"errors"`
 }
 
+type jsonFormat struct{}
+
+func (jsonFormat) print(f *Formatter, issues tflint.Issues, err error, _ map[string][]byte) {
+	f.jsonPrint(issues, err)
+}
+
+func (jsonFormat) buffersErrors() bool { return true }
+
 func (f *Formatter) jsonPrint(issues tflint.Issues, appErr error) {
 	ret := &JSONOutput{Issues: make([]JSONIssue, len(issues)), Errors: f.jsonErrors(appErr)}
 
@@ -91,17 +99,21 @@ func (f *Formatter) jsonPrint(issues tflint.Issues, appErr error) {
 
 func (f *Formatter) jsonErrors(err error) []JSONError {
 	return mapErrors(err, errorMapper[JSONError]{
-		diagnostic: func(diag *hcl.Diagnostic) JSONError {
-			return JSONError{
-				Severity: fromHclSeverity(diag.Severity),
-				Summary:  diag.Summary,
-				Message:  diag.Detail,
-				Range: &JSONRange{
-					Filename: diag.Subject.Filename,
-					Start:    JSONPos{Line: diag.Subject.Start.Line, Column: diag.Subject.Start.Column},
-					End:      JSONPos{Line: diag.Subject.End.Line, Column: diag.Subject.End.Column},
-				},
+		diagnostics: func(_ error, diags hcl.Diagnostics) []JSONError {
+			errors := make([]JSONError, len(diags))
+			for i, diag := range diags {
+				errors[i] = JSONError{
+					Severity: fromHclSeverity(diag.Severity),
+					Summary:  diag.Summary,
+					Message:  diag.Detail,
+					Range: &JSONRange{
+						Filename: diag.Subject.Filename,
+						Start:    JSONPos{Line: diag.Subject.Start.Line, Column: diag.Subject.Start.Column},
+						End:      JSONPos{Line: diag.Subject.End.Line, Column: diag.Subject.End.Column},
+					},
+				}
 			}
+			return errors
 		},
 		error: func(err error) JSONError {
 			return JSONError{

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -53,13 +53,11 @@ type JSONOutput struct {
 	Errors []JSONError `json:"errors"`
 }
 
-type jsonFormat struct{}
+type jsonFormat struct{ bufferedFormat }
 
 func (jsonFormat) print(f *Formatter, issues tflint.Issues, err error, _ map[string][]byte) {
 	f.jsonPrint(issues, err)
 }
-
-func (jsonFormat) buffersErrors() bool { return true }
 
 func (f *Formatter) jsonPrint(issues tflint.Issues, appErr error) {
 	ret := &JSONOutput{Issues: make([]JSONIssue, len(issues)), Errors: f.jsonErrors(appErr)}

--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -12,13 +12,11 @@ import (
 
 // https://www.ibm.com/docs/en/developer-for-zos/14.1.0?topic=formats-junit-xml-format
 
-type junitFormat struct{}
+type junitFormat struct{ bufferedFormat }
 
 func (junitFormat) print(f *Formatter, issues tflint.Issues, err error, sources map[string][]byte) {
 	f.junitPrint(issues, err, sources)
 }
-
-func (junitFormat) buffersErrors() bool { return true }
 
 func (f *Formatter) junitPrint(issues tflint.Issues, appErr error, sources map[string][]byte) {
 	cases := make([]formatter.JUnitTestCase, len(issues))

--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -12,6 +12,14 @@ import (
 
 // https://www.ibm.com/docs/en/developer-for-zos/14.1.0?topic=formats-junit-xml-format
 
+type junitFormat struct{}
+
+func (junitFormat) print(f *Formatter, issues tflint.Issues, err error, sources map[string][]byte) {
+	f.junitPrint(issues, err, sources)
+}
+
+func (junitFormat) buffersErrors() bool { return true }
+
 func (f *Formatter) junitPrint(issues tflint.Issues, appErr error, sources map[string][]byte) {
 	cases := make([]formatter.JUnitTestCase, len(issues))
 
@@ -59,34 +67,38 @@ func (f *Formatter) junitPrint(issues tflint.Issues, appErr error, sources map[s
 
 func (f *Formatter) junitErrors(err error) []formatter.JUnitTestCase {
 	return mapErrors(err, errorMapper[formatter.JUnitTestCase]{
-		diagnostic: func(diag *hcl.Diagnostic) formatter.JUnitTestCase {
-			return formatter.JUnitTestCase{
-				Name:      diag.Summary,
-				Classname: diag.Subject.Filename,
-				Time:      "0",
-				Failure: &formatter.JUnitFailure{
-					Message: fmt.Sprintf("%s:%d,%d-%d,%d: %s",
-						diag.Subject.Filename,
-						diag.Subject.Start.Line,
-						diag.Subject.Start.Column,
-						diag.Subject.End.Line,
-						diag.Subject.End.Column,
-						diag.Detail,
-					),
-					Type: fromHclSeverity(diag.Severity),
-					Contents: fmt.Sprintf(
-						"%s: %s\nSummary: %s\nRange: %s:%d,%d-%d,%d",
-						fromHclSeverity(diag.Severity),
-						diag.Detail,
-						diag.Summary,
-						diag.Subject.Filename,
-						diag.Subject.Start.Line,
-						diag.Subject.Start.Column,
-						diag.Subject.End.Line,
-						diag.Subject.End.Column,
-					),
-				},
+		diagnostics: func(_ error, diags hcl.Diagnostics) []formatter.JUnitTestCase {
+			cases := make([]formatter.JUnitTestCase, len(diags))
+			for i, diag := range diags {
+				cases[i] = formatter.JUnitTestCase{
+					Name:      diag.Summary,
+					Classname: diag.Subject.Filename,
+					Time:      "0",
+					Failure: &formatter.JUnitFailure{
+						Message: fmt.Sprintf("%s:%d,%d-%d,%d: %s",
+							diag.Subject.Filename,
+							diag.Subject.Start.Line,
+							diag.Subject.Start.Column,
+							diag.Subject.End.Line,
+							diag.Subject.End.Column,
+							diag.Detail,
+						),
+						Type: fromHclSeverity(diag.Severity),
+						Contents: fmt.Sprintf(
+							"%s: %s\nSummary: %s\nRange: %s:%d,%d-%d,%d",
+							fromHclSeverity(diag.Severity),
+							diag.Detail,
+							diag.Summary,
+							diag.Subject.Filename,
+							diag.Subject.Start.Line,
+							diag.Subject.Start.Column,
+							diag.Subject.End.Line,
+							diag.Subject.End.Column,
+						),
+					},
+				}
 			}
+			return cases
 		},
 		error: func(err error) formatter.JUnitTestCase {
 			return formatter.JUnitTestCase{

--- a/formatter/pretty.go
+++ b/formatter/pretty.go
@@ -2,7 +2,6 @@ package formatter
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -19,6 +18,14 @@ var colorHighlight = color.New(color.Bold).Add(color.Underline).SprintFunc()
 var colorError = color.New(color.FgRed).SprintFunc()
 var colorWarning = color.New(color.FgYellow).SprintFunc()
 var colorNotice = color.New(color.FgHiWhite).SprintFunc()
+
+type prettyFormat struct{}
+
+func (prettyFormat) print(f *Formatter, issues tflint.Issues, err error, sources map[string][]byte) {
+	f.prettyPrint(issues, err, sources)
+}
+
+func (prettyFormat) buffersErrors() bool { return false }
 
 func (f *Formatter) prettyPrint(issues tflint.Issues, err error, sources map[string][]byte) {
 	if len(issues) > 0 {
@@ -103,33 +110,23 @@ func (f *Formatter) prettyPrintIssueWithSource(issue *tflint.Issue, sources map[
 }
 
 func (f *Formatter) prettyPrintErrors(err error, sources map[string][]byte, withIndent bool) {
-	if err == nil {
-		return
-	}
+	mapErrors(err, errorMapper[struct{}]{
+		diagnostics: func(err error, diags hcl.Diagnostics) []struct{} {
+			fmt.Fprintf(f.Stderr, "%s:\n\n", err)
 
-	// errors.Join
-	if errs, ok := err.(interface{ Unwrap() []error }); ok {
-		for _, err := range errs.Unwrap() {
-			f.prettyPrintErrors(err, sources, withIndent)
-		}
-		return
-	}
-
-	// hcl.Diagnostics
-	var diags hcl.Diagnostics
-	if errors.As(err, &diags) {
-		fmt.Fprintf(f.Stderr, "%s:\n\n", err)
-
-		writer := hcl.NewDiagnosticTextWriter(f.Stderr, parseSources(sources), 0, !f.NoColor)
-		_ = writer.WriteDiagnostics(diags)
-		return
-	}
-
-	if withIndent {
-		fmt.Fprintf(f.Stderr, "%s %s\n", colorError("│"), err)
-	} else {
-		fmt.Fprintf(f.Stderr, "%s\n", err)
-	}
+			writer := hcl.NewDiagnosticTextWriter(f.Stderr, parseSources(sources), 0, !f.NoColor)
+			_ = writer.WriteDiagnostics(diags)
+			return nil
+		},
+		error: func(err error) struct{} {
+			if withIndent {
+				fmt.Fprintf(f.Stderr, "%s %s\n", colorError("│"), err)
+			} else {
+				fmt.Fprintf(f.Stderr, "%s\n", err)
+			}
+			return struct{}{}
+		},
+	})
 }
 
 // PrettyPrintStderr outputs the given output to stderr with an indent.

--- a/formatter/pretty_test.go
+++ b/formatter/pretty_test.go
@@ -221,6 +221,35 @@ detail
 `, warningColor, resetColor, highlightColor, resetColor),
 		},
 		{
+			Name:   "wrapped diagnostics",
+			Issues: tflint.Issues{},
+			Error: fmt.Errorf("Failed to load the root module; %w", hcl.Diagnostics{
+				&hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  "summary",
+					Detail:   "detail",
+					Subject: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+			}),
+			Sources: map[string][]byte{
+				"test.tf": []byte("foo = 1"),
+			},
+			Stderr: fmt.Sprintf(`Failed to load the root module; test.tf:1,1-4: summary; detail:
+
+%sWarning%s: summary
+
+  on test.tf line 1:
+   1: %sfoo%s = 1
+
+detail
+
+`, warningColor, resetColor, highlightColor, resetColor),
+		},
+		{
 			Name:   "joined errors",
 			Issues: tflint.Issues{},
 			Error: errors.Join(

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -1,7 +1,6 @@
 package formatter
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -10,6 +9,14 @@ import (
 	sdk "github.com/terraform-linters/tflint-plugin-sdk/tflint"
 	"github.com/terraform-linters/tflint/tflint"
 )
+
+type sarifFormat struct{}
+
+func (sarifFormat) print(f *Formatter, issues tflint.Issues, err error, _ map[string][]byte) {
+	f.sarifPrint(issues, err)
+}
+
+func (sarifFormat) buffersErrors() bool { return true }
 
 func (f *Formatter) sarifPrint(issues tflint.Issues, appErr error) {
 	report, initErr := sarif.New(sarif.Version210)
@@ -79,47 +86,37 @@ func (f *Formatter) sarifPrint(issues tflint.Issues, appErr error) {
 }
 
 func (f *Formatter) sarifAddErrors(errRun *sarif.Run, err error) {
-	if err == nil {
-		return
-	}
+	mapErrors(err, errorMapper[struct{}]{
+		diagnostics: func(_ error, diags hcl.Diagnostics) []struct{} {
+			for _, diag := range diags {
+				rule := errRun.AddRule(diag.Summary).WithDescription("")
 
-	// errors.Join
-	if errs, ok := err.(interface{ Unwrap() []error }); ok {
-		for _, err := range errs.Unwrap() {
-			f.sarifAddErrors(errRun, err)
-		}
-		return
-	}
+				location := sarif.NewPhysicalLocation().
+					WithArtifactLocation(sarif.NewSimpleArtifactLocation(filepath.ToSlash(diag.Subject.Filename))).
+					WithRegion(
+						sarif.NewRegion().
+							WithByteOffset(diag.Subject.Start.Byte).
+							WithByteLength(diag.Subject.End.Byte - diag.Subject.Start.Byte).
+							WithStartLine(diag.Subject.Start.Line).
+							WithStartColumn(diag.Subject.Start.Column).
+							WithEndLine(diag.Subject.End.Line).
+							WithEndColumn(diag.Subject.End.Column),
+					)
 
-	// hcl.Diagnostics
-	var diags hcl.Diagnostics
-	if errors.As(err, &diags) {
-		for _, diag := range diags {
-			rule := errRun.AddRule(diag.Summary).WithDescription("")
-
-			location := sarif.NewPhysicalLocation().
-				WithArtifactLocation(sarif.NewSimpleArtifactLocation(filepath.ToSlash(diag.Subject.Filename))).
-				WithRegion(
-					sarif.NewRegion().
-						WithByteOffset(diag.Subject.Start.Byte).
-						WithByteLength(diag.Subject.End.Byte - diag.Subject.Start.Byte).
-						WithStartLine(diag.Subject.Start.Line).
-						WithStartColumn(diag.Subject.Start.Column).
-						WithEndLine(diag.Subject.End.Line).
-						WithEndColumn(diag.Subject.End.Column),
-				)
+				errRun.CreateResultForRule(rule.ID).
+					WithLevel(fromHclSeverity(diag.Severity)).
+					WithMessage(sarif.NewTextMessage(diag.Detail)).
+					AddLocation(sarif.NewLocationWithPhysicalLocation(location))
+			}
+			return nil
+		},
+		error: func(err error) struct{} {
+			rule := errRun.AddRule("application_error").WithDescription("")
 
 			errRun.CreateResultForRule(rule.ID).
-				WithLevel(fromHclSeverity(diag.Severity)).
-				WithMessage(sarif.NewTextMessage(diag.Detail)).
-				AddLocation(sarif.NewLocationWithPhysicalLocation(location))
-		}
-		return
-	}
-
-	rule := errRun.AddRule("application_error").WithDescription("")
-
-	errRun.CreateResultForRule(rule.ID).
-		WithLevel("error").
-		WithMessage(sarif.NewTextMessage(err.Error()))
+				WithLevel("error").
+				WithMessage(sarif.NewTextMessage(err.Error()))
+			return struct{}{}
+		},
+	})
 }

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -10,13 +10,11 @@ import (
 	"github.com/terraform-linters/tflint/tflint"
 )
 
-type sarifFormat struct{}
+type sarifFormat struct{ bufferedFormat }
 
 func (sarifFormat) print(f *Formatter, issues tflint.Issues, err error, _ map[string][]byte) {
 	f.sarifPrint(issues, err)
 }
-
-func (sarifFormat) buffersErrors() bool { return true }
 
 func (f *Formatter) sarifPrint(issues tflint.Issues, appErr error) {
 	report, initErr := sarif.New(sarif.Version210)


### PR DESCRIPTION
Replaces the `switch f.Format` dispatch in `formatter.go` with a small per-format adapter interface and a map registry, and routes every format's error unwrapping through the existing `mapErrors` helper so the `Unwrap() []error` + `errors.As(&diags)` walk lives in one place.

Before, adding a format meant editing `Print` plus two identical hardcoded `[]string{...}` slices that encoded "does this format buffer errors to the end?" a second and third time. Now each format handles that: an adapter declares `buffersErrors()`, and `PrintErrorParallel`/`PrintParallel` ask the adapter instead of matching format strings. A new format is one adapter struct plus one registry entry, with no switch to edit.

## Changes

- Adds a `format` interface (`print` + `buffersErrors()`) and a `formats` map registry in `formatter.go`. `resolveFormat()` falls back to `prettyFormat{}` for unknown formats, matching the old `default:` case. Both duplicated string slices and the `slices` import are gone.
- Each format file gains a zero-size adapter struct (`prettyFormat`, `jsonFormat`, etc.) delegating to its existing print method. Only `prettyFormat` returns `false` from `buffersErrors()`.
- Regroups `errorMapper` around the diagnostics group: the mapper now takes `diagnostics func(error, hcl.Diagnostics) []T` instead of a per-diagnostic `func(*hcl.Diagnostic) T`, so `mapErrors` hands the whole `hcl.Diagnostics` group to the format. This lets `pretty` (which renders a group as one header + one `WriteDiagnostics` call) fold into the shared walk losslessly.
- Converts `compact`, `sarif`, and `pretty` error printing to `mapErrors`, removing the hand-rolled unwrap walk from all three (and the now-unused `errors` import).

## Testing

- Adds `TestResolveFormat`, a table test covering all six formats' `resolveFormat()` and `buffersErrors()` plus the unknown→pretty fallback.
- `pretty`'s diagnostics header keeps using the matched (possibly wrapped) error rather than `diags.Error()`. `cmd/inspect.go` wraps every diagnostics error with a `%w` prefix (e.g. `Failed to load the root module; %w`), so using `diags.Error()` would have dropped that prefix from user-facing output in the default format. I added a `wrapped diagnostics` case to `pretty_test.go` to guard it, since existing tests only passed bare diagnostics, where the two coincide.
