### PR TITLE
formatter: make JUnit error testcase names unique

### DIFF
--- a/formatter/junit.go
+++ b/formatter/junit.go
@@ -67,7 +67,10 @@ func (f *Formatter) junitErrors(err error) []formatter.JUnitTestCase {
 			for i, diag := range diags {
 				rng := diagRange(diag)
 				cases[i] = formatter.JUnitTestCase{
-					Name:      diag.Summary,
+					// Include the range so that diagnostics sharing a summary
+					// (e.g. the same error on different lines) still produce
+					// unique testcase names, matching how issues are named.
+					Name:      fmt.Sprintf("%s %s", diag.Summary, rng),
 					Classname: rng.Filename,
 					Time:      "0",
 					Failure: &formatter.JUnitFailure{

--- a/formatter/junit_test.go
+++ b/formatter/junit_test.go
@@ -140,8 +140,45 @@ func Test_junitPrint(t *testing.T) {
 <testsuites>
   <testsuite tests="1" failures="1" time="0" name="">
     <properties></properties>
-    <testcase classname="" name="summary" time="0">
+    <testcase classname="" name="summary :0,0-0" time="0">
       <failure message=":0,0-0,0: detail" type="error">error: detail&#xA;Summary: summary&#xA;Range: :0,0-0,0</failure>
+    </testcase>
+  </testsuite>
+</testsuites>`,
+		},
+		{
+			Name: "diagnostics with the same summary",
+			Error: hcl.Diagnostics{
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Unsupported argument",
+					Detail:   "first",
+					Subject: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 1, Column: 1, Byte: 0},
+						End:      hcl.Pos{Line: 1, Column: 4, Byte: 3},
+					},
+				},
+				&hcl.Diagnostic{
+					Severity: hcl.DiagError,
+					Summary:  "Unsupported argument",
+					Detail:   "second",
+					Subject: &hcl.Range{
+						Filename: "test.tf",
+						Start:    hcl.Pos{Line: 2, Column: 1, Byte: 15},
+						End:      hcl.Pos{Line: 2, Column: 5, Byte: 18},
+					},
+				},
+			},
+			Stdout: `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite tests="2" failures="2" time="0" name="">
+    <properties></properties>
+    <testcase classname="test.tf" name="Unsupported argument test.tf:1,1-4" time="0">
+      <failure message="test.tf:1,1-1,4: first" type="error">error: first&#xA;Summary: Unsupported argument&#xA;Range: test.tf:1,1-1,4</failure>
+    </testcase>
+    <testcase classname="test.tf" name="Unsupported argument test.tf:2,1-5" time="0">
+      <failure message="test.tf:2,1-2,5: second" type="error">error: second&#xA;Summary: Unsupported argument&#xA;Range: test.tf:2,1-2,5</failure>
     </testcase>
   </testsuite>
 </testsuites>`,


### PR DESCRIPTION
Fixes #1608

### Problem

#2538 made **issue** testcase names unique by including the range, but the **error** testcases appended after them still use the bare diagnostic summary. Multiple diagnostics sharing a summary — e.g. the same `Unsupported argument` error on two different lines — still produce duplicate `<testcase>` names inside the same `<testsuite>`, which JUnit consumers key on.

This is exactly the gap called out in the review of #2522:

> `junitErrors` sets `Name: diag.Summary` directly, so multiple diagnostics sharing a summary (e.g. two "Unsupported argument" errors on different lines) still produce duplicate `<testcase>` names in the same `<testsuite>` (#1608).

and:

> this should cover errors too, then LGTM

### Change

Include the diagnostic range in the error testcase name, mirroring the issue-testcase naming from #2538 (`<summary> <range>`, via the existing nil-safe `diagRange`). The `application_error` singleton case is untouched.

One edge worth noting: two **subject-less** diagnostics with an identical summary would still collide (both synthesize the empty range `:0,0-0`). That mirrors the pre-#2538 state for issues and seems acceptable for a case that can't point at a location — happy to add a positional suffix there if you'd prefer.

### Tests

- Updated the existing "diagnostics without subject" golden output for the new name.
- Added a "diagnostics with the same summary" case: two diagnostics sharing a summary on different lines now produce unique `<testcase>` names.

```
go test ./formatter/ -run Test_junitPrint
```
