### PR TITLE
plugin: fetch attestation bundles from bundle_url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/jstemmer/go-junit-report v1.0.0
+	github.com/klauspost/compress v1.18.6
 	github.com/mattn/go-colorable v0.1.15
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/owenrumney/go-sarif/v2 v2.3.3
@@ -125,7 +126,6 @@ require (
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/in-toto/attestation v1.2.0 // indirect
 	github.com/in-toto/in-toto-golang v0.11.0 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect

--- a/plugin/install.go
+++ b/plugin/install.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -18,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v81/github"
+	"github.com/klauspost/compress/snappy"
 	"github.com/terraform-linters/tflint/tflint"
 	"golang.org/x/net/idna"
 	"golang.org/x/oauth2"
@@ -296,7 +298,22 @@ func (c *InstallConfig) fetchReleaseAssets(ctx context.Context, client *github.C
 	return assets, nil
 }
 
+// attestationsResponse is like github.AttestationsResponse, but also captures
+// the bundle_url field, which go-github does not expose. GitHub may serve the
+// sigstore bundle from blob storage instead of embedding it in the response.
+type attestationsResponse struct {
+	Attestations []*attestation `json:"attestations"`
+}
+
+type attestation struct {
+	Bundle       json.RawMessage `json:"bundle"`
+	BundleURL    string          `json:"bundle_url"`
+	RepositoryID int64           `json:"repository_id"`
+}
+
 // fetchArtifactAttestations fetches GitHub Artifact Attestations based on the given artifact.
+// Attestations whose sigstore bundle is not embedded in the API response are
+// resolved by downloading the bundle from the URL in the bundle_url field.
 func (c *InstallConfig) fetchArtifactAttestations(ctx context.Context, client *github.Client, artifact []byte) ([]*github.Attestation, error) {
 	hash := sha256.New()
 	if _, err := hash.Write(artifact); err != nil {
@@ -304,11 +321,70 @@ func (c *InstallConfig) fetchArtifactAttestations(ctx context.Context, client *g
 	}
 	digest := hex.EncodeToString(hash.Sum(nil))
 
-	resp, _, err := client.Repositories.ListAttestations(ctx, c.SourceOwner, c.SourceRepo, "sha256:"+digest, nil)
+	u := fmt.Sprintf("repos/%s/%s/attestations/sha256:%s", c.SourceOwner, c.SourceRepo, digest)
+	req, err := client.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return []*github.Attestation{}, err
 	}
-	return resp.Attestations, nil
+	var resp attestationsResponse
+	if _, err := client.Do(ctx, req, &resp); err != nil {
+		return []*github.Attestation{}, err
+	}
+
+	attestations := make([]*github.Attestation, 0, len(resp.Attestations))
+	for _, a := range resp.Attestations {
+		b := a.Bundle
+		if isNullJSON(b) {
+			if a.BundleURL == "" {
+				return []*github.Attestation{}, fmt.Errorf("attestation has no bundle or bundle URL")
+			}
+			log.Printf("[DEBUG] Attestation bundle is not embedded, downloading from the bundle URL")
+			b, err = downloadAttestationBundle(ctx, a.BundleURL)
+			if err != nil {
+				return []*github.Attestation{}, err
+			}
+		}
+		attestations = append(attestations, &github.Attestation{Bundle: b, RepositoryID: a.RepositoryID})
+	}
+	return attestations, nil
+}
+
+// isNullJSON returns whether the raw JSON value is empty or the null literal.
+func isNullJSON(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null"))
+}
+
+// downloadAttestationBundle downloads a sigstore bundle from the given URL.
+// GitHub serves bundles from blob storage as snappy-compressed JSON.
+// The URL is pre-signed, so the request is sent without API credentials.
+func downloadAttestationBundle(ctx context.Context, url string) (json.RawMessage, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to download attestation bundle: %s", resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	decoded, err := snappy.Decode(nil, body)
+	if err != nil {
+		// Fall back to the response as-is for bundles served without compression.
+		if json.Valid(body) {
+			return body, nil
+		}
+		return nil, fmt.Errorf("failed to decompress attestation bundle: %s", err)
+	}
+	return decoded, nil
 }
 
 func isIgnorableAttestationError(err error) bool {

--- a/plugin/install_test.go
+++ b/plugin/install_test.go
@@ -1,12 +1,21 @@
 package plugin
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/v81/github"
+	"github.com/klauspost/compress/snappy"
 	"github.com/terraform-linters/tflint/tflint"
 )
 
@@ -446,6 +455,114 @@ func TestIsIgnorableAttestationError(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if got := isIgnorableAttestationError(test.err); got != test.want {
 				t.Fatalf("isIgnorableAttestationError() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func Test_fetchArtifactAttestations(t *testing.T) {
+	artifact := []byte("test artifact")
+	digest := sha256.Sum256(artifact)
+	attestationsPath := "/repos/terraform-linters/tflint-ruleset-aws/attestations/sha256:" + hex.EncodeToString(digest[:])
+
+	bundleJSON := `{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}`
+
+	cases := []struct {
+		name        string
+		response    func(serverURL string) string
+		blobHandler http.HandlerFunc
+		want        []*github.Attestation
+		expectedErr error
+	}{
+		{
+			name: "embedded bundle",
+			response: func(string) string {
+				return `{"attestations":[{"repository_id":1,"bundle":` + bundleJSON + `}]}`
+			},
+			want: []*github.Attestation{{Bundle: json.RawMessage(bundleJSON), RepositoryID: 1}},
+		},
+		{
+			name: "bundle from bundle_url",
+			response: func(serverURL string) string {
+				return `{"attestations":[{"repository_id":1,"bundle":null,"bundle_url":"` + serverURL + `/blob"}]}`
+			},
+			blobHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/x-snappy")
+				w.Write(snappy.Encode(nil, []byte(bundleJSON)))
+			},
+			want: []*github.Attestation{{Bundle: json.RawMessage(bundleJSON), RepositoryID: 1}},
+		},
+		{
+			name: "uncompressed bundle from bundle_url",
+			response: func(serverURL string) string {
+				return `{"attestations":[{"repository_id":1,"bundle":null,"bundle_url":"` + serverURL + `/blob"}]}`
+			},
+			blobHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(bundleJSON))
+			},
+			want: []*github.Attestation{{Bundle: json.RawMessage(bundleJSON), RepositoryID: 1}},
+		},
+		{
+			name: "no bundle and no bundle_url",
+			response: func(string) string {
+				return `{"attestations":[{"repository_id":1,"bundle":null}]}`
+			},
+			expectedErr: fmt.Errorf("attestation has no bundle or bundle URL"),
+		},
+		{
+			name: "bundle_url download failure",
+			response: func(serverURL string) string {
+				return `{"attestations":[{"repository_id":1,"bundle":null,"bundle_url":"` + serverURL + `/blob"}]}`
+			},
+			blobHandler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "gone", http.StatusNotFound)
+			},
+			expectedErr: fmt.Errorf("failed to download attestation bundle: 404 Not Found"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			mux.HandleFunc(attestationsPath, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, tc.response(server.URL))
+			})
+			if tc.blobHandler != nil {
+				mux.HandleFunc("/blob", tc.blobHandler)
+			}
+
+			client := github.NewClient(nil)
+			baseURL, err := url.Parse(server.URL + "/")
+			if err != nil {
+				t.Fatal(err)
+			}
+			client.BaseURL = baseURL
+
+			config := NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{
+				SourceHost:  "github.com",
+				SourceOwner: "terraform-linters",
+				SourceRepo:  "tflint-ruleset-aws",
+			})
+			got, err := config.fetchArtifactAttestations(context.Background(), client, artifact)
+
+			if tc.expectedErr != nil {
+				if err == nil {
+					t.Fatalf("expected=%s, actual=no errors", tc.expectedErr)
+				}
+				if err.Error() != tc.expectedErr.Error() {
+					t.Fatalf("expected=%s, actual=%s", tc.expectedErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("failed to fetch attestations: %s", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatal(diff)
 			}
 		})
 	}

