### PR TITLE
Bump Go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/terraform-linters/tflint
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/agext/levenshtein v1.2.3


### PR DESCRIPTION
Update Go minor version to 1.26.5 which includes security fixes.


On tflint 0.64.0:

```
$ trivy rootfs --scanners vuln  tflint
2026-08-11T14:07:28+02:00       INFO    [vuln] Vulnerability scanning is enabled
2026-08-11T14:07:28+02:00       INFO    Number of language-specific files       num=1
2026-08-11T14:07:28+02:00       INFO    [gobinary] Detecting vulnerabilities...
2026-08-11T14:07:28+02:00       WARN    Using severities from other vendors for some vulnerabilities. Read https://trivy.dev/docs/v0.73/guide/scanner/vulnerability#severity-selection for details.

Report Summary

┌────────┬──────────┬─────────────────┐
│ Target │   Type   │ Vulnerabilities │
├────────┼──────────┼─────────────────┤
│ tflint │ gobinary │        7        │
└────────┴──────────┴─────────────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


tflint (gobinary)

Total: 7 (UNKNOWN: 1, LOW: 0, MEDIUM: 2, HIGH: 4, CRITICAL: 0)

┌────────────────────────┬─────────────────────┬──────────┬──────────┬───────────────────┬──────────────────────────────┬──────────────────────────────────────────────────────────────┐
│        Library         │    Vulnerability    │ Severity │  Status  │ Installed Version │        Fixed Version         │                            Title                             │
├────────────────────────┼─────────────────────┼──────────┼──────────┼───────────────────┼──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/crypto    │ GO-2026-5932        │ UNKNOWN  │ affected │ v0.53.0           │                              │ The golang.org/x/crypto/openpgp package is unmaintained,     │
│                        │                     │          │          │                   │                              │ unsafe by design, and has known security...                  │
├────────────────────────┼─────────────────────┼──────────┼──────────┼───────────────────┼──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ google.golang.org/grpc │ GHSA-hrxh-6v49-42gf │ HIGH     │ fixed    │ v1.82.0           │ 1.82.1                       │ gRPC-Go: xDS RBAC and HTTP/2 Vulnerabilities                 │
│                        │                     │          │          │                   │                              │ https://github.com/advisories/GHSA-hrxh-6v49-42gf            │
├────────────────────────┼─────────────────────┤          │          ├───────────────────┼──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib                 │ CVE-2026-27145      │          │          │ v1.26.3           │ 1.25.11, 1.26.4              │ crypto/x509: golang: golang crypto/x509: Denial of Service   │
│                        │                     │          │          │                   │                              │ via excessive processing of DNS...                           │
│                        │                     │          │          │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-27145                   │
│                        ├─────────────────────┤          │          │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                        │ CVE-2026-39822      │          │          │                   │ 1.25.12, 1.26.5, 1.27.0-rc.2 │ golang: Go os.Root: Symlink following vulnerability allows   │
│                        │                     │          │          │                   │                              │ directory traversal                                          │
│                        │                     │          │          │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-39822                   │
│                        ├─────────────────────┤          │          │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                        │ CVE-2026-42504      │          │          │                   │ 1.25.11, 1.26.4              │ mime: golang: Golang MIME: Denial of Service via             │
│                        │                     │          │          │                   │                              │ maliciously-crafted MIME header                              │
│                        │                     │          │          │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-42504                   │
│                        ├─────────────────────┼──────────┤          │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                        │ CVE-2026-42505      │ MEDIUM   │          │                   │ 1.25.12, 1.26.5, 1.27.0-rc.2 │ crypto/tls: golang: Go crypto/tls: Information disclosure in │
│                        │                     │          │          │                   │                              │ Encrypted Client Hello                                       │
│                        │                     │          │          │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-42505                   │
│                        ├─────────────────────┤          │          │                   ├──────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                        │ CVE-2026-42507      │          │          │                   │ 1.25.11, 1.26.4              │ net/textproto: golang: Golang net/textproto: Misleading      │
│                        │                     │          │          │                   │                              │ error messages via input injection                           │
│                        │                     │          │          │                   │                              │ https://avd.aquasec.com/nvd/cve-2026-42507                   │
└────────────────────────┴─────────────────────┴──────────┴──────────┴───────────────────┴──────────────────────────────┴──────────────────────────────────────────────────────────────┘

```