### PR TITLE
formatter: guard diagnostics with no source range

### DIFF
--- a/formatter/checkstyle.go
+++ b/formatter/checkstyle.go
@@ -111,13 +111,14 @@ func (f *Formatter) checkstyleErrors(err error) []*checkstyleError {
 		diagnostics: func(_ error, diags hcl.Diagnostics) []*checkstyleError {
 			errors := make([]*checkstyleError, len(diags))
 			for i, diag := range diags {
+				rng := diagRange(diag)
 				errors[i] = &checkstyleError{
 					Source:   diag.Summary,
-					Line:     diag.Subject.Start.Line,
-					Column:   diag.Subject.Start.Column,
+					Line:     rng.Start.Line,
+					Column:   rng.Start.Column,
 					Severity: fromHclSeverity(diag.Severity),
 					Message:  diag.Detail,
-					filename: diag.Subject.Filename,
+					filename: rng.Filename,
 				}
 			}
 			return errors

--- a/formatter/checkstyle_test.go
+++ b/formatter/checkstyle_test.go
@@ -99,6 +99,24 @@ func Test_checkstylePrint(t *testing.T) {
   </file>
 </checkstyle>`,
 		},
+		{
+			Name:   "diagnostics without subject group under the application source",
+			Issues: tflint.Issues{},
+			Error: hcl.Diagnostics{
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "summary",
+					Detail:   "detail",
+					Subject:  nil,
+				},
+			},
+			Stdout: `<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle>
+  <file name="(application)">
+    <error source="summary" line="0" column="0" severity="error" message="detail" link="" rule=""></error>
+  </file>
+</checkstyle>`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/formatter/compact.go
+++ b/formatter/compact.go
@@ -34,12 +34,13 @@ func (f *Formatter) compactPrintErrors(err error, sources map[string][]byte) {
 	mapErrors(err, errorMapper[struct{}]{
 		diagnostics: func(_ error, diags hcl.Diagnostics) []struct{} {
 			for _, diag := range diags {
+				rng := diagRange(diag)
 				fmt.Fprintf(
 					f.Stdout,
 					"%s:%d:%d: %s - %s. %s\n",
-					diag.Subject.Filename,
-					diag.Subject.Start.Line,
-					diag.Subject.Start.Column,
+					rng.Filename,
+					rng.Start.Line,
+					rng.Start.Column,
 					fromHclSeverity(diag.Severity),
 					diag.Summary,
 					diag.Detail,

--- a/formatter/compact_test.go
+++ b/formatter/compact_test.go
@@ -52,6 +52,18 @@ test.tf:1:1: Error - test (test_rule)
 			Stdout: "main.tf:1:22: error - Unclosed configuration block. There is no closing brace for this block before the end of the file. This may be caused by incorrect brace nesting elsewhere in this file.\n",
 		},
 		{
+			Name: "diagnostics without subject",
+			Error: hcl.Diagnostics{
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "summary",
+					Detail:   "detail",
+					Subject:  nil,
+				},
+			},
+			Stdout: ":0:0: error - summary. detail\n",
+		},
+		{
 			Name: "joined errors",
 			Error: errors.Join(
 				errors.New("an error occurred"),

--- a/formatter/errors.go
+++ b/formatter/errors.go
@@ -11,6 +11,16 @@ type errorMapper[T any] struct {
 	error       func(error) T
 }
 
+// diagRange returns the diagnostic's source range. hcl permits a nil Subject
+// ("some diagnostics have no source ranges at all"), in which case a zero range
+// is returned so formatters can render it without dereferencing nil.
+func diagRange(diag *hcl.Diagnostic) hcl.Range {
+	if diag.Subject == nil {
+		return hcl.Range{}
+	}
+	return *diag.Subject
+}
+
 func mapErrors[T any](err error, mapper errorMapper[T]) []T {
 	if err == nil {
 		return []T{}

--- a/formatter/json.go
+++ b/formatter/json.go
@@ -100,11 +100,15 @@ func (f *Formatter) jsonErrors(err error) []JSONError {
 					Severity: fromHclSeverity(diag.Severity),
 					Summary:  diag.Summary,
 					Message:  diag.Detail,
-					Range: &JSONRange{
+				}
+				// hcl permits a nil Subject. Omit the range in that case;
+				// JSONError.Range is a pointer with omitempty for this reason.
+				if diag.Subject != nil {
+					errors[i].Range = &JSONRange{
 						Filename: diag.Subject.Filename,
 						Start:    JSONPos{Line: diag.Subject.Start.Line, Column: diag.Subject.Start.Column},
 						End:      JSONPos{Line: diag.Subject.End.Line, Column: diag.Subject.End.Column},
-					},
+					}
 				}
 			}
 			return errors

--- a/formatter/json_test.go
+++ b/formatter/json_test.go
@@ -99,6 +99,18 @@ func Test_jsonPrint(t *testing.T) {
 			Stdout: `{"issues":[],"errors":[{"summary":"summary","message":"detail","severity":"warning","range":{"filename":"filename","start":{"line":1,"column":1},"end":{"line":5,"column":1}}}]}`,
 		},
 		{
+			Name: "diagnostics without subject",
+			Error: hcl.Diagnostics{
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "summary",
+					Detail:   "detail",
+					Subject:  nil,
+				},
+			},
+			Stdout: `{"issues":[],"errors":[{"summary":"summary","message":"detail","severity":"error"}]}`,
+		},
+		{
 			Name: "joined errors",
 			Error: errors.Join(
 				errors.New("an error occurred"),

--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -65,17 +65,18 @@ func (f *Formatter) junitErrors(err error) []formatter.JUnitTestCase {
 		diagnostics: func(_ error, diags hcl.Diagnostics) []formatter.JUnitTestCase {
 			cases := make([]formatter.JUnitTestCase, len(diags))
 			for i, diag := range diags {
+				rng := diagRange(diag)
 				cases[i] = formatter.JUnitTestCase{
 					Name:      diag.Summary,
-					Classname: diag.Subject.Filename,
+					Classname: rng.Filename,
 					Time:      "0",
 					Failure: &formatter.JUnitFailure{
 						Message: fmt.Sprintf("%s:%d,%d-%d,%d: %s",
-							diag.Subject.Filename,
-							diag.Subject.Start.Line,
-							diag.Subject.Start.Column,
-							diag.Subject.End.Line,
-							diag.Subject.End.Column,
+							rng.Filename,
+							rng.Start.Line,
+							rng.Start.Column,
+							rng.End.Line,
+							rng.End.Column,
 							diag.Detail,
 						),
 						Type: fromHclSeverity(diag.Severity),
@@ -84,11 +85,11 @@ func (f *Formatter) junitErrors(err error) []formatter.JUnitTestCase {
 							fromHclSeverity(diag.Severity),
 							diag.Detail,
 							diag.Summary,
-							diag.Subject.Filename,
-							diag.Subject.Start.Line,
-							diag.Subject.Start.Column,
-							diag.Subject.End.Line,
-							diag.Subject.End.Column,
+							rng.Filename,
+							rng.Start.Line,
+							rng.Start.Column,
+							rng.End.Line,
+							rng.End.Column,
 						),
 					},
 				}

--- a/formatter/junit_test.go
+++ b/formatter/junit_test.go
@@ -126,6 +126,26 @@ func Test_junitPrint(t *testing.T) {
   </testsuite>
 </testsuites>`,
 		},
+		{
+			Name: "diagnostics without subject",
+			Error: hcl.Diagnostics{
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "summary",
+					Detail:   "detail",
+					Subject:  nil,
+				},
+			},
+			Stdout: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite tests="1" failures="1" time="0" name="">
+    <properties></properties>
+    <testcase classname="" name="summary" time="0">
+      <failure message=":0,0-0,0: detail" type="error">error: detail&#xA;Summary: summary&#xA;Range: :0,0-0,0</failure>
+    </testcase>
+  </testsuite>
+</testsuites>`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/formatter/sarif.go
+++ b/formatter/sarif.go
@@ -85,22 +85,27 @@ func (f *Formatter) sarifAddErrors(errRun *sarif.Run, err error) {
 			for _, diag := range diags {
 				rule := errRun.AddRule(diag.Summary).WithDescription("")
 
-				location := sarif.NewPhysicalLocation().
-					WithArtifactLocation(sarif.NewSimpleArtifactLocation(filepath.ToSlash(diag.Subject.Filename))).
-					WithRegion(
-						sarif.NewRegion().
-							WithByteOffset(diag.Subject.Start.Byte).
-							WithByteLength(diag.Subject.End.Byte - diag.Subject.Start.Byte).
-							WithStartLine(diag.Subject.Start.Line).
-							WithStartColumn(diag.Subject.Start.Column).
-							WithEndLine(diag.Subject.End.Line).
-							WithEndColumn(diag.Subject.End.Column),
-					)
-
-				errRun.CreateResultForRule(rule.ID).
+				result := errRun.CreateResultForRule(rule.ID).
 					WithLevel(fromHclSeverity(diag.Severity)).
-					WithMessage(sarif.NewTextMessage(diag.Detail)).
-					AddLocation(sarif.NewLocationWithPhysicalLocation(location))
+					WithMessage(sarif.NewTextMessage(diag.Detail))
+
+				// hcl permits a nil Subject. Emit the result without a location
+				// in that case, mirroring how issues without a source are handled.
+				if diag.Subject != nil {
+					location := sarif.NewPhysicalLocation().
+						WithArtifactLocation(sarif.NewSimpleArtifactLocation(filepath.ToSlash(diag.Subject.Filename))).
+						WithRegion(
+							sarif.NewRegion().
+								WithByteOffset(diag.Subject.Start.Byte).
+								WithByteLength(diag.Subject.End.Byte - diag.Subject.Start.Byte).
+								WithStartLine(diag.Subject.Start.Line).
+								WithStartColumn(diag.Subject.Start.Column).
+								WithEndLine(diag.Subject.End.Line).
+								WithEndColumn(diag.Subject.End.Column),
+						)
+
+					result.AddLocation(sarif.NewLocationWithPhysicalLocation(location))
+				}
 			}
 			return nil
 		},

--- a/formatter/sarif_test.go
+++ b/formatter/sarif_test.go
@@ -613,6 +613,61 @@ func Test_sarifPrint(t *testing.T) {
   ]
 }`, tflint.Version, tflint.Version),
 		},
+		{
+			Name: "HCL diagnostics without a subject omit the location",
+			Error: hcl.Diagnostics{
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "summary",
+					Detail:   "detail",
+					Subject:  nil,
+				},
+			},
+			Stdout: fmt.Sprintf(`{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/terraform-linters/tflint",
+          "name": "tflint",
+          "rules": [],
+          "version": "%s"
+        }
+      },
+      "results": []
+    },
+    {
+      "tool": {
+        "driver": {
+          "informationUri": "https://github.com/terraform-linters/tflint",
+          "name": "tflint-errors",
+          "rules": [
+            {
+              "id": "summary",
+              "shortDescription": {
+                "text": ""
+              }
+            }
+          ],
+          "version": "%s"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "summary",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "detail"
+          }
+        }
+      ]
+    }
+  ]
+}`, tflint.Version, tflint.Version),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Guards every formatter against an `hcl.Diagnostic` with a nil `Subject`. The JSON, SARIF, JUnit, Checkstyle, and Compact formatters all dereferenced `diag.Subject` unconditionally when rendering an `hcl.Diagnostics` error, so a diagnostic without a source range crashes the process with a nil pointer panic. HCL documents `Subject` as optional ("some diagnostics have no source ranges at all").

I couldn't reach this from current CLI input: every host-side diagnostic producer sets `Subject`, and plugin diagnostics cross the gRPC boundary as plain strings rather than `hcl.Diagnostics`. So this is hardening against a documented-nullable field, not a fix for a live crash. The SDK's own `hclext` decode does emit nil-`Subject` diagnostics ("Missing attribute/block"), so a future path that surfaces those host-side would hit it.

## Changes

- Adds a `diagRange` helper in `errors.go` that returns a zero `hcl.Range` when `Subject` is nil.
- `json.go` omits the range when `Subject` is nil. `JSONError.Range` is already a pointer with `omitempty` for this.
- `checkstyle.go`, `junit.go`, and `compact.go` render through `diagRange`, so a missing subject yields an empty filename and zero line/column, matching how those formats already render empty issue ranges.
- `sarif.go` emits the result without a location when `Subject` is nil, mirroring the issue path that already attaches locations conditionally.

The non-nil path is byte-for-byte unchanged in every format. The default (pretty) format was already safe because HCL's `DiagnosticTextWriter` handles a nil `Subject`.

## Testing

Adds a nil-`Subject` case to each format's table test (`json`, `sarif`, `junit`, `checkstyle`, `compact`). Each case panics on `master` and passes here.
