### PR TITLE
Inline per-format print methods into their adapters

### DIFF
--- a/formatter/checkstyle.go
+++ b/formatter/checkstyle.go
@@ -40,11 +40,7 @@ type checkstyle struct {
 
 type checkstyleFormat struct{ bufferedFormat }
 
-func (checkstyleFormat) print(f *Formatter, issues tflint.Issues, err error, sources map[string][]byte) {
-	f.checkstylePrint(issues, err, sources)
-}
-
-func (f *Formatter) checkstylePrint(issues tflint.Issues, appErr error, sources map[string][]byte) {
+func (checkstyleFormat) print(f *Formatter, issues tflint.Issues, appErr error, _ map[string][]byte) {
 	files := map[string]*checkstyleFile{}
 	for _, issue := range issues {
 		cherr := &checkstyleError{

--- a/formatter/checkstyle_test.go
+++ b/formatter/checkstyle_test.go
@@ -105,9 +105,9 @@ func Test_checkstylePrint(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			stdout := &bytes.Buffer{}
 			stderr := &bytes.Buffer{}
-			formatter := &Formatter{Stdout: stdout, Stderr: stderr}
+			formatter := &Formatter{Stdout: stdout, Stderr: stderr, Format: "checkstyle"}
 
-			formatter.checkstylePrint(tc.Issues, tc.Error, map[string][]byte{})
+			formatter.Print(tc.Issues, tc.Error, map[string][]byte{})
 
 			if stdout.String() != tc.Stdout {
 				t.Fatalf("expected=%s, stdout=%s", tc.Stdout, stdout.String())

--- a/formatter/compact.go
+++ b/formatter/compact.go
@@ -9,11 +9,7 @@ import (
 
 type compactFormat struct{ bufferedFormat }
 
-func (compactFormat) print(f *Formatter, issues tflint.Issues, err error, sources map[string][]byte) {
-	f.compactPrint(issues, err, sources)
-}
-
-func (f *Formatter) compactPrint(issues tflint.Issues, appErr error, sources map[string][]byte) {
+func (compactFormat) print(f *Formatter, issues tflint.Issues, appErr error, sources map[string][]byte) {
 	if len(issues) > 0 {
 		fmt.Fprintf(f.Stdout, "%d issue(s) found:\n\n", len(issues))
 	}

--- a/formatter/compact_test.go
+++ b/formatter/compact_test.go
@@ -66,9 +66,9 @@ test.tf:1:1: Error - test (test_rule)
 	for _, tc := range cases {
 		stdout := &bytes.Buffer{}
 		stderr := &bytes.Buffer{}
-		formatter := &Formatter{Stdout: stdout, Stderr: stderr}
+		formatter := &Formatter{Stdout: stdout, Stderr: stderr, Format: "compact"}
 
-		formatter.compactPrint(tc.Issues, tc.Error, map[string][]byte{})
+		formatter.Print(tc.Issues, tc.Error, map[string][]byte{})
 
 		if stdout.String() != tc.Stdout {
 			t.Errorf("Failed %s test: expected=%s, stdout=%s", tc.Name, tc.Stdout, stdout.String())

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -55,11 +55,7 @@ type JSONOutput struct {
 
 type jsonFormat struct{ bufferedFormat }
 
-func (jsonFormat) print(f *Formatter, issues tflint.Issues, err error, _ map[string][]byte) {
-	f.jsonPrint(issues, err)
-}
-
-func (f *Formatter) jsonPrint(issues tflint.Issues, appErr error) {
+func (jsonFormat) print(f *Formatter, issues tflint.Issues, appErr error, _ map[string][]byte) {
 	ret := &JSONOutput{Issues: make([]JSONIssue, len(issues)), Errors: f.jsonErrors(appErr)}
 
 	for idx, issue := range issues.Sort() {

--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -14,11 +14,7 @@ import (
 
 type junitFormat struct{ bufferedFormat }
 
-func (junitFormat) print(f *Formatter, issues tflint.Issues, err error, sources map[string][]byte) {
-	f.junitPrint(issues, err, sources)
-}
-
-func (f *Formatter) junitPrint(issues tflint.Issues, appErr error, sources map[string][]byte) {
+func (junitFormat) print(f *Formatter, issues tflint.Issues, appErr error, _ map[string][]byte) {
 	cases := make([]formatter.JUnitTestCase, len(issues))
 
 	for i, issue := range issues.Sort() {

--- a/formatter/junit_test.go
+++ b/formatter/junit_test.go
@@ -96,9 +96,9 @@ func Test_junitPrint(t *testing.T) {
 	for _, tc := range cases {
 		stdout := &bytes.Buffer{}
 		stderr := &bytes.Buffer{}
-		formatter := &Formatter{Stdout: stdout, Stderr: stderr}
+		formatter := &Formatter{Stdout: stdout, Stderr: stderr, Format: "junit"}
 
-		formatter.junitPrint(tc.Issues, tc.Error, map[string][]byte{})
+		formatter.Print(tc.Issues, tc.Error, map[string][]byte{})
 
 		if stdout.String() != tc.Stdout {
 			t.Fatalf("%s: stdout did not match expected:\n%s", tc.Name, cmp.Diff(tc.Stdout, stdout.String()))

--- a/formatter/pretty.go
+++ b/formatter/pretty.go
@@ -21,13 +21,9 @@ var colorNotice = color.New(color.FgHiWhite).SprintFunc()
 
 type prettyFormat struct{}
 
-func (prettyFormat) print(f *Formatter, issues tflint.Issues, err error, sources map[string][]byte) {
-	f.prettyPrint(issues, err, sources)
-}
-
 func (prettyFormat) buffersErrors() bool { return false }
 
-func (f *Formatter) prettyPrint(issues tflint.Issues, err error, sources map[string][]byte) {
+func (prettyFormat) print(f *Formatter, issues tflint.Issues, err error, sources map[string][]byte) {
 	if len(issues) > 0 {
 		fmt.Fprintf(f.Stdout, "%d issue(s) found:\n\n", len(issues))
 

--- a/formatter/pretty_test.go
+++ b/formatter/pretty_test.go
@@ -290,9 +290,9 @@ detail
 		t.Run(tc.Name, func(t *testing.T) {
 			stdout := &bytes.Buffer{}
 			stderr := &bytes.Buffer{}
-			formatter := &Formatter{Stdout: stdout, Stderr: stderr, Fix: tc.Fix}
+			formatter := &Formatter{Stdout: stdout, Stderr: stderr, Format: "default", Fix: tc.Fix}
 
-			formatter.prettyPrint(tc.Issues, tc.Error, tc.Sources)
+			formatter.Print(tc.Issues, tc.Error, tc.Sources)
 
 			if stdout.String() != tc.Stdout {
 				t.Fatalf("expected=%s, stdout=%s", tc.Stdout, stdout.String())

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -12,11 +12,7 @@ import (
 
 type sarifFormat struct{ bufferedFormat }
 
-func (sarifFormat) print(f *Formatter, issues tflint.Issues, err error, _ map[string][]byte) {
-	f.sarifPrint(issues, err)
-}
-
-func (f *Formatter) sarifPrint(issues tflint.Issues, appErr error) {
+func (sarifFormat) print(f *Formatter, issues tflint.Issues, appErr error, _ map[string][]byte) {
 	report, initErr := sarif.New(sarif.Version210)
 	if initErr != nil {
 		panic(initErr)


### PR DESCRIPTION
Collapses each format adapter's `print` method and its `*Formatter.xxxPrint` counterpart into one method. After #2556 introduced the adapter interface, every adapter's `print` was a one-line wrapper delegating to `f.jsonPrint`/`f.sarifPrint`/etc., so the implementation lived one hop away from the interface method that called it. This moves each body directly onto the adapter's `print` and deletes the standalone method.

## Changes

- Removes the six `f.xxxPrint` methods (`jsonPrint`, `sarifPrint`, `junitPrint`, `compactPrint`, `checkstylePrint`, `prettyPrint`), inlining their bodies into the corresponding adapter `print` methods. `f` is now a parameter rather than a receiver; the bodies are otherwise unchanged.
- Formats that ignore `sources` (`json`, `sarif`, `junit`, `checkstyle`) take it as `_`; `compact` and `pretty` still use it.

## Testing

- `junit`, `compact`, `checkstyle`, and `pretty` tests called the now-deleted `f.xxxPrint` methods directly. I switched them to `formatter.Print(...)` with `Format` set, matching how the `json` and `sarif` tests already drive output. This also exercises the real dispatch path. Golden output is unchanged.

## References

Follow-up to #2556.
