### PR TITLE
cmd: add per-runner concurrency benchmark harness and baseline

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,63 @@
+name: benchmark
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'go.mod'
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+      - name: Benchmark HEAD
+        run: |
+          make bench
+          cp bench.txt head.txt
+      - name: Benchmark base
+        # The base branch may not contain the benchmarks yet (e.g. the PR that
+        # introduces them). A missing or empty base result falls back to showing
+        # the HEAD numbers alone, so this step must never fail the job.
+        continue-on-error: true
+        run: |
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$base_sha" ]; then
+            exit 0
+          fi
+          git worktree add ../base "$base_sha"
+          make -C ../base bench
+          cp ../base/bench.txt base.txt
+      - name: Compare
+        run: |
+          {
+            echo '## Benchmarks'
+            echo
+            if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
+              echo "Base: \`${{ github.event.pull_request.base.sha }}\`"
+            fi
+            echo "HEAD: \`${{ github.sha }}\`"
+            echo
+            echo '```'
+            if [ -s base.txt ] && grep -q '^Benchmark' base.txt; then
+              benchstat base.txt head.txt
+            else
+              echo '(no benchmarks on the base ref; showing HEAD results only)'
+              echo
+              benchstat head.txt
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.test
 /vendor
 /dist
+/bench.txt
 tflint-ruleset-*
 !tflint-ruleset-*/

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ e2e: prepare install
 e2e-race: prepare
 	go test --race --timeout 5m ./integrationtest/race
 
+bench:
+	go test -timeout 30m -run='^$$' -bench=. -benchmem -count=10 ./cmd/... | tee bench.txt
+
 lint:
 	golangci-lint run ./...
 	cd terraform/ && golangci-lint run ./...
@@ -34,4 +37,4 @@ generate:
 release:
 	go run ./tools/release/main.go
 
-.PHONY: prepare test build install e2e lint clean generate
+.PHONY: prepare test build install e2e e2e-race bench lint clean generate

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -149,23 +149,12 @@ By setting TFLINT_LOG=trace, you can confirm the changes made by the autofix and
 			// Run checks for module calls are performed in parallel.
 			// The rootRunner is shared between goroutines but read-only, so this is goroutine-safe.
 			// Note that checks against the rootRunner are not parallelized, as autofix may cause the module to be rebuilt.
-			ch := make(chan error, len(moduleRunners))
-			for _, runner := range moduleRunners {
-				if opts.NoParallelRunners {
-					ch <- ruleset.Check(plugin.NewGRPCServer(runner, rootRunner, cli.loader.Files(), sdkVersions[name]))
-				} else {
-					go func(runner *tflint.Runner) {
-						ch <- ruleset.Check(plugin.NewGRPCServer(runner, rootRunner, cli.loader.Files(), sdkVersions[name]))
-					}(runner)
-				}
+			err = checkRunners(moduleRunners, !opts.NoParallelRunners, func(runner *tflint.Runner) error {
+				return ruleset.Check(plugin.NewGRPCServer(runner, rootRunner, cli.loader.Files(), sdkVersions[name]))
+			})
+			if err != nil {
+				return issues, changes, fmt.Errorf("Failed to check ruleset; %w", err)
 			}
-			for range moduleRunners {
-				err = <-ch
-				if err != nil {
-					return issues, changes, fmt.Errorf("Failed to check ruleset; %w", err)
-				}
-			}
-			close(ch)
 		}
 
 		changesInAttempt := map[string][]byte{}
@@ -194,6 +183,31 @@ By setting TFLINT_LOG=trace, you can confirm the changes made by the autofix and
 	maps.Copy(cli.sources, cli.loader.Sources())
 
 	return issues, changes, nil
+}
+
+// checkRunners runs check against each of the given module-call runners and
+// returns the first error encountered. When parallel is true, each runner is
+// checked in its own goroutine; otherwise they are checked sequentially.
+//
+// The per-runner check fan-out is extracted into a single function so its
+// concurrency behavior can be benchmarked in isolation.
+func checkRunners(runners []*tflint.Runner, parallel bool, check func(runner *tflint.Runner) error) error {
+	ch := make(chan error, len(runners))
+	for _, runner := range runners {
+		if parallel {
+			go func(runner *tflint.Runner) {
+				ch <- check(runner)
+			}(runner)
+		} else {
+			ch <- check(runner)
+		}
+	}
+	for range runners {
+		if err := <-ch; err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func launchPlugins(config *tflint.Config, fix bool) (*plugin.Plugin, error) {

--- a/cmd/inspect_bench_test.go
+++ b/cmd/inspect_bench_test.go
@@ -1,0 +1,238 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/spf13/afero"
+	sdk "github.com/terraform-linters/tflint-plugin-sdk/tflint"
+	"github.com/terraform-linters/tflint/plugin"
+	"github.com/terraform-linters/tflint/terraform"
+	"github.com/terraform-linters/tflint/tflint"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// benchModuleCounts is the fixture size swept by the benchmarks. The break
+// dimension for the per-runner storm is the number of module-call runners, so
+// the suite scales it across orders of magnitude.
+var benchModuleCounts = []int{1, 10, 100, 1000}
+
+// BenchmarkCheckRunners measures the per-runner check fan-out in isolation with
+// a synthetic check of fixed latency. The deterministic "peak-concurrency"
+// metric is the authoritative signal: it records the maximum number of checks
+// running at once. With the current unbounded fan-out, parallel peak concurrency
+// equals the number of runners regardless of available CPUs.
+func BenchmarkCheckRunners(b *testing.B) {
+	const checkLatency = 50 * time.Microsecond
+
+	for _, parallel := range []bool{false, true} {
+		for _, modules := range benchModuleCounts {
+			runners := make([]*tflint.Runner, modules)
+			b.Run(fmt.Sprintf("parallel=%t/modules=%d", parallel, modules), func(b *testing.B) {
+				var calls, inflight, peak atomic.Int64
+				check := func(_ *tflint.Runner) error {
+					updatePeakConcurrency(&peak, inflight.Add(1))
+					calls.Add(1)
+					time.Sleep(checkLatency)
+					inflight.Add(-1)
+					return nil
+				}
+
+				b.ReportAllocs()
+				iterations := 0
+				for b.Loop() {
+					if err := checkRunners(runners, parallel, check); err != nil {
+						b.Fatal(err)
+					}
+					iterations++
+				}
+
+				b.ReportMetric(float64(peak.Load()), "peak-concurrency")
+				if iterations > 0 {
+					b.ReportMetric(float64(calls.Load())/float64(iterations), "check-calls/op")
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkBuildRunners measures runner construction over a generated fixture.
+// Runner construction is serial today, so this establishes the baseline cost
+// against which any future parallelization is judged.
+func BenchmarkBuildRunners(b *testing.B) {
+	for _, modules := range benchModuleCounts {
+		b.Run(fmt.Sprintf("modules=%d", modules), func(b *testing.B) {
+			dir := b.TempDir()
+			generateModulesFixture(b, dir, modules)
+			b.Chdir(dir)
+			config := tflint.EmptyConfig()
+
+			b.ReportAllocs()
+			var runnerCount int
+			for b.Loop() {
+				loader, err := terraform.NewLoader(afero.Afero{Fs: afero.NewOsFs()}, dir)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_, moduleRunners, err := tflint.BuildRunners(loader, config, dir, ".")
+				if err != nil {
+					b.Fatal(err)
+				}
+				runnerCount = len(moduleRunners)
+			}
+
+			b.ReportMetric(float64(runnerCount), "runners")
+		})
+	}
+}
+
+// BenchmarkInspectFanout drives the per-runner check fan-out end-to-end over a
+// generated fixture. Each check evaluates a root-context expression through a
+// real plugin GRPCServer (the shared-rootRunner path that issue #2094 concerns)
+// and then sleeps to model the remote latency of an I/O-bound deep check. The
+// "peak-concurrency" metric shows how many checks run at once; with the
+// unbounded fan-out it equals the number of module runners, which is the storm
+// this work aims to bound.
+func BenchmarkInspectFanout(b *testing.B) {
+	const remoteLatency = time.Millisecond
+
+	for _, modules := range benchModuleCounts {
+		b.Run(fmt.Sprintf("modules=%d", modules), func(b *testing.B) {
+			dir := b.TempDir()
+			generateModulesFixture(b, dir, modules)
+			b.Chdir(dir)
+
+			loader, err := terraform.NewLoader(afero.Afero{Fs: afero.NewOsFs()}, dir)
+			if err != nil {
+				b.Fatal(err)
+			}
+			rootRunner, moduleRunners, err := tflint.BuildRunners(loader, tflint.EmptyConfig(), dir, ".")
+			if err != nil {
+				b.Fatal(err)
+			}
+			files := loader.Files()
+			expr := parseBenchExpr(b, "local.tag")
+			wantType := cty.String
+
+			var inflight, peak atomic.Int64
+			check := func(runner *tflint.Runner) error {
+				updatePeakConcurrency(&peak, inflight.Add(1))
+				defer inflight.Add(-1)
+
+				server := plugin.NewGRPCServer(runner, rootRunner, files, nil)
+				if _, err := server.EvaluateExpr(expr, sdk.EvaluateExprOption{ModuleCtx: sdk.RootModuleCtxType, WantType: &wantType}); err != nil {
+					return err
+				}
+				time.Sleep(remoteLatency)
+				return nil
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := checkRunners(moduleRunners, true, check); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			b.ReportMetric(float64(peak.Load()), "peak-concurrency")
+			b.ReportMetric(float64(len(moduleRunners)), "runners")
+		})
+	}
+}
+
+// updatePeakConcurrency records n as the new peak if it exceeds the current one.
+func updatePeakConcurrency(peak *atomic.Int64, n int64) {
+	for {
+		current := peak.Load()
+		if n <= current || peak.CompareAndSwap(current, n) {
+			return
+		}
+	}
+}
+
+func parseBenchExpr(tb testing.TB, src string) hcl.Expression {
+	tb.Helper()
+	expr, diags := hclsyntax.ParseExpression([]byte(src), "bench.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		tb.Fatal(diags)
+	}
+	return expr
+}
+
+// generateModulesFixture writes a Terraform configuration to dir: a root module
+// that calls a child module `modules` times, plus the .terraform/modules
+// manifest the loader uses to resolve those calls. Each call expands to one
+// module runner, so the fixture yields exactly `modules` runners. The root and
+// child modules each declare interdependent locals so checks exercise the real
+// evaluator rather than a trivial expression.
+func generateModulesFixture(tb testing.TB, dir string, modules int) {
+	tb.Helper()
+
+	childDir := filepath.Join(dir, "child")
+	if err := os.MkdirAll(childDir, 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	writeBenchFile(tb, filepath.Join(childDir, "main.tf"), `
+variable "instance_type" {
+  type = string
+}
+
+locals {
+  base    = "prefix-${var.instance_type}"
+  derived = "${local.base}-suffix"
+}
+
+resource "aws_instance" "this" {
+  instance_type = local.derived
+}
+`)
+
+	type manifestEntry struct {
+		Key    string
+		Source string
+		Dir    string
+	}
+	manifest := struct{ Modules []manifestEntry }{
+		Modules: []manifestEntry{{Key: "", Source: "", Dir: "."}},
+	}
+
+	var root strings.Builder
+	root.WriteString(`
+locals {
+  region = "us-east-1"
+  env    = "prod"
+  tag    = "${local.region}-${local.env}"
+}
+`)
+	for i := range modules {
+		name := fmt.Sprintf("mod%d", i)
+		fmt.Fprintf(&root, "\nmodule %q {\n  source        = \"./child\"\n  instance_type = \"t2.micro\"\n}\n", name)
+		manifest.Modules = append(manifest.Modules, manifestEntry{Key: name, Source: "./child", Dir: "child"})
+	}
+	writeBenchFile(tb, filepath.Join(dir, "main.tf"), root.String())
+
+	manifestDir := filepath.Join(dir, ".terraform", "modules")
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	writeBenchFile(tb, filepath.Join(manifestDir, "modules.json"), string(data))
+}
+
+func writeBenchFile(tb testing.TB, path, content string) {
+	tb.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		tb.Fatal(err)
+	}
+}

--- a/cmd/inspect_test.go
+++ b/cmd/inspect_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/terraform-linters/tflint/tflint"
+)
+
+func Test_checkRunners(t *testing.T) {
+	checkErr := errors.New("check failed")
+
+	for _, tc := range []struct {
+		name     string
+		parallel bool
+		runners  int
+		fail     bool
+		// wantAllChecked is whether every runner is deterministically checked.
+		// In parallel mode the first error is returned without waiting for the
+		// remaining goroutines, so on failure the number of checks actually run
+		// is not deterministic.
+		wantAllChecked bool
+	}{
+		{name: "parallel success", parallel: true, runners: 8, fail: false, wantAllChecked: true},
+		{name: "serial success", parallel: false, runners: 8, fail: false, wantAllChecked: true},
+		{name: "serial failure", parallel: false, runners: 8, fail: true, wantAllChecked: true},
+		{name: "no runners", parallel: true, runners: 0, fail: true, wantAllChecked: true},
+		{name: "parallel failure", parallel: true, runners: 8, fail: true, wantAllChecked: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runners := make([]*tflint.Runner, tc.runners)
+			var calls atomic.Int64
+			check := func(_ *tflint.Runner) error {
+				calls.Add(1)
+				if tc.fail {
+					return checkErr
+				}
+				return nil
+			}
+
+			err := checkRunners(runners, tc.parallel, check)
+
+			if tc.wantAllChecked {
+				if got := int(calls.Load()); got != tc.runners {
+					t.Errorf("expected check to run for all %d runners, but ran %d", tc.runners, got)
+				}
+			}
+
+			if tc.fail && tc.runners > 0 {
+				if !errors.Is(err, checkErr) {
+					t.Errorf("expected error %v, got %v", checkErr, err)
+				}
+			} else if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
First PR in a benchmark-driven pass at tflint's concurrency. The repo has no
benchmarks, and the changes that follow (bounding the per-runner check fan-out, cutting
redundant per-runner work) only make sense measured against a baseline, so this
establishes one. No behavior change.

It extracts the inline per-runner fan-out in `inspectModule` into `checkRunners`, the
seam the benchmarks measure and that a later PR will bound. Three benchmarks cover the
path: `BenchmarkCheckRunners` runs the fan-out in isolation with a synthetic check,
`BenchmarkInspectFanout` runs it end-to-end over a generated N-module fixture with each
check hitting the real evaluator through a `plugin.GRPCServer` plus a simulated remote
delay, and `BenchmarkBuildRunners` isolates runner construction. Sizes sweep
1/10/100/1000.

The path is I/O-bound, so wall-clock is noisy and the signals that matter are the custom
metrics: `peak-concurrency`, `check-calls/op`, and `runners`. `make bench` runs the
suite; `bench.yml` posts a `benchstat` table to the job summary, non-blocking and
HEAD-only until the base branch also carries the benchmarks.

Two things the baseline already shows. The fan-out is unbounded: peak concurrency tracks
runner count, ~900 in flight at 1000 module calls on 10 cores. And runner construction
is serial and superlinear, 7s and ~14 GiB allocated at 1000 modules, which may matter
more than the fan-out itself.

One correction to the plan that motivated this: the shared-root evaluation race it set
out to fix (#2094) doesn't exist on master. `Evaluator.scope()` allocates a fresh scope
per call, so the `CallStack`/`ResolvedLocalValues` caches are never shared across
goroutines, and `integrationtest/race/eval_locals_on_root_ctx` passes under `-race`. If
#2094 still reproduces, it's a logic bug in `CallStack` ordering.
