### PR TITLE
release: generate sigstore bundles rather than certs and signatures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,14 +24,12 @@ checksum:
   name_template: 'checksums.txt'
 signs:
   - cmd: cosign
-    signature: '${artifact}.keyless.sig'
-    certificate: '${artifact}.pem'
+    signature: '${artifact}.sigstore.json'
     output: true
     artifacts: checksum
     args:
       - sign-blob
-      - '--output-certificate=${certificate}'
-      - '--output-signature=${signature}'
+      - '--bundle=${signature}'
       - '${artifact}'
       - --yes
 release:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ sha256sum --ignore-missing -c checksums.txt
 [Cosign](https://github.com/sigstore/cosign) `verify-blob` command ensures that the release was built with GitHub Actions in this repository.
 
 ```console
-cosign verify-blob --certificate=checksums.txt.pem --signature=checksums.txt.keyless.sig --certificate-identity-regexp="^https://github.com/terraform-linters/tflint" --certificate-oidc-issuer=https://token.actions.githubusercontent.com checksums.txt
+cosign verify-blob --bundle=checksums.txt.sigstore.json --certificate-identity-regexp="^https://github.com/terraform-linters/tflint" --certificate-oidc-issuer=https://token.actions.githubusercontent.com checksums.txt
 sha256sum --ignore-missing -c checksums.txt
 ```
 


### PR DESCRIPTION
Made this before noticing the cosign deprecation notice, but thought I'd submit it anyway.

The latter two are deprecated as of cosign 3.1.1,
ref https://github.com/sigstore/cosign/releases/tag/v3.1.1