### PR TITLE
docs: mention MegaLinter in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ To download plugins, you can override the entrypoint to a shell (`sh`) to run `-
 
 If you want to run on GitHub Actions, [setup-tflint](https://github.com/terraform-linters/setup-tflint) action is available.
 
+TFLint is also embedded in [MegaLinter](https://megalinter.io/latest/descriptors/terraform_tflint/), which can run it in CI alongside linters for other languages.
+
 ## Getting Started
 
 First, enable rules for [Terraform Language](https://www.terraform.io/language) (e.g. warn about deprecated syntax, unused declarations). [TFLint Ruleset for Terraform Language](https://github.com/terraform-linters/tflint-ruleset-terraform) is bundled with TFLint, so you can use it without installing it separately.


### PR DESCRIPTION
Hi! I maintain [MegaLinter](https://megalinter.io), an open-source linters aggregator for CI, and TFLint has been one of its embedded linters for years.

This adds a one-line mention next to the GitHub Actions section of the README, so users looking for a CI setup know they can also get TFLint through MegaLinter (descriptor page: https://megalinter.io/latest/descriptors/terraform_tflint/).

Happy to reword or move it elsewhere if you prefer. Thanks for TFLint!