### PR TITLE
cmd: bound the per-runner check fan-out

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -14,6 +14,7 @@ import (
 	"github.com/terraform-linters/tflint/plugin"
 	"github.com/terraform-linters/tflint/terraform"
 	"github.com/terraform-linters/tflint/tflint"
+	"golang.org/x/sync/errgroup"
 )
 
 func (cli *CLI) inspect(opts Options) int {
@@ -149,7 +150,7 @@ By setting TFLINT_LOG=trace, you can confirm the changes made by the autofix and
 			// Run checks for module calls are performed in parallel.
 			// The rootRunner is shared between goroutines but read-only, so this is goroutine-safe.
 			// Note that checks against the rootRunner are not parallelized, as autofix may cause the module to be rebuilt.
-			err = checkRunners(moduleRunners, !opts.NoParallelRunners, func(runner *tflint.Runner) error {
+			err = checkRunners(moduleRunners, opts.runnerWorkers(), func(runner *tflint.Runner) error {
 				return ruleset.Check(plugin.NewGRPCServer(runner, rootRunner, cli.loader.Files(), sdkVersions[name]))
 			})
 			if err != nil {
@@ -185,29 +186,19 @@ By setting TFLINT_LOG=trace, you can confirm the changes made by the autofix and
 	return issues, changes, nil
 }
 
-// checkRunners runs check against each of the given module-call runners and
-// returns the first error encountered. When parallel is true, each runner is
-// checked in its own goroutine; otherwise they are checked sequentially.
-//
-// The per-runner check fan-out is extracted into a single function so its
-// concurrency behavior can be benchmarked in isolation.
-func checkRunners(runners []*tflint.Runner, parallel bool, check func(runner *tflint.Runner) error) error {
-	ch := make(chan error, len(runners))
+// checkRunners runs check against each of the given module-call runners,
+// limiting the number of concurrent checks to limit (a limit of 1 runs them
+// sequentially). It returns the first error encountered after every check has
+// finished, so no check goroutine outlives the call.
+func checkRunners(runners []*tflint.Runner, limit int, check func(runner *tflint.Runner) error) error {
+	var g errgroup.Group
+	g.SetLimit(limit)
 	for _, runner := range runners {
-		if parallel {
-			go func(runner *tflint.Runner) {
-				ch <- check(runner)
-			}(runner)
-		} else {
-			ch <- check(runner)
-		}
+		g.Go(func() error {
+			return check(runner)
+		})
 	}
-	for range runners {
-		if err := <-ch; err != nil {
-			return err
-		}
-	}
-	return nil
+	return g.Wait()
 }
 
 func launchPlugins(config *tflint.Config, fix bool) (*plugin.Plugin, error) {

--- a/cmd/inspect_bench_test.go
+++ b/cmd/inspect_bench_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -25,18 +26,29 @@ import (
 // the suite scales it across orders of magnitude.
 var benchModuleCounts = []int{1, 10, 100, 1000}
 
+// benchLimits sweeps the per-runner concurrency bound: serial, bounded to the
+// number of CPUs, and unbounded (the pre-bound behavior).
+var benchLimits = []struct {
+	name  string
+	limit int
+}{
+	{name: "serial", limit: 1},
+	{name: "cpu", limit: runtime.GOMAXPROCS(0)},
+	{name: "unbounded", limit: -1},
+}
+
 // BenchmarkCheckRunners measures the per-runner check fan-out in isolation with
 // a synthetic check of fixed latency. The deterministic "peak-concurrency"
 // metric is the authoritative signal: it records the maximum number of checks
-// running at once. With the current unbounded fan-out, parallel peak concurrency
-// equals the number of runners regardless of available CPUs.
+// running at once. With a finite limit, peak concurrency is capped at the limit
+// regardless of how many runners exist; unbounded, it equals the runner count.
 func BenchmarkCheckRunners(b *testing.B) {
 	const checkLatency = 50 * time.Microsecond
 
-	for _, parallel := range []bool{false, true} {
+	for _, lim := range benchLimits {
 		for _, modules := range benchModuleCounts {
 			runners := make([]*tflint.Runner, modules)
-			b.Run(fmt.Sprintf("parallel=%t/modules=%d", parallel, modules), func(b *testing.B) {
+			b.Run(fmt.Sprintf("limit=%s/modules=%d", lim.name, modules), func(b *testing.B) {
 				var calls, inflight, peak atomic.Int64
 				check := func(_ *tflint.Runner) error {
 					updatePeakConcurrency(&peak, inflight.Add(1))
@@ -49,7 +61,7 @@ func BenchmarkCheckRunners(b *testing.B) {
 				b.ReportAllocs()
 				iterations := 0
 				for b.Loop() {
-					if err := checkRunners(runners, parallel, check); err != nil {
+					if err := checkRunners(runners, lim.limit, check); err != nil {
 						b.Fatal(err)
 					}
 					iterations++
@@ -98,53 +110,60 @@ func BenchmarkBuildRunners(b *testing.B) {
 // generated fixture. Each check evaluates a root-context expression through a
 // real plugin GRPCServer (the shared-rootRunner path that issue #2094 concerns)
 // and then sleeps to model the remote latency of an I/O-bound deep check. The
-// "peak-concurrency" metric shows how many checks run at once; with the
-// unbounded fan-out it equals the number of module runners, which is the storm
-// this work aims to bound.
+// "peak-concurrency" metric shows how many checks run at once: bounded, it is
+// capped at the limit; unbounded, it equals the number of module runners, which
+// is the storm this work bounds.
 func BenchmarkInspectFanout(b *testing.B) {
 	const remoteLatency = time.Millisecond
 
-	for _, modules := range benchModuleCounts {
-		b.Run(fmt.Sprintf("modules=%d", modules), func(b *testing.B) {
-			dir := b.TempDir()
-			generateModulesFixture(b, dir, modules)
-			b.Chdir(dir)
+	for _, lim := range benchLimits {
+		if lim.limit == 1 {
+			// Serial is covered by BenchmarkCheckRunners; skip it here to keep
+			// the end-to-end sweep focused on bounded vs unbounded.
+			continue
+		}
+		for _, modules := range benchModuleCounts {
+			b.Run(fmt.Sprintf("limit=%s/modules=%d", lim.name, modules), func(b *testing.B) {
+				dir := b.TempDir()
+				generateModulesFixture(b, dir, modules)
+				b.Chdir(dir)
 
-			loader, err := terraform.NewLoader(afero.Afero{Fs: afero.NewOsFs()}, dir)
-			if err != nil {
-				b.Fatal(err)
-			}
-			rootRunner, moduleRunners, err := tflint.BuildRunners(loader, tflint.EmptyConfig(), dir, ".")
-			if err != nil {
-				b.Fatal(err)
-			}
-			files := loader.Files()
-			expr := parseBenchExpr(b, "local.tag")
-			wantType := cty.String
-
-			var inflight, peak atomic.Int64
-			check := func(runner *tflint.Runner) error {
-				updatePeakConcurrency(&peak, inflight.Add(1))
-				defer inflight.Add(-1)
-
-				server := plugin.NewGRPCServer(runner, rootRunner, files, nil)
-				if _, err := server.EvaluateExpr(expr, sdk.EvaluateExprOption{ModuleCtx: sdk.RootModuleCtxType, WantType: &wantType}); err != nil {
-					return err
-				}
-				time.Sleep(remoteLatency)
-				return nil
-			}
-
-			b.ReportAllocs()
-			for b.Loop() {
-				if err := checkRunners(moduleRunners, true, check); err != nil {
+				loader, err := terraform.NewLoader(afero.Afero{Fs: afero.NewOsFs()}, dir)
+				if err != nil {
 					b.Fatal(err)
 				}
-			}
+				rootRunner, moduleRunners, err := tflint.BuildRunners(loader, tflint.EmptyConfig(), dir, ".")
+				if err != nil {
+					b.Fatal(err)
+				}
+				files := loader.Files()
+				expr := parseBenchExpr(b, "local.tag")
+				wantType := cty.String
 
-			b.ReportMetric(float64(peak.Load()), "peak-concurrency")
-			b.ReportMetric(float64(len(moduleRunners)), "runners")
-		})
+				var inflight, peak atomic.Int64
+				check := func(runner *tflint.Runner) error {
+					updatePeakConcurrency(&peak, inflight.Add(1))
+					defer inflight.Add(-1)
+
+					server := plugin.NewGRPCServer(runner, rootRunner, files, nil)
+					if _, err := server.EvaluateExpr(expr, sdk.EvaluateExprOption{ModuleCtx: sdk.RootModuleCtxType, WantType: &wantType}); err != nil {
+						return err
+					}
+					time.Sleep(remoteLatency)
+					return nil
+				}
+
+				b.ReportAllocs()
+				for b.Loop() {
+					if err := checkRunners(moduleRunners, lim.limit, check); err != nil {
+						b.Fatal(err)
+					}
+				}
+
+				b.ReportMetric(float64(peak.Load()), "peak-concurrency")
+				b.ReportMetric(float64(len(moduleRunners)), "runners")
+			})
+		}
 	}
 }
 

--- a/cmd/inspect_parallel.go
+++ b/cmd/inspect_parallel.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"runtime"
 	"sync"
 	"time"
 
@@ -126,15 +125,8 @@ func spawnWorkers(ctx context.Context, workingDirs []string, opts Options) (<-ch
 		return nil, err
 	}
 
-	maxWorkers := runtime.NumCPU()
-	if opts.MaxWorkers != nil {
-		if c := *opts.MaxWorkers; c > 0 {
-			maxWorkers = c
-		}
-	}
-
 	ch := make(chan worker)
-	semaphore := make(chan struct{}, maxWorkers)
+	semaphore := make(chan struct{}, opts.maxWorkers())
 
 	go func() {
 		defer close(ch)

--- a/cmd/inspect_test.go
+++ b/cmd/inspect_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/terraform-linters/tflint/tflint"
 )
@@ -12,39 +13,50 @@ func Test_checkRunners(t *testing.T) {
 	checkErr := errors.New("check failed")
 
 	for _, tc := range []struct {
-		name     string
-		parallel bool
-		runners  int
-		fail     bool
-		// wantAllChecked is whether every runner is deterministically checked.
-		// In parallel mode the first error is returned without waiting for the
-		// remaining goroutines, so on failure the number of checks actually run
-		// is not deterministic.
-		wantAllChecked bool
+		name    string
+		limit   int
+		runners int
+		fail    bool
 	}{
-		{name: "parallel success", parallel: true, runners: 8, fail: false, wantAllChecked: true},
-		{name: "serial success", parallel: false, runners: 8, fail: false, wantAllChecked: true},
-		{name: "serial failure", parallel: false, runners: 8, fail: true, wantAllChecked: true},
-		{name: "no runners", parallel: true, runners: 0, fail: true, wantAllChecked: true},
-		{name: "parallel failure", parallel: true, runners: 8, fail: true, wantAllChecked: false},
+		{name: "serial success", limit: 1, runners: 8, fail: false},
+		{name: "serial failure", limit: 1, runners: 8, fail: true},
+		{name: "bounded success", limit: 4, runners: 8, fail: false},
+		{name: "bounded failure", limit: 4, runners: 8, fail: true},
+		{name: "unbounded success", limit: 8, runners: 8, fail: false},
+		{name: "no runners", limit: 4, runners: 0, fail: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			runners := make([]*tflint.Runner, tc.runners)
-			var calls atomic.Int64
+			var calls, inflight, peak atomic.Int64
 			check := func(_ *tflint.Runner) error {
+				n := inflight.Add(1)
+				for {
+					p := peak.Load()
+					if n <= p || peak.CompareAndSwap(p, n) {
+						break
+					}
+				}
 				calls.Add(1)
+				// Hold briefly so concurrent checks overlap, exercising the bound.
+				time.Sleep(time.Millisecond)
+				inflight.Add(-1)
 				if tc.fail {
 					return checkErr
 				}
 				return nil
 			}
 
-			err := checkRunners(runners, tc.parallel, check)
+			err := checkRunners(runners, tc.limit, check)
 
-			if tc.wantAllChecked {
-				if got := int(calls.Load()); got != tc.runners {
-					t.Errorf("expected check to run for all %d runners, but ran %d", tc.runners, got)
-				}
+			// errgroup waits for every goroutine, so all runners are checked even
+			// when one fails.
+			if got := int(calls.Load()); got != tc.runners {
+				t.Errorf("expected check to run for all %d runners, but ran %d", tc.runners, got)
+			}
+
+			// Concurrency never exceeds the limit.
+			if got := int(peak.Load()); got > tc.limit {
+				t.Errorf("peak concurrency %d exceeded limit %d", got, tc.limit)
 			}
 
 			if tc.fail && tc.runners > 0 {

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -3,11 +3,31 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"runtime"
 	"strings"
 
 	"github.com/terraform-linters/tflint/terraform"
 	"github.com/terraform-linters/tflint/tflint"
 )
+
+// maxWorkers resolves the upper bound on concurrent work, from --max-workers or
+// the number of CPUs. It governs both the recursive directory pool and the
+// per-runner check fan-out.
+func (opts *Options) maxWorkers() int {
+	if opts.MaxWorkers != nil && *opts.MaxWorkers > 0 {
+		return *opts.MaxWorkers
+	}
+	return runtime.NumCPU()
+}
+
+// runnerWorkers resolves the maximum number of module-call runners checked
+// concurrently. It is 1 when --no-parallel-runners is set.
+func (opts *Options) runnerWorkers() int {
+	if opts.NoParallelRunners {
+		return 1
+	}
+	return opts.maxWorkers()
+}
 
 // Options is an option specified by arguments.
 type Options struct {

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.37.0
 	google.golang.org/grpc v1.81.1
 )
@@ -160,7 +161,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6 // indirect
 	golang.org/x/term v0.43.0 // indirect


### PR DESCRIPTION
The per-runner check fan-out launched one goroutine per module-call runner with no
bound, so peak concurrency equaled the number of runners. When a check guards a remote
service, as the deep_check case in #1113 does, hundreds of module calls become hundreds of
simultaneous requests. That is what produced the STS throttling and false `no such host`
failures.

This caps the fan-out. A single worker count is resolved from `--max-workers` (or the
number of CPUs, or 1 under `--no-parallel-runners`) and applied with `errgroup.SetLimit`.
The recursive directory pool already derived its bound the same way, so both now draw from
one helper and the two concurrency layers share a budget. `errgroup.Wait` also blocks
until every check finishes, so a failing check no longer leaves goroutines touching a
runner after `Clean`.

No user-facing flags change. `--max-workers` and `--no-parallel-runners` keep their
meaning, and `--max-workers` now bounds the per-runner path too.

Measured with the end-to-end fan-out benchmark from #2573, at 1000 module calls this caps
peak concurrency at the worker count instead of ~900. Wall-clock rises under the bound,
which is the intent: it trades throughput for bounded resource use, the safety property the
storm needs.

Stacked on #2576.
