### PR TITLE
cmd: bound per-runner check concurrency

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -146,26 +146,16 @@ By setting TFLINT_LOG=trace, you can confirm the changes made by the autofix and
 			if err := ruleset.Check(plugin.NewGRPCServer(rootRunner, rootRunner, cli.loader.Files(), sdkVersions[name])); err != nil {
 				return issues, changes, fmt.Errorf("Failed to check ruleset; %w", err)
 			}
-			// Run checks for module calls are performed in parallel.
+			// Checks for module calls run in parallel, bounded by runnerWorkers
+			// (the --max-workers value, or 1 with --no-parallel-runners).
 			// The rootRunner is shared between goroutines but read-only, so this is goroutine-safe.
 			// Note that checks against the rootRunner are not parallelized, as autofix may cause the module to be rebuilt.
-			ch := make(chan error, len(moduleRunners))
-			for _, runner := range moduleRunners {
-				if opts.NoParallelRunners {
-					ch <- ruleset.Check(plugin.NewGRPCServer(runner, rootRunner, cli.loader.Files(), sdkVersions[name]))
-				} else {
-					go func(runner *tflint.Runner) {
-						ch <- ruleset.Check(plugin.NewGRPCServer(runner, rootRunner, cli.loader.Files(), sdkVersions[name]))
-					}(runner)
-				}
+			err = checkRunners(moduleRunners, opts.runnerWorkers(), func(runner *tflint.Runner) error {
+				return ruleset.Check(plugin.NewGRPCServer(runner, rootRunner, cli.loader.Files(), sdkVersions[name]))
+			})
+			if err != nil {
+				return issues, changes, fmt.Errorf("Failed to check ruleset; %w", err)
 			}
-			for range moduleRunners {
-				err = <-ch
-				if err != nil {
-					return issues, changes, fmt.Errorf("Failed to check ruleset; %w", err)
-				}
-			}
-			close(ch)
 		}
 
 		changesInAttempt := map[string][]byte{}
@@ -194,6 +184,30 @@ By setting TFLINT_LOG=trace, you can confirm the changes made by the autofix and
 	maps.Copy(cli.sources, cli.loader.Sources())
 
 	return issues, changes, nil
