### PR TITLE
terraform: iterate primary files in a deterministic order

### DIFF
--- a/terraform/module.go
+++ b/terraform/module.go
@@ -132,10 +132,6 @@ func (m *Module) PartialContent(schema *hclext.BodySchema, ctx *Evaluator) (*hcl
 	content := &hclext.BodyContent{}
 	diags := hcl.Diagnostics{}
 
-	// Primaries are processed in order by filename (in lexicographical order)
-	// to ensure a stable block order across runs. Go randomizes map iteration
-	// order, so iterating m.primaries directly produced non-deterministic
-	// results for any rule whose logic depends on block order.
 	for _, filename := range m.primaryFilenames {
 		expanded, d := ctx.ExpandBlock(m.primaries[filename].Body, schema)
 		diags = diags.Extend(d)

--- a/terraform/module.go
+++ b/terraform/module.go
@@ -22,6 +22,7 @@ type Module struct {
 	Files   map[string]*hcl.File
 
 	primaries         map[string]*hcl.File
+	primaryFilenames  []string
 	overrides         map[string]*hcl.File
 	overrideFilenames []string
 }
@@ -39,6 +40,7 @@ func NewEmptyModule() *Module {
 		Files:   map[string]*hcl.File{},
 
 		primaries:         map[string]*hcl.File{},
+		primaryFilenames:  []string{},
 		overrides:         map[string]*hcl.File{},
 		overrideFilenames: []string{},
 	}
@@ -130,8 +132,12 @@ func (m *Module) PartialContent(schema *hclext.BodySchema, ctx *Evaluator) (*hcl
 	content := &hclext.BodyContent{}
 	diags := hcl.Diagnostics{}
 
-	for _, f := range m.primaries {
-		expanded, d := ctx.ExpandBlock(f.Body, schema)
+	// Primaries are processed in order by filename (in lexicographical order)
+	// to ensure a stable block order across runs. Go randomizes map iteration
+	// order, so iterating m.primaries directly produced non-deterministic
+	// results for any rule whose logic depends on block order.
+	for _, filename := range m.primaryFilenames {
+		expanded, d := ctx.ExpandBlock(m.primaries[filename].Body, schema)
 		diags = diags.Extend(d)
 		c, d := hclext.PartialContent(expanded, schema)
 		diags = diags.Extend(d)

--- a/terraform/module_test.go
+++ b/terraform/module_test.go
@@ -28,10 +28,12 @@ func TestRebuild(t *testing.T) {
 				primaries: map[string]*hcl.File{
 					"main.tf": {Bytes: []byte(`variable "foo" { default = 1 }`), Body: hcl.EmptyBody()},
 				},
+				primaryFilenames: []string{"main.tf"},
 				overrides: map[string]*hcl.File{
 					"main_override.tf": {Bytes: []byte(`variable "foo" { default = 2 }`), Body: hcl.EmptyBody()},
 					"override.tf":      {Bytes: []byte(`variable "foo" { default = 3 }`), Body: hcl.EmptyBody()},
 				},
+				overrideFilenames: []string{"main_override.tf", "override.tf"},
 				Sources: map[string][]byte{
 					"main.tf":          []byte(`variable "foo" { default = 1 }`),
 					"main_override.tf": []byte(`variable "foo" { default = 2 }`),
@@ -65,6 +67,7 @@ variable "bar" { default = "bar" }
 						Body: hcl.EmptyBody(),
 					},
 				},
+				primaryFilenames: []string{"main.tf"},
 				overrides: map[string]*hcl.File{
 					"main_override.tf": {
 						Bytes: []byte(`
@@ -75,6 +78,7 @@ variable "bar" { default = "baz" }
 					},
 					"override.tf": {Bytes: []byte(`variable "foo" { default = 3 }`), Body: hcl.EmptyBody()},
 				},
+				overrideFilenames: []string{"main_override.tf", "override.tf"},
 				Sources: map[string][]byte{
 					"main.tf": []byte(`
 variable "foo" { default = 1 }
@@ -113,10 +117,12 @@ variable "bar" { default = "baz" }
 				primaries: map[string]*hcl.File{
 					"main.tf.json": {Bytes: []byte(`{"variable": {"foo": {"default": 1}}}`), Body: hcl.EmptyBody()},
 				},
+				primaryFilenames: []string{"main.tf.json"},
 				overrides: map[string]*hcl.File{
 					"main_override.tf.json": {Bytes: []byte(`{"variable": {"foo": {"default": 2}}}`), Body: hcl.EmptyBody()},
 					"override.tf.json":      {Bytes: []byte(`{"variable": {"foo": {"default": 3}}}`), Body: hcl.EmptyBody()},
 				},
+				overrideFilenames: []string{"main_override.tf.json", "override.tf.json"},
 				Sources: map[string][]byte{
 					"main.tf.json":          []byte(`{"variable": {"foo": {"default": 1}}}`),
 					"main_override.tf.json": []byte(`{"variable": {"foo": {"default": 2}}}`),
@@ -138,10 +144,12 @@ variable "bar" { default = "baz" }
 				primaries: map[string]*hcl.File{
 					"main.tf.json": {Bytes: []byte(`{"variable": {"foo": {"default": 1}, "bar": {"default": "bar"}}}`), Body: hcl.EmptyBody()},
 				},
+				primaryFilenames: []string{"main.tf.json"},
 				overrides: map[string]*hcl.File{
 					"main_override.tf.json": {Bytes: []byte(`{"variable": {"foo": {"default": 2}, "bar": {"default": "baz"}}}`), Body: hcl.EmptyBody()},
 					"override.tf.json":      {Bytes: []byte(`{"variable": {"foo": {"default": 3}}}`), Body: hcl.EmptyBody()},
 				},
+				overrideFilenames: []string{"main_override.tf.json", "override.tf.json"},
 				Sources: map[string][]byte{
 					"main.tf.json":          []byte(`{"variable": {"foo": {"default": 1}, "bar": {"default": "bar"}}}`),
 					"main_override.tf.json": []byte(`{"variable": {"foo": {"default": 2}, "bar": {"default": "baz"}}}`),
@@ -1767,5 +1775,92 @@ func Test_overrideBlocks(t *testing.T) {
 				t.Errorf("diff: %s", diff)
 			}
 		})
+	}
+}
+
+// TestPartialContent_deterministicPrimaryOrder is a regression test for a
+// nondeterminism bug in Module.PartialContent. It used to iterate the
+// m.primaries map directly, and because Go randomizes map iteration order,
+// modules with multiple primary .tf files produced a different block order
+// on every invocation. Any rule whose logic depends on block order
+// (e.g. "last matching block wins") then produced non-reproducible results,
+// which surfaced as intermittent tflint failures on identical inputs.
+//
+// The same bug class was previously reported and fixed for override files:
+// tflint-ruleset-terraform#205 / tflint#2124 introduced overrideFilenames +
+// sort.Strings so overrides are iterated in a stable lexicographical order.
+// This test pins the equivalent guarantee for primary files.
+func TestPartialContent_deterministicPrimaryOrder(t *testing.T) {
+	files := map[string]string{
+		"d.tf": `resource "aws_instance" "d" {}`,
+		"b.tf": `resource "aws_instance" "b" {}`,
+		"a.tf": `resource "aws_instance" "a" {}`,
+		"c.tf": `resource "aws_instance" "c" {}`,
+	}
+	schema := &hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{
+				Type:       "resource",
+				LabelNames: []string{"type", "name"},
+				Body:       &hclext.BodySchema{},
+			},
+		},
+	}
+	// Primaries must be iterated in lexicographical filename order, matching
+	// the existing guarantee for overrides.
+	wantOrder := []string{"a.tf", "b.tf", "c.tf", "d.tf"}
+
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	for name, content := range files {
+		if err := fs.WriteFile(name, []byte(content), os.ModePerm); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	parser := NewParser(fs)
+	mod, diags := parser.LoadConfigDir(".", ".")
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+
+	// LoadConfigDir must populate primaryFilenames in sorted order.
+	if diff := cmp.Diff(wantOrder, mod.primaryFilenames); diff != "" {
+		t.Fatalf("primaryFilenames mismatch:\n%s", diff)
+	}
+
+	config, diags := BuildConfig(mod, ModuleWalkerFunc(func(req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) { return nil, nil, nil }), ".")
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+	variableValues, diags := VariableValues(config)
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+	ctx := &Evaluator{
+		Meta:           &ContextMeta{Env: Workspace()},
+		ModulePath:     config.Path.UnkeyedInstanceShim(),
+		Config:         config,
+		VariableValues: variableValues,
+	}
+
+	// Call PartialContent many times. Every call must return blocks in the
+	// same lexicographical filename order. Without the fix, Go's randomized
+	// map iteration order over m.primaries would virtually guarantee that at
+	// least one of these iterations returned a different order.
+	for i := 0; i < 20; i++ {
+		got, diags := config.Module.PartialContent(schema, ctx)
+		if diags.HasErrors() {
+			t.Fatalf("iteration %d: %s", i, diags)
+		}
+		if len(got.Blocks) != len(wantOrder) {
+			t.Fatalf("iteration %d: got %d blocks, want %d", i, len(got.Blocks), len(wantOrder))
+		}
+		gotOrder := make([]string, len(got.Blocks))
+		for j, block := range got.Blocks {
+			gotOrder[j] = block.DefRange.Filename
+		}
+		if diff := cmp.Diff(wantOrder, gotOrder); diff != "" {
+			t.Fatalf("iteration %d: block order mismatch:\n%s", i, diff)
+		}
 	}
 }

--- a/terraform/module_test.go
+++ b/terraform/module_test.go
@@ -1778,18 +1778,6 @@ func Test_overrideBlocks(t *testing.T) {
 	}
 }
 
-// TestPartialContent_deterministicPrimaryOrder is a regression test for a
-// nondeterminism bug in Module.PartialContent. It used to iterate the
-// m.primaries map directly, and because Go randomizes map iteration order,
-// modules with multiple primary .tf files produced a different block order
-// on every invocation. Any rule whose logic depends on block order
-// (e.g. "last matching block wins") then produced non-reproducible results,
-// which surfaced as intermittent tflint failures on identical inputs.
-//
-// The same bug class was previously reported and fixed for override files:
-// tflint-ruleset-terraform#205 / tflint#2124 introduced overrideFilenames +
-// sort.Strings so overrides are iterated in a stable lexicographical order.
-// This test pins the equivalent guarantee for primary files.
 func TestPartialContent_deterministicPrimaryOrder(t *testing.T) {
 	files := map[string]string{
 		"d.tf": `resource "aws_instance" "d" {}`,
@@ -1806,8 +1794,6 @@ func TestPartialContent_deterministicPrimaryOrder(t *testing.T) {
 			},
 		},
 	}
-	// Primaries must be iterated in lexicographical filename order, matching
-	// the existing guarantee for overrides.
 	wantOrder := []string{"a.tf", "b.tf", "c.tf", "d.tf"}
 
 	fs := afero.Afero{Fs: afero.NewMemMapFs()}
@@ -1823,7 +1809,6 @@ func TestPartialContent_deterministicPrimaryOrder(t *testing.T) {
 		t.Fatal(diags)
 	}
 
-	// LoadConfigDir must populate primaryFilenames in sorted order.
 	if diff := cmp.Diff(wantOrder, mod.primaryFilenames); diff != "" {
 		t.Fatalf("primaryFilenames mismatch:\n%s", diff)
 	}
@@ -1843,10 +1828,6 @@ func TestPartialContent_deterministicPrimaryOrder(t *testing.T) {
 		VariableValues: variableValues,
 	}
 
-	// Call PartialContent many times. Every call must return blocks in the
-	// same lexicographical filename order. Without the fix, Go's randomized
-	// map iteration order over m.primaries would virtually guarantee that at
-	// least one of these iterations returned a different order.
 	for i := 0; i < 20; i++ {
 		got, diags := config.Module.PartialContent(schema, ctx)
 		if diags.HasErrors() {

--- a/terraform/parser.go
+++ b/terraform/parser.go
@@ -65,6 +65,7 @@ func (p *Parser) LoadConfigDir(baseDir, dir string) (*Module, hcl.Diagnostics) {
 	}
 
 	mod := NewEmptyModule()
+	mod.primaryFilenames = make([]string, 0, len(primaries))
 	mod.overrideFilenames = make([]string, len(overrides))
 
 	for _, path := range primaries {
@@ -78,6 +79,7 @@ func (p *Parser) LoadConfigDir(baseDir, dir string) (*Module, hcl.Diagnostics) {
 		mod.primaries[realPath] = f
 		mod.Sources[realPath] = f.Bytes
 		mod.Files[realPath] = f
+		mod.primaryFilenames = append(mod.primaryFilenames, realPath)
 	}
 	for idx, path := range overrides {
 		f, loadDiags := p.loadHCLFile(baseDir, path)
@@ -92,7 +94,12 @@ func (p *Parser) LoadConfigDir(baseDir, dir string) (*Module, hcl.Diagnostics) {
 		mod.Files[realPath] = f
 		mod.overrideFilenames[idx] = realPath
 	}
-	// Overrides are processed in order first by filename (in lexicographical order)
+	// Primaries and overrides are both processed in order by filename
+	// (in lexicographical order) so that any rule whose logic depends on
+	// block order behaves deterministically across runs. Go randomizes map
+	// iteration order, so iterating m.primaries / m.overrides directly
+	// would otherwise yield a different block order every invocation.
+	sort.Strings(mod.primaryFilenames)
 	sort.Strings(mod.overrideFilenames)
 	if diags.HasErrors() {
 		return mod, diags

--- a/terraform/parser.go
+++ b/terraform/parser.go
@@ -94,11 +94,7 @@ func (p *Parser) LoadConfigDir(baseDir, dir string) (*Module, hcl.Diagnostics) {
 		mod.Files[realPath] = f
 		mod.overrideFilenames[idx] = realPath
 	}
-	// Primaries and overrides are both processed in order by filename
-	// (in lexicographical order) so that any rule whose logic depends on
-	// block order behaves deterministically across runs. Go randomizes map
-	// iteration order, so iterating m.primaries / m.overrides directly
-	// would otherwise yield a different block order every invocation.
+	// Primaries and overrides are processed in order by filename (in lexicographical order)
 	sort.Strings(mod.primaryFilenames)
 	sort.Strings(mod.overrideFilenames)
 	if diags.HasErrors() {


### PR DESCRIPTION
## Summary

`Module.PartialContent` iterates the `m.primaries` map directly. Because Go randomizes map iteration order, modules with multiple primary `.tf` files produce a different block order on every `tflint` invocation, and any rule whose logic depends on block order (e.g. "last matching block wins") produces non-reproducible results across runs of the same, unchanged config.

This mirrors the exact same bug class that was previously reported and fixed for override files — see [tflint-ruleset-terraform#205](https://github.com/terraform-linters/tflint-ruleset-terraform/issues/205) for the original symptom report (7 tflint runs on identical input, 2 failed), and #2124 for the fix that introduced `overrideFilenames` + `sort.Strings` so overrides are iterated in a stable lexicographical order. That fix never touched the general primaries path, which this PR closes.

## Repro

A real Terraform module with several `aws_*` resources spread across multiple primary `.tf` files and no `required_providers` constraint will non-deterministically report the "missing version constraint" warning against a different resource on each `tflint` run (`GetProviderRefs` in the terraform ruleset overwrites `providerRefs[providerName]` on every match, so which resource "wins" the blame depends on the primary-file iteration order that this PR pins down). I hit this reliably as an intermittently-flaking Bazel `tflint` test — same file content, no changes, PASS/FAIL split across `bazel test --runs_per_test=8`.

## Fix

Mirror the override treatment for primaries exactly:

1. `terraform/module.go`: add `primaryFilenames []string` to `Module`, initialize it in `NewEmptyModule`.
2. `terraform/parser.go` (`LoadConfigDir`): populate `primaryFilenames` as each primary file is loaded, then `sort.Strings` it alongside `overrideFilenames`.
3. `terraform/module.go` (`Module.PartialContent`): iterate `m.primaryFilenames` and look up `m.primaries[filename]`, matching the existing override loop.

## Test

New `TestPartialContent_deterministicPrimaryOrder` (in `terraform/module_test.go`) sets up a module with four primary files (`d.tf`, `b.tf`, `a.tf`, `c.tf`), calls `PartialContent` 20 times, and asserts every call returns blocks in the same lexicographical filename order (`a`, `b`, `c`, `d`). Also asserts `LoadConfigDir` populates `primaryFilenames` in sorted order.

Without the fix, Go's per-`range` map iteration randomization over a 4-element map makes it effectively certain that at least one of the 20 iterations returns a different order.

The existing `TestRebuild` fixtures were updated to also populate `primaryFilenames` / `overrideFilenames` (they construct a `Module` directly, bypassing `NewEmptyModule` / `LoadConfigDir`).

## Downstream impact

Any downstream ruleset rule that relies on `GetModuleContent` / `PartialContent` block order for anything order-sensitive is currently exposed to this same nondeterminism — this fix benefits all rulesets, not just the resource-order-sensitive `terraform_required_providers` case that surfaced it.

## Test plan

- [x] `go test ./terraform/...` passes locally, including new `TestPartialContent_deterministicPrimaryOrder`
- [x] `go vet ./terraform/...` clean
- [x] CI green
