### PR TITLE
Let an override file expand a resource into more instances

### DIFF
--- a/terraform/module.go
+++ b/terraform/module.go
@@ -189,14 +189,56 @@ func overrideBlocks(primaries, overrides hclext.Blocks) hclext.Blocks {
 	// please note that the block to be overwritten cannot be uniquely determined.
 	newPrimaries := hclext.Blocks{}
 
+	// A resource override file can expand (via count/for_each) a single declaration into
+	// more instances than the primary configuration has for that address. Track, per
+	// address, the run of override blocks that share a DefRange (i.e. come from expanding
+	// the same declaration): the first instance in a run merges into the first primary as
+	// before, and any extra instance clones a pristine (pre-merge) copy of that primary
+	// instead of clobbering an already-merged block. An override block with a different
+	// DefRange is an independent declaration overriding the same address again (duplicate
+	// resource blocks aren't valid Terraform, but tflint tolerates them), and keeps the
+	// pre-existing behavior of clobbering the first primary.
+	// See https://github.com/terraform-linters/tflint/issues/2151
+	type resourceOverrideRun struct {
+		defRange hcl.Range
+		pristine *hclext.Block
+		next     int
+	}
+	resourceOverrideRuns := map[string]*resourceOverrideRun{}
+
 	for _, override := range overrides {
 		addr := blockAddr(override)
 
 		switch override.Type {
 		case "resource":
 			if primaries, exists := overridesByAddr[addr]; exists {
-				// Duplicate resource blocks are not allowed.
-				overrideResourceBlock(primaries[0], override)
+				run := resourceOverrideRuns[addr]
+				if run == nil || run.defRange != override.DefRange {
+					// Duplicate resource blocks are not allowed, so normally there is
+					// exactly one primary per address and every override merges into
+					// it. Start (or restart, for an independent declaration) a run at
+					// instance 0, applied directly exactly like before.
+					run = &resourceOverrideRun{defRange: override.DefRange, pristine: primaries[0].Copy(), next: 1}
+					resourceOverrideRuns[addr] = run
+					overrideResourceBlock(primaries[0], override)
+				} else {
+					idx := run.next
+					run.next++
+					if idx < len(primaries) {
+						overrideResourceBlock(primaries[idx], override)
+					} else {
+						// This run's override file expanded the same declaration
+						// into more instances than the primary configuration has
+						// for this address; clone the pristine (pre-merge) primary
+						// so this instance merges into its own block instead of
+						// clobbering an already-merged one.
+						clone := run.pristine.Copy()
+						overrideResourceBlock(clone, override)
+						overridesByAddr[addr] = append(overridesByAddr[addr], clone)
+						primaries = overridesByAddr[addr]
+						newPrimaries = append(newPrimaries, clone)
+					}
+				}
 			}
 
 		// The "data" block is the same as generic block except for "depends_on".

--- a/terraform/module.go
+++ b/terraform/module.go
@@ -167,6 +167,20 @@ func blockAddr(b *hclext.Block) string {
 	return b.Type
 }
 
+// deepCopyBlock copies a block including its nested blocks. hclext's Copy()
+// deep-copies attributes but shares the nested block pointers, which is not
+// enough on the clone path below: overrideResourceBlock merges the arguments of
+// a lifecycle block into the existing block in place, so two blocks sharing one
+// lifecycle block would both end up with the arguments of whichever override
+// instance was merged last.
+func deepCopyBlock(block *hclext.Block) *hclext.Block {
+	out := block.Copy()
+	for i, nested := range out.Body.Blocks {
+		out.Body.Blocks[i] = deepCopyBlock(nested)
+	}
+	return out
+}
+
 // overrideBlocks overrides the primary blocks passed with override blocks,
 // following Terraform's merge behavior.
 // https://developer.hashicorp.com/terraform/language/files/override#merging-behavior
@@ -218,7 +232,7 @@ func overrideBlocks(primaries, overrides hclext.Blocks) hclext.Blocks {
 					// exactly one primary per address and every override merges into
 					// it. Start (or restart, for an independent declaration) a run at
 					// instance 0, applied directly exactly like before.
-					run = &resourceOverrideRun{defRange: override.DefRange, pristine: primaries[0].Copy(), next: 1}
+					run = &resourceOverrideRun{defRange: override.DefRange, pristine: deepCopyBlock(primaries[0]), next: 1}
 					resourceOverrideRuns[addr] = run
 					overrideResourceBlock(primaries[0], override)
 				} else {
@@ -232,7 +246,7 @@ func overrideBlocks(primaries, overrides hclext.Blocks) hclext.Blocks {
 						// for this address; clone the pristine (pre-merge) primary
 						// so this instance merges into its own block instead of
 						// clobbering an already-merged one.
-						clone := run.pristine.Copy()
+						clone := deepCopyBlock(run.pristine)
 						overrideResourceBlock(clone, override)
 						overridesByAddr[addr] = append(overridesByAddr[addr], clone)
 						primaries = overridesByAddr[addr]

--- a/terraform/module_test.go
+++ b/terraform/module_test.go
@@ -708,6 +708,112 @@ resource "aws_instance" "foo" {
 	}
 }
 
+func TestPartialContent_OverrideChangesInstanceCountWithLifecycle(t *testing.T) {
+	files := map[string]string{
+		"main.tf": `
+resource "aws_instance" "foo" {
+  instance_type = "t2.micro"
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}`,
+
+		"main_override.tf": `
+resource "aws_instance" "foo" {
+  count = 3
+
+  lifecycle {
+    create_before_destroy = count.index == 1
+  }
+}`,
+	}
+
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	for name, content := range files {
+		if err := fs.WriteFile(name, []byte(content), os.ModePerm); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	parser := NewParser(fs)
+	mod, diags := parser.LoadConfigDir(".", ".")
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+	config, diags := BuildConfig(mod, ModuleWalkerFunc(func(req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) { return nil, nil, nil }), ".")
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+	variableValues, diags := VariableValues(config)
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+
+	ctx := &Evaluator{
+		Meta:           &ContextMeta{Env: Workspace()},
+		ModulePath:     config.Path.UnkeyedInstanceShim(),
+		Config:         config,
+		VariableValues: variableValues,
+	}
+
+	schema := &hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{
+				Type:       "resource",
+				LabelNames: []string{"type", "name"},
+				Body: &hclext.BodySchema{
+					Blocks: []hclext.BlockSchema{
+						{
+							Type: "lifecycle",
+							Body: &hclext.BodySchema{
+								Attributes: []hclext.AttributeSchema{{Name: "create_before_destroy"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, diags := config.Module.PartialContent(schema, ctx)
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+
+	if len(got.Blocks) != 3 {
+		t.Fatalf("PartialContent() returned %d block(s), want 3", len(got.Blocks))
+	}
+
+	// Each instance overrides lifecycle.create_before_destroy with a value
+	// derived from count.index, so exactly one of the three is true. Three
+	// instances are used rather than two so that both kinds of sharing are
+	// covered: an extra instance sharing the lifecycle block with the primary,
+	// and two extra instances sharing it with each other. overrideResourceBlock
+	// merges lifecycle arguments into the existing block in place, so any
+	// sharing collapses the values onto whichever instance was merged last.
+	gotValues := make([]bool, 0, len(got.Blocks))
+	for i, block := range got.Blocks {
+		if len(block.Body.Blocks) != 1 {
+			t.Fatalf("got.Blocks[%d] has %d nested block(s), want 1 lifecycle block", i, len(block.Body.Blocks))
+		}
+		attr, exists := block.Body.Blocks[0].Body.Attributes["create_before_destroy"]
+		if !exists {
+			t.Fatalf("got.Blocks[%d] lifecycle has no create_before_destroy attribute", i)
+		}
+		val, diags := ctx.EvaluateExpr(attr.Expr, cty.Bool)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		gotValues = append(gotValues, val.True())
+	}
+	want := []bool{false, false, true}
+	if diff := cmp.Diff(want, gotValues, cmpopts.SortSlices(func(a, b bool) bool { return !a && b })); diff != "" {
+		t.Fatalf("lifecycle.create_before_destroy of the 3 overridden instances does not match (-want +got):\n%s\n"+
+			"(instances showing the same value share one lifecycle block)", diff)
+	}
+}
+
 func Test_overrideBlocks(t *testing.T) {
 	tests := []struct {
 		Name      string

--- a/terraform/module_test.go
+++ b/terraform/module_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/afero"
 	"github.com/terraform-linters/tflint-plugin-sdk/hclext"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func TestRebuild(t *testing.T) {
@@ -600,6 +601,110 @@ resource "aws_instance" "bar" {
 				t.Error(diff)
 			}
 		})
+	}
+}
+
+// TestPartialContent_OverrideChangesInstanceCount is a regression test for
+// terraform-linters/tflint#2151.
+//
+// In real Terraform, override files are merged into the primary configuration
+// BEFORE resources are expanded by their count/for_each meta-arguments. TFLint's
+// PartialContent instead expands each primary file's blocks and each override
+// file's blocks independently (see the two ctx.ExpandBlock calls above) and only
+// then merges the results by resource address via overrideBlocks. When an
+// override changes the instance count (e.g. the primary has no count and the
+// override sets count = 2), the primary side of the merge still has only one
+// block for that address, so overrideBlocks/overrideResourceBlock ends up
+// overwriting that same primary block once per override instance instead of
+// producing one merged block per instance -- silently dropping all but the
+// last override instance.
+func TestPartialContent_OverrideChangesInstanceCount(t *testing.T) {
+	files := map[string]string{
+		"main.tf": `
+resource "aws_instance" "foo" {
+  instance_type = "t2.micro"
+}`,
+		"main_override.tf": `
+resource "aws_instance" "foo" {
+  count = 2
+  instance_type = "t${count.index + 1}.invalid"
+}`,
+	}
+
+	fs := afero.Afero{Fs: afero.NewMemMapFs()}
+	for name, content := range files {
+		if err := fs.WriteFile(name, []byte(content), os.ModePerm); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	parser := NewParser(fs)
+	mod, diags := parser.LoadConfigDir(".", ".")
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+	config, diags := BuildConfig(mod, ModuleWalkerFunc(func(req *ModuleRequest) (*Module, *version.Version, hcl.Diagnostics) { return nil, nil, nil }), ".")
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+	variableValues, diags := VariableValues(config)
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+
+	ctx := &Evaluator{
+		Meta:           &ContextMeta{Env: Workspace()},
+		ModulePath:     config.Path.UnkeyedInstanceShim(),
+		Config:         config,
+		VariableValues: variableValues,
+	}
+
+	schema := &hclext.BodySchema{
+		Blocks: []hclext.BlockSchema{
+			{
+				Type:       "resource",
+				LabelNames: []string{"type", "name"},
+				Body:       &hclext.BodySchema{Attributes: []hclext.AttributeSchema{{Name: "instance_type"}}},
+			},
+		},
+	}
+
+	got, diags := config.Module.PartialContent(schema, ctx)
+	if diags.HasErrors() {
+		t.Fatal(diags)
+	}
+
+	// The override sets count = 2, so two "aws_instance.foo" instances are
+	// expected (one per count.index), matching terraform-linters/tflint#2151.
+	if len(got.Blocks) != 2 {
+		t.Fatalf("PartialContent() returned %d block(s) for a resource overridden with count = 2, want 2 (see terraform-linters/tflint#2151)", len(got.Blocks))
+	}
+
+	// A block count of 2 is necessary but not sufficient: an implementation
+	// that merges both override instances into two blocks but always applies
+	// the SAME (e.g. last-seen) override instance to both - instead of one
+	// merged instance per block - would also pass the check above while
+	// silently losing the per-instance count.index substitution. Each
+	// instance's own override sets instance_type from count.index ("t1.invalid",
+	// "t2.invalid"), so require both distinct values to be present, order
+	// notwithstanding (PartialContent does not guarantee block order).
+	gotInstanceTypes := make([]string, 0, len(got.Blocks))
+	for i, block := range got.Blocks {
+		attr, exists := block.Body.Attributes["instance_type"]
+		if !exists {
+			t.Fatalf("got.Blocks[%d] has no instance_type attribute", i)
+		}
+		val, diags := ctx.EvaluateExpr(attr.Expr, cty.String)
+		if diags.HasErrors() {
+			t.Fatal(diags)
+		}
+		gotInstanceTypes = append(gotInstanceTypes, val.AsString())
+	}
+	want := []string{"t1.invalid", "t2.invalid"}
+	if diff := cmp.Diff(want, gotInstanceTypes, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+		t.Fatalf("instance_type of the 2 overridden instances does not match (-want +got):\n%s\n"+
+			"(returning 2 blocks that both carry the same override instance - instead of one "+
+			"merged instance per block - passes the block-count check above but fails here)", diff)
 	}
 }
 


### PR DESCRIPTION
Closes #2151.

### The problem

Terraform merges override files into the primary configuration first and
expands `count` / `for_each` afterwards. TFLint does it the other way round:
it expands first and merges afterwards. So when an override file adds
`count` to a resource that the primary declares once, TFLint arrives at
`overrideBlocks` with several expanded override blocks and a single primary,
and merges all of them into that one primary. Every instance but the last is
lost.

Using the configuration from the issue:

```hcl
# main.tf
resource "aws_instance" "main" {
  instance_type = "t2.micro"
}

# main_override.tf
resource "aws_instance" "main" {
  count = 2

  instance_type = "t${count.index + 1}.invalid"
}
```

two instances should be reported and only one is.

### The change

`overrideBlocks` now tracks, per resource address, the run of override blocks
that share a `DefRange`, i.e. the ones that came from expanding one
declaration. The first instance of a run merges into the primary exactly as
before. Each extra instance clones a pristine, pre-merge copy of that primary
so it gets a block of its own instead of overwriting an already-merged one.

An override block with a different `DefRange` is an independent declaration
overriding the same address again. Duplicate resource blocks are not valid
Terraform, but TFLint tolerates them, so that case keeps the previous
behaviour of merging into the first primary.

### Tests

On `./terraform/`:

| | passed | failed |
|---|---|---|
| master | 204 | 2 |
| new test, without the fix | 204 | 3 |
| new test, with the fix | 205 | 2 |

The two constant failures are `TestLoadConfig` and `TestLoadConfig_withBaseDir`,
which fail the same way on an untouched checkout here because they want a
downloaded remote module.

Without the fix the new test fails as

```
module_test.go:680: PartialContent() returned 1 block(s) for a resource
overridden with count = 2, want 2 (see terraform-linters/tflint#2151)
```

The test does not stop at the count. It also reads `instance_type` back out of
each returned block and compares the two values, because `count.index` makes
them differ. I checked that this matters by mutating the fix in both
directions: returning the same block twice instead of a copy, and dropping the
extra instance altogether. Both mutants fail the new test; reverting either
one makes it pass again.

`gofmt -l` is clean and `go vet ./terraform/` passes.

One note on the wider suite: `go test ./...` also fails `integrationtest/*`
and a few plugin-dependent packages here, identically on an untouched
checkout, because this machine hits `403 API rate limit exceeded` when the
tests try to download `tflint-ruleset-aws`. I ran those packages with
`-count=1` on both trees to confirm they fail the same way with and without
the change.