+}
+
+// checkRunners runs check for each runner concurrently, bounding the number of
+// simultaneous calls to workers. It waits for all checks to finish and returns
+// the first error reported, if any. workers must be at least 1.
+func checkRunners(runners []*tflint.Runner, workers int, check func(*tflint.Runner) error) error {
+	ch := make(chan error, len(runners))
+	sem := make(chan struct{}, workers)
+	for _, runner := range runners {
+		sem <- struct{}{}
+		go func(runner *tflint.Runner) {
+			defer func() { <-sem }()
+			ch <- check(runner)
+		}(runner)
+	}
+
+	var firstErr error
+	for range runners {
+		if err := <-ch; err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	close(ch)
+	return firstErr
 }
 
 func launchPlugins(config *tflint.Config, fix bool) (*plugin.Plugin, error) {

--- a/cmd/inspect_parallel.go
+++ b/cmd/inspect_parallel.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"runtime"
 	"sync"
 	"time"
 
@@ -126,15 +125,8 @@ func spawnWorkers(ctx context.Context, workingDirs []string, opts Options) (<-ch
 		return nil, err
 	}
 
-	maxWorkers := runtime.NumCPU()
-	if opts.MaxWorkers != nil {
-		if c := *opts.MaxWorkers; c > 0 {
-			maxWorkers = c
-		}
-	}
-
 	ch := make(chan worker)
-	semaphore := make(chan struct{}, maxWorkers)
+	semaphore := make(chan struct{}, opts.maxWorkers())
 
 	go func() {
 		defer close(ch)

--- a/cmd/inspect_test.go
+++ b/cmd/inspect_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_checkRunners_boundsConcurrency(t *testing.T) {
+	cases := []struct {
+		name    string
+		runners int
+		workers int
+		// wantPeak is the expected number of checks in flight at once:
+		// min(workers, runners).
+		wantPeak int32
+	}{
+		{name: "serial", runners: 8, workers: 1, wantPeak: 1},
+		{name: "bounded below runner count", runners: 12, workers: 3, wantPeak: 3},
+		{name: "workers exceed runner count", runners: 2, workers: 8, wantPeak: 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runners := make([]*tflint.Runner, tc.runners)
+
+			var inflight, max int32
+			proceed := make(chan struct{})
+			done := make(chan error, 1)
+
+			go func() {
+				done <- checkRunners(runners, tc.workers, func(*tflint.Runner) error {
+					cur := atomic.AddInt32(&inflight, 1)
+					for {
+						old := atomic.LoadInt32(&max)
+						if cur <= old || atomic.CompareAndSwapInt32(&max, old, cur) {
+							break
+						}
+					}
+					<-proceed
+					atomic.AddInt32(&inflight, -1)
+					return nil
+				})
+			}()
+
+			// Wait until the expected number of checks are simultaneously in
+			// flight. An unbounded implementation would blow past wantPeak here.
+			deadline := time.After(2 * time.Second)
+			for atomic.LoadInt32(&inflight) < tc.wantPeak {
+				select {
+				case <-deadline:
+					t.Fatalf("only %d checks became in-flight, expected %d", atomic.LoadInt32(&inflight), tc.wantPeak)
+				default:
+					time.Sleep(time.Millisecond)
+				}
+			}
+			// Give any unbounded extra goroutines a window to start before sampling.
+			time.Sleep(20 * time.Millisecond)
+			peak := atomic.LoadInt32(&inflight)
+			close(proceed)
+
+			if err := <-done; err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if peak > int32(tc.workers) {
+				t.Fatalf("expected at most %d concurrent checks, observed %d", tc.workers, peak)
+			}
+			if max > int32(tc.workers) {
+				t.Fatalf("expected peak concurrency to stay within %d, observed %d", tc.workers, max)
+			}
+		})
+	}
+}
+
+func Test_checkRunners_returnsFirstError(t *testing.T) {
+	runners := make([]*tflint.Runner, 5)
+	wantErr := errors.New("boom")
+
+	var calls int32
+	err := checkRunners(runners, 2, func(*tflint.Runner) error {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return wantErr
+		}
+		return nil
+	})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+	// Every runner is still drained even after an error.
+	if got := atomic.LoadInt32(&calls); got != int32(len(runners)) {
+		t.Fatalf("expected all %d runners to be checked, got %d", len(runners), got)
+	}
+}
+
+func Test_Options_runnerWorkers(t *testing.T) {
+	workers2 := 2
+	workersZero := 0
+
+	cases := []struct {
+		name string
+		opts Options
+		want int
+	}{
+		{name: "no-parallel-runners forces serial", opts: Options{NoParallelRunners: true}, want: 1},
+		{name: "no-parallel-runners wins over max-workers", opts: Options{NoParallelRunners: true, MaxWorkers: &workers2}, want: 1},
+		{name: "max-workers sets the bound", opts: Options{MaxWorkers: &workers2}, want: 2},
+		// A non-positive max-workers falls back to the CPU count.
+		{name: "non-positive max-workers falls back to NumCPU", opts: Options{MaxWorkers: &workersZero}, want: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := tc.want
+			if want == 0 {
+				want = tc.opts.maxWorkers()
+			}
+			if got := tc.opts.runnerWorkers(); got != want {
+				t.Fatalf("expected runnerWorkers to return %d, got %d", want, got)
+			}
+		})
+	}
+}

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"runtime"
 	"strings"
 
 	"github.com/terraform-linters/tflint/terraform"
