### PR TITLE
Title: Fix panic on nil sigstore bundle during plugin installation

### DIFF
--- a/plugin/signature.go
+++ b/plugin/signature.go
@@ -133,6 +133,11 @@ func (c *SignatureChecker) VerifyAttestations(target io.Reader, attestations []*
 			return fmt.Errorf("failed to unmarshal sigstore bundle: %s", err)
 		}
 
+		if b == nil {
+			verifyErr = fmt.Errorf("attestation contains an empty sigstore bundle")
+			continue
+		}
+
 		ret, err := verifier.Verify(b, policy)
 		if err != nil {
 			verifyErr = err

--- a/plugin/signature_test.go
+++ b/plugin/signature_test.go
@@ -291,6 +291,17 @@ b97e20eae04a45d650886611f17020fd0aa29114b86268b71e3841195fbc55ca  tflint-ruleset
 			Expected:     fmt.Errorf("no attestations found"),
 		},
 		{
+			Name:   "null bundle",
+			Config: NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SourceHost: "github.com", SourceOwner: "terraform-linters", SourceRepo: "tflint-ruleset-aws"}),
+			Attestations: []*github.Attestation{
+				{
+					RepositoryID: 245765716,
+					Bundle:       []byte(`null`),
+				},
+			},
+			Expected: fmt.Errorf("attestation contains an empty sigstore bundle"),
+		},
+		{
 			Name:   "mismatched attestations",
 			Config: NewInstallConfig(tflint.EmptyConfig(), &tflint.PluginConfig{SourceHost: "github.com", SourceOwner: "terraform-linters", SourceRepo: "tflint-ruleset-aws"}),
 			Attestations: []*github.Attestation{


### PR DESCRIPTION
This PR fixes a critical runtime panic (invalid memory address or nil pointer dereference) that occurs during tflint --init when the GitHub API returns an empty (null) sigstore bundle for an artifact attestation.

**Root Cause**: GitHub's artifact attestations endpoint recently stopped embedding the sigstore bundle directly in the response, now returning "bundle": null and providing a bundle_url instead. Currently, json.Unmarshal successfully parses the null bundle into a nil pointer without throwing an error. This nil pointer is then passed directly to verifier.Verify(b, policy). Inside the sigstore-go library, it attempts to call (*Bundle).TlogEntries() on this nil pointer, leading to a hard crash.

_Panic Stack Trace_

```
Installing "terraform" plugin...
Panic: runtime error: invalid memory address or nil pointer dereference
 -> 0: main.main.func1: /main.go(25)
 -> 1: runtime.gopanic: /panic.go(860)
 -> 2: runtime.panicmem: /panic.go(336)
 -> 3: runtime.sigpanic: /signal_unix.go(931)
 -> 4: github.com/sigstore/sigstore-go/pkg/bundle.(*Bundle).TlogEntries: /bundle.go(300)
 -> 5: github.com/sigstore/sigstore-go/pkg/verify.VerifyTlogEntry: /tlog.go(40)
 -> 6: github.com/sigstore/sigstore-go/pkg/verify.(*Verifier).VerifyTransparencyLogInclusion: /signed_entity.go(809)
 -> 7: github.com/sigstore/sigstore-go/pkg/verify.(*Verifier).Verify: /signed_entity.go(606)
 -> 8: github.com/terraform-linters/tflint/plugin.(*SignatureChecker).VerifyAttestations: /signature.go(136)
 -> 9: github.com/terraform-linters/tflint/plugin.(*InstallConfig).Install: /install.go(134)
Fix: Added a safeguard in plugin/signature.go to explicitly check if the unmarshaled bundle b is nil. If it is nil, the verifier correctly registers an fmt.Errorf and skips to the next attestation, translating the fatal panic into a properly handled error.
```