--- a/plugin/signature.go
+++ b/plugin/signature.go
@@ -79,6 +79,19 @@ func (c *SignatureChecker) VerifyAttestations(target io.Reader, attestations []*
 	}
 	artifactDigest := sha256.Sum256(artifact)
 
+	// Parse attestation bundles upfront. Note that a null bundle is
+	// unmarshaled to nil without errors, which would crash the verifier
+	// if passed through.
+	bundles := make([]*bundle.Bundle, len(attestations))
+	for i, attestation := range attestations {
+		if err := json.Unmarshal(attestation.Bundle, &bundles[i]); err != nil {
+			return fmt.Errorf("failed to unmarshal sigstore bundle: %s", err)
+		}
+		if bundles[i] == nil {
+			return fmt.Errorf("attestation contains an empty sigstore bundle")
+		}
+	}
+
 	// Initialize Sigstore trust root
 	// This saves the caches under the "~/.sigstore"
 	client, err := tuf.New(tuf.DefaultOptions())
@@ -126,13 +139,8 @@ func (c *SignatureChecker) VerifyAttestations(target io.Reader, attestations []*
 	)
 
 	// Verify attestations
-	var b *bundle.Bundle
 	var verifyErr error
-	for _, attestation := range attestations {
-		if err := json.Unmarshal(attestation.Bundle, &b); err != nil {
-			return fmt.Errorf("failed to unmarshal sigstore bundle: %s", err)
-		}
-
+	for _, b := range bundles {
 		ret, err := verifier.Verify(b, policy)
 		if err != nil {
 			verifyErr = err

--- a/plugin/signature_test.go
+++ b/plugin/signature_test.go
@@ -291,6 +291,17 @@ b97e20eae04a45d650886611f17020fd0aa29114b86268b71e3841195fbc55ca  tflint-ruleset
 			Expected:     fmt.Errorf("no attestations found"),
 		},
 		{
+			Name:   "null bundle",
+			Config: NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SourceHost: "github.com", SourceOwner: "terraform-linters", SourceRepo: "tflint-ruleset-aws"}),
+			Attestations: []*github.Attestation{
+				{
+					RepositoryID: 245765716,
+					Bundle:       []byte(`null`),
+				},
+			},
+			Expected: fmt.Errorf("attestation contains an empty sigstore bundle"),
+		},
+		{
 			Name:   "mismatched attestations",
 			Config: NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SourceHost: "github.com", SourceOwner: "terraform-linters", SourceRepo: "tflint-ruleset-aws"}),
 			Attestations: []*github.Attestation{


### PR DESCRIPTION
Fixes #2591

## Root cause

GitHub stopped embedding sigstore bundles in attestation list responses. As @sarahhodne noted in the issue, this matches the documented [breaking change](https://docs.github.com/en/rest/about-the-rest-api/breaking-changes) ("Remove the bundle property from attestation list responses. ... Use `bundle_url` to retrieve the attestation bundle"), except it now applies to the `2022-11-28` API version as well. The endpoint currently returns:

```json
{
  "attestations": [
    {
      "repository_id": 245765716,
      "bundle_url": "https://tmaproduction.blob.core.windows.net/attestations/...json.sn?...",
      "initiator": "user",
      "bundle": null
    }
  ]
}
```

`json.Unmarshal` unmarshals `null` into a `*bundle.Bundle` without error — it just sets the pointer to `nil` — and `VerifyAttestations` passes that `nil` straight to `verifier.Verify`, which dereferences it in `bundle.(*Bundle).TlogEntries`. That's the panic in the issue. It also reproduces in this repo's CI: the `build` workflow on #2592 hit the same panic in `Test_Install_withAttestations` ([run](https://github.com/terraform-linters/tflint/actions/runs/29538159046/job/87754264210)), and the nightly on master will hit it too.

## Changes

1. **`fetchArtifactAttestations` resolves `bundle_url`.** go-github v81 doesn't expose the field, so the endpoint is queried via `client.NewRequest`/`client.Do` with a small local struct — this keeps `github.ErrorResponse` semantics, so `isIgnorableAttestationError` keeps working for 403/404. When `bundle` is null or absent, the bundle is downloaded from `bundle_url`. The blob is served as snappy-compressed JSON (`Content-Type: application/x-snappy`), so it's snappy-decoded, mirroring what the gh CLI does in [`getBundle`](https://github.com/cli/cli/blob/trunk/pkg/cmd/attestation/api/client.go). The download intentionally uses `http.DefaultClient`: the URL is pre-signed, and API credentials must not be sent to blob storage. If a bundle is ever served uncompressed, the raw body is used as long as it's valid JSON.

2. **`VerifyAttestations` rejects empty bundles instead of crashing.** Bundles are now parsed upfront, and a null bundle returns `attestation contains an empty sigstore bundle`. Even if the API serves something unexpected again, `tflint --init` fails with an error rather than a SIGSEGV.

Uses `github.com/klauspost/compress/snappy`, which is already in the module graph as an indirect dependency, rather than adding a new module.

## Tests

- `Test_fetchArtifactAttestations` (new, offline via httptest): embedded-bundle passthrough, `bundle_url` + snappy, `bundle_url` + uncompressed fallback, null bundle with no URL, download failure.
- `Test_SignatureChecker_VerifyAttestations_errors`: new `null bundle` case — the exact crash input now returns an error.
- `Test_Install_withAttestations` (existing, live): panicked before this change exactly as reported; now passes end-to-end against the real API (list → download from `bundle_url` → decompress → verify).
