### PR TITLE
Modernize the codebase with `go fix`

### DIFF
--- a/formatter/errors.go
+++ b/formatter/errors.go
@@ -34,8 +34,7 @@ func mapErrors[T any](err error, mapper errorMapper[T]) []T {
 		return results
 	}
 
-	var diags hcl.Diagnostics
-	if errors.As(err, &diags) {
+	if diags, ok := errors.AsType[hcl.Diagnostics](err); ok {
 		return mapper.diagnostics(err, diags)
 	}
 

--- a/plugin/discovery_test.go
+++ b/plugin/discovery_test.go
@@ -87,8 +87,7 @@ func Test_Discovery_envVar(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	os.Setenv("TFLINT_PLUGIN_DIR", filepath.Join(cwd, "test-fixtures", "locals", ".tflint.d", "plugins"))
-	defer os.Setenv("TFLINT_PLUGIN_DIR", "")
+	t.Setenv("TFLINT_PLUGIN_DIR", filepath.Join(cwd, "test-fixtures", "locals", ".tflint.d", "plugins"))
 
 	plugin, err := Discovery(&tflint.Config{
 		Plugins: map[string]*tflint.PluginConfig{
@@ -370,8 +369,7 @@ func Test_FindPluginPath_envVar(t *testing.T) {
 	}
 
 	dir := filepath.Join(cwd, "test-fixtures", "locals", ".tflint.d", "plugins")
-	os.Setenv("TFLINT_PLUGIN_DIR", dir)
-	defer os.Setenv("TFLINT_PLUGIN_DIR", "")
+	t.Setenv("TFLINT_PLUGIN_DIR", dir)
 
 	cases := []struct {
 		Name     string

--- a/plugin/install.go
+++ b/plugin/install.go
@@ -437,12 +437,12 @@ func (c *InstallConfig) downloadToTempFile(ctx context.Context, client *github.C
 func (c *InstallConfig) getGitHubToken() string {
 	prefix := "GITHUB_TOKEN_"
 	for _, env := range os.Environ() {
-		eqIdx := strings.Index(env, "=")
-		if eqIdx < 0 {
+		before, after, ok := strings.Cut(env, "=")
+		if !ok {
 			continue
 		}
-		name := env[:eqIdx]
-		value := env[eqIdx+1:]
+		name := before
+		value := after
 
 		if !strings.HasPrefix(name, prefix) {
 			continue

--- a/plugin/install.go
+++ b/plugin/install.go
@@ -437,12 +437,10 @@ func (c *InstallConfig) downloadToTempFile(ctx context.Context, client *github.C
 func (c *InstallConfig) getGitHubToken() string {
 	prefix := "GITHUB_TOKEN_"
 	for _, env := range os.Environ() {
-		before, after, ok := strings.Cut(env, "=")
+		name, value, ok := strings.Cut(env, "=")
 		if !ok {
 			continue
 		}
-		name := before
-		value := after
 
 		if !strings.HasPrefix(name, prefix) {
 			continue

--- a/plugin/stub-generator/sources/testing/rules/terraform_required_providers.go
+++ b/plugin/stub-generator/sources/testing/rules/terraform_required_providers.go
@@ -2,7 +2,7 @@ package rules
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
@@ -70,7 +70,7 @@ func (r *TerraformRequiredProviders) Check(runner tflint.Runner) error {
 				}
 				ret = append(ret, fmt.Sprintf("%s=%s", name, v.AsString()))
 			}
-			sort.Strings(ret)
+			slices.Sort(ret)
 
 			err := runner.EmitIssue(
 				r,

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -17,11 +17,6 @@ import (
 	"github.com/terraform-linters/tflint/terraform"
 )
 
-//go:fix inline
-func boolPtr(v bool) *bool {
-	return new(v)
-}
-
 func TestLoadConfig(t *testing.T) {
 	// default error check helper
 	neverHappend := func(err error) bool { return err != nil }

--- a/tflint/config_test.go
+++ b/tflint/config_test.go
@@ -17,8 +17,9 @@ import (
 	"github.com/terraform-linters/tflint/terraform"
 )
 
+//go:fix inline
 func boolPtr(v bool) *bool {
-	return &v
+	return new(v)
 }
 
 func TestLoadConfig(t *testing.T) {
@@ -104,7 +105,7 @@ plugin "baz" {
 					"aws_instance_invalid_type": {
 						Name:      "aws_instance_invalid_type",
 						Enabled:   false,
-						Ignorable: boolPtr(false),
+						Ignorable: new(false),
 					},
 					"aws_instance_previous_type": {
 						Name:    "aws_instance_previous_type",
@@ -597,7 +598,7 @@ config {
 					"aws_instance_invalid_type": {
 						Name:      "aws_instance_invalid_type",
 						Enabled:   false,
-						Ignorable: boolPtr(false),
+						Ignorable: new(false),
 					},
 					"aws_instance_previous_type": {
 						Name:    "aws_instance_previous_type",

--- a/tflint/runner_test.go
+++ b/tflint/runner_test.go
@@ -555,7 +555,7 @@ func Test_EmitIssue(t *testing.T) {
 					"test_rule": {
 						Name:      "test_rule",
 						Enabled:   true,
-						Ignorable: boolPtr(false),
+						Ignorable: new(false),
 					},
 				},
 			},
@@ -599,7 +599,7 @@ func Test_EmitIssue(t *testing.T) {
 					"test_rule": {
 						Name:      "test_rule",
 						Enabled:   true,
-						Ignorable: boolPtr(false),
+						Ignorable: new(false),
 					},
 				},
 			},

--- a/versioncheck/github_test.go
+++ b/versioncheck/github_test.go
@@ -15,7 +15,7 @@ func TestFetchLatestReleaseWithClient(t *testing.T) {
 	tests := []struct {
 		name        string
 		statusCode  int
-		response    interface{}
+		response    any
 		wantErr     bool
 		wantVersion string
 		checkReq    func(*testing.T, *http.Request)
@@ -24,7 +24,7 @@ func TestFetchLatestReleaseWithClient(t *testing.T) {
 			name:       "successful fetch",
 			statusCode: http.StatusOK,
 			response: &github.RepositoryRelease{
-				TagName: github.Ptr("v0.60.0"),
+				TagName: new("v0.60.0"),
 			},
 			wantVersion: "v0.60.0",
 		},
@@ -39,7 +39,7 @@ func TestFetchLatestReleaseWithClient(t *testing.T) {
 		{
 			name:       "rate limit error",
 			statusCode: http.StatusForbidden,
-			response: map[string]interface{}{
+			response: map[string]any{
 				"message": "API rate limit exceeded",
 			},
 			wantErr: true,
@@ -47,7 +47,7 @@ func TestFetchLatestReleaseWithClient(t *testing.T) {
 		{
 			name:       "not found error",
 			statusCode: http.StatusNotFound,
-			response: map[string]interface{}{
+			response: map[string]any{
 				"message": "Not Found",
 			},
 			wantErr: true,
@@ -55,7 +55,7 @@ func TestFetchLatestReleaseWithClient(t *testing.T) {
 		{
 			name:       "server error",
 			statusCode: http.StatusInternalServerError,
-			response: map[string]interface{}{
+			response: map[string]any{
 				"message": "Internal Server Error",
 			},
 			wantErr: true,


### PR DESCRIPTION
Applies `go fix` to pick up Go 1.26 idioms: `any`, `maps.Copy`, `strings.Cut`, `for i := range n`, `reflect.TypeFor`, and `new(expr)`.

The automated pass also rewrote nine files under `terraform/`, which I reverted. That directory is a fork of Terraform's internal packages, and `.golangci.yml` already excludes it from every linter and formatter for the same reason: churn there shows up as conflicts the next time the fork is synced against upstream. Worth doing eventually, but as its own decision rather than a side effect of this one.

The second commit covers what `go fix` can't do on its own. It inlined `boolPtr` at its call sites but left the now-dead function behind, along with the `//go:fix inline` directive it added to drive the inlining, so both are removed. It also emits `before, after, ok := strings.Cut(...)` followed by `name := before`, which is mechanical but ugly, so those results are named directly. Beyond that, two rewrites `go fix` doesn't ship: `errors.AsType`, which `gopls`'s `modernize` analyzer still flags, and `slices.Sort` for the one remaining single-argument `sort.Strings` call. `sort.Slice` in `tflint/issue.go` is left alone, since converting a five-key comparator with two descending keys is a rewrite rather than a swap.

Last, the two `TFLINT_PLUGIN_DIR` tests move to `t.Setenv`. The old `defer os.Setenv(key, "")` cleared the variable instead of restoring whatever the caller had set. Note that this makes both tests incompatible with `t.Parallel`, which neither currently uses.

Verified with `modernize` run with every analyzer explicitly enabled, which reports zero diagnostics across the non-`terraform` packages.
