### PR TITLE
docs: add Go install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ WinGet (Windows):
 winget install -e --id TerraformLinters.tflint
 ```
 
+Go:
+
+```console
+go install github.com/terraform-linters/tflint@latest
+```
+
 ### Verification
 
 #### GitHub CLI (Recommended)


### PR DESCRIPTION
## what and why

- Add a brief Go install example to the installation section of the README.
- Improve user experience and tool installation
