### PR TITLE
cmd: propagate a derived worker share to recursive subprocesses

### DIFF
--- a/cmd/inspect_parallel.go
+++ b/cmd/inspect_parallel.go
@@ -127,6 +127,9 @@ func spawnWorkers(ctx context.Context, workingDirs []string, opts Options) (<-ch
 
 	ch := make(chan worker)
 	semaphore := make(chan struct{}, opts.maxWorkers())
+	// Divide the budget across the directory workers so the per-runner fan-out
+	// in each subprocess is bounded and total in-flight work stays within it.
+	workerShare := opts.workerShare(len(workingDirs))
 
 	go func() {
 		defer close(ch)
@@ -136,7 +139,7 @@ func spawnWorkers(ctx context.Context, workingDirs []string, opts Options) (<-ch
 			wg.Add(1)
 			go func(wd string) {
 				defer wg.Done()
-				spawnWorker(ctx, self, wd, opts, ch, semaphore)
+				spawnWorker(ctx, self, wd, opts, workerShare, ch, semaphore)
 			}(wd)
 		}
 		wg.Wait()
@@ -148,7 +151,7 @@ func spawnWorkers(ctx context.Context, workingDirs []string, opts Options) (<-ch
 // Spawn a worker process for the given directory.
 // When the process is complete, send the results to the given channel.
 // If the context is canceled, the started process will be interrupted.
-func spawnWorker(ctx context.Context, executable string, workingDir string, opts Options, ch chan<- worker, semaphore chan struct{}) {
+func spawnWorker(ctx context.Context, executable string, workingDir string, opts Options, maxWorkers int, ch chan<- worker, semaphore chan struct{}) {
 	// Blocks from exceeding the maximum number of workers
 	select {
 	case semaphore <- struct{}{}:
@@ -162,7 +165,7 @@ func spawnWorker(ctx context.Context, executable string, workingDir string, opts
 	}
 
 	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
-	cmd := exec.CommandContext(ctx, executable, opts.toWorkerCommands(workingDir)...)
+	cmd := exec.CommandContext(ctx, executable, opts.toWorkerCommands(workingDir, maxWorkers)...)
 	cmd.Stdout, cmd.Stderr = stdout, stderr
 	cmd.Cancel = func() error {
 		log.Printf("[DEBUG] Worker in %s is terminated\n", workingDir)

--- a/cmd/option.go
+++ b/cmd/option.go
@@ -160,10 +160,28 @@ func (opts *Options) toConfig() *tflint.Config {
 	}
 }
 
+// workerShare divides the worker budget across the directory workers that run
+// concurrently, so that directories times per-runner checks stays within the
+// budget. Each recursive subprocess receives this share as its --max-workers.
+func (opts *Options) workerShare(dirs int) int {
+	budget := opts.maxWorkers()
+	concurrent := dirs
+	if concurrent > budget {
+		concurrent = budget
+	}
+	if concurrent < 1 {
+		concurrent = 1
+	}
+	if share := budget / concurrent; share > 1 {
+		return share
+	}
+	return 1
+}
+
 // Return commands to be executed by worker processes in recursive inspection.
 // All possible CLI flags are delegated, but some flags are ignored because
 // the coordinator process that starts the workers is responsible.
-func (opts *Options) toWorkerCommands(workingDir string) []string {
+func (opts *Options) toWorkerCommands(workingDir string, maxWorkers int) []string {
 	commands := []string{
 		"--act-as-worker",
 		"--chdir=" + workingDir,
@@ -221,7 +239,10 @@ func (opts *Options) toWorkerCommands(workingDir string) []string {
 		commands = append(commands, "--no-parallel-runners")
 	}
 
-	// opts.MaxWorkers is ignored because the coordinator is responsible for parallelism
+	// Propagate a derived per-runner worker share so the per-runner fan-out in
+	// each subprocess is bounded. Without this the bound resets to NumCPU per
+	// subprocess and total in-flight work becomes workers times NumCPU.
+	commands = append(commands, fmt.Sprintf("--max-workers=%d", maxWorkers))
 
 	// opts.ActAsBundledPlugin and opts.ActAsWorker are not supported
 

--- a/cmd/option_test.go
+++ b/cmd/option_test.go
@@ -260,6 +260,31 @@ func Test_toConfig(t *testing.T) {
 	}
 }
 
+func Test_workerShare(t *testing.T) {
+	maxWorkers := func(n int) *int { return &n }
+
+	for _, tc := range []struct {
+		name       string
+		maxWorkers *int
+		dirs       int
+		want       int
+	}{
+		{name: "dirs below budget get the remainder", maxWorkers: maxWorkers(10), dirs: 2, want: 5},
+		{name: "dirs at budget get one each", maxWorkers: maxWorkers(10), dirs: 10, want: 1},
+		{name: "dirs above budget get one each", maxWorkers: maxWorkers(10), dirs: 100, want: 1},
+		{name: "single dir gets the whole budget", maxWorkers: maxWorkers(8), dirs: 1, want: 8},
+		{name: "share floors at one", maxWorkers: maxWorkers(3), dirs: 5, want: 1},
+		{name: "zero dirs floors at one", maxWorkers: maxWorkers(4), dirs: 0, want: 4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &Options{MaxWorkers: tc.maxWorkers}
+			if got := opts.workerShare(tc.dirs); got != tc.want {
+				t.Errorf("workerShare(%d) with max-workers %d = %d, want %d", tc.dirs, *tc.maxWorkers, got, tc.want)
+			}
+		})
+	}
+}
+
 func Test_toWorkerCommands(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -271,7 +296,7 @@ func Test_toWorkerCommands(t *testing.T) {
 			name:       "no args",
 			in:         []string{},
 			workingDir: "subdir",
-			want:       []string{"--act-as-worker", "--chdir=subdir", "--force"},
+			want:       []string{"--act-as-worker", "--chdir=subdir", "--force", "--max-workers=3"},
 		},
 		{
 			name: "all",
@@ -342,7 +367,7 @@ func Test_toWorkerCommands(t *testing.T) {
 				// "--no-color",
 				"--fix",
 				"--no-parallel-runners",
-				// "--max-workers=2",
+				"--max-workers=3",
 				// "--act-as-bundled-plugin",
 				"--act-as-worker",
 			},
@@ -358,7 +383,7 @@ func Test_toWorkerCommands(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			got := in.toWorkerCommands(test.workingDir)
+			got := in.toWorkerCommands(test.workingDir, 3)
 
 			opt := cmpopts.SortSlices(func(a, b string) bool { return a < b })
 			if diff := cmp.Diff(test.want, got, opt); diff != "" {


### PR DESCRIPTION
`toWorkerCommands` dropped `--max-workers`, so under `--recursive` each subprocess fell
back to the number of CPUs for its per-runner fan-out. Total in-flight work became
(directory workers) times NumCPU, which means the bound from #2577 did nothing in the
recursive case that motivated this whole effort.

This divides the worker budget across the directory workers that run concurrently and
passes that share to each subprocess as `--max-workers`. With a budget of N and N busy
directory workers, each subprocess runs its per-runner checks one at a time, so the
product stays at N. With fewer directories than the budget, each subprocess gets a larger
share. Directories times per-runner checks now stays within the budget in both plain and
recursive modes.

No user-facing flags change. `--max-workers` keeps its meaning and now bounds the
per-runner path under `--recursive` too. This is the gap the benchmark suite cannot reach
directly (it does not spawn subprocesses), so it is covered by unit tests for the share
math and the propagated command, plus the recursive integration suite.

Stacked on #2577.