@@ -33,9 +34,29 @@ type Options struct {
 	NoColor                bool     `long:"no-color" description:"Disable colorized output"`
 	Fix                    bool     `long:"fix" description:"Fix issues automatically"`
 	NoParallelRunners      bool     `long:"no-parallel-runners" description:"Disable per-runner parallelism"`
-	MaxWorkers             *int     `long:"max-workers" description:"Set maximum number of workers in recursive inspection (default: number of CPUs)" value-name:"N"`
+	MaxWorkers             *int     `long:"max-workers" description:"Set maximum number of workers for parallel inspection, across both directories and per-runner checks (default: number of CPUs)" value-name:"N"`
 	ActAsBundledPlugin     bool     `long:"act-as-bundled-plugin" hidden:"true"`
 	ActAsWorker            bool     `long:"act-as-worker" hidden:"true"`
+}
+
+// maxWorkers returns the configured worker count for parallel inspection.
+// It defaults to the number of CPUs and is overridden by --max-workers.
+func (opts *Options) maxWorkers() int {
+	if opts.MaxWorkers != nil {
+		if c := *opts.MaxWorkers; c > 0 {
+			return c
+		}
+	}
+	return runtime.NumCPU()
+}
+
+// runnerWorkers returns the maximum number of module runners checked
+// concurrently. --no-parallel-runners forces serial execution.
+func (opts *Options) runnerWorkers() int {
+	if opts.NoParallelRunners {
+		return 1
+	}
+	return opts.maxWorkers()
 }
 
 func (opts *Options) toConfig() *tflint.Config {


### PR DESCRIPTION
## Summary

Per-runner check parallelism had no concurrency limit. tflint runs each ruleset's `Check` once per runner (the root module plus one runner per module call), and dispatched the module-call checks as one goroutine each with no bound. The only control was the boolean `--no-parallel-runners`, which turns the fan-out fully off. `--max-workers` did not apply. A configuration with many module calls therefore ran that many plugin `Check` RPCs at once, and the only way to reduce the load was to serialize every runner.

This bounds the per-runner fan-out by the `--max-workers` value (default: number of CPUs), so parallelism has a ceiling instead of an on/off switch.

## Motivation

`Check` is plugin code, and a plugin may do network or other rate-limited work per runner. When it does, unbounded fan-out becomes a load problem rather than a speedup.

This surfaced in terraform-linters/tflint-ruleset-aws#1113. With `deep_check` and ~60 `provider "aws"` instances, each runner opened many concurrent STS connections, and the runner count multiplied that into a connection storm that exhausted DNS and sockets. `--max-workers` had no effect. Only `--no-parallel-runners` avoided the errors, at a large speed cost. The plugin side now caches clients across runners tflint-ruleset-aws#1114, but the core fan-out stayed unbounded for any plugin that does per-runner work.

Two existing reports look like the same unbounded concurrency from other angles:

- #2094: sporadic false `circular reference found` errors under parallel runners, gone with `--no-parallel-runners`.
- #2544: `timeout waiting for connection info` under heavy load, with `--no-parallel-runners` tried as a workaround.

## Change

The per-runner loop in `inspectModule` now acquires from a semaphore sized by a worker count before launching each check. The worker count comes from `runnerWorkers()`: `--max-workers` when set, otherwise the CPU count, or 1 under `--no-parallel-runners`. The old `NoParallelRunners` branch collapses into the N=1 case of the same path.

The `--max-workers` resolution that recursive inspection already used moves to a shared `Options.maxWorkers()`, so one definition now governs concurrency on both paths. The flag description now says it bounds both directory and per-runner workers.

`--no-parallel-runners` is unchanged in behavior: it still forces fully serial checks.

### Flag

This reuses `--max-workers` rather than adding a flag, so a single, familiar control governs concurrency everywhere. If per-directory and per-runner concurrency turn out to need independent tuning, a dedicated flag (for example `--max-runner-workers`) could be layered on later without changing this default.

One interaction to note: under `--recursive`, `--max-workers` already bounds the directory subprocess pool, and it is not currently propagated to those subprocesses. So each subprocess resolves its own per-runner bound, and the effective ceiling is roughly `--max-workers` directories times `--max-workers` runners. That is bounded and far below today's unbounded fan-out, but we could also propagate the value to workers.

## Testing

`Test_checkRunners_boundsConcurrency` blocks the checks mid-flight and samples the peak number running at once, asserting it never exceeds the worker count across serial, bounded, and worker-heavy cases. An unbounded implementation fails it. `Test_checkRunners_returnsFirstError` confirms the first error surfaces and every runner is still drained. `Test_Options_runnerWorkers` covers the worker-count resolution, including `--no-parallel-runners` overriding `--max-workers`.

## Origin

Per-runner parallelism landed in #1944 and the recursive `--max-workers` pool in #2021. This reconciles the two so one concurrency model covers both paths.